### PR TITLE
Correct llama 3.1 405b huggingface ID

### DIFF
--- a/exo/api/chatgpt_api.py
+++ b/exo/api/chatgpt_api.py
@@ -21,7 +21,7 @@ shard_mappings = {
         "MLXDynamicShardInferenceEngine": Shard(model_id="mlx-community/Meta-Llama-3.1-70B-Instruct-4bit", start_layer=0, end_layer=0, n_layers=80),
     },
     "llama-3.1-405b": {
-        "MLXDynamicShardInferenceEngine": Shard(model_id="/Users/alex/405b-instruct-4bit", start_layer=0, end_layer=0, n_layers=126),
+        "MLXDynamicShardInferenceEngine": Shard(model_id="unsloth/Meta-Llama-3.1-405B-Instruct-bnb-4bit", start_layer=0, end_layer=0, n_layers=126),
     },
     "llama-3-8b": {
         "MLXDynamicShardInferenceEngine": Shard(model_id="mlx-community/Meta-Llama-3-8B-Instruct-4bit", start_layer=0, end_layer=0, n_layers=32),


### PR DESCRIPTION
Fix for:

Error handling request
Traceback (most recent call last):
  File "/Users/samm/git/exo/.venv/lib/python3.12/site-packages/aiohttp/web_protocol.py", line 452, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/samm/git/exo/.venv/lib/python3.12/site-packages/aiohttp/web_app.py", line 543, in _handle
    resp = await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/samm/git/exo/.venv/lib/python3.12/site-packages/aiohttp/web_middlewares.py", line 114, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/samm/git/exo/exo/api/chatgpt_api.py", line 178, in middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/samm/git/exo/exo/api/chatgpt_api.py", line 208, in handle_post_chat_completions
    tokenizer = await resolve_tokenizer(shard.model_id)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/samm/git/exo/exo/api/chatgpt_api.py", line 81, in resolve_tokenizer
    return load_tokenizer(await get_model_path(model_id))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/samm/git/exo/exo/inference/mlx/sharded_utils.py", line 170, in get_model_path
    await snapshot_download_async(
  File "/Users/samm/git/exo/exo/inference/mlx/sharded_utils.py", line 152, in snapshot_download_async
    return await asyncio.get_event_loop().run_in_executor(None, func)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/samm/.pyenv/versions/3.12.4/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/samm/git/exo/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 106, in _inner_fn
    validate_repo_id(arg_value)
  File "/Users/samm/git/exo/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 154, in validate_repo_id
    raise HFValidationError(
huggingface_hub.errors.HFValidationError: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/Users/alex/405b-instruct-4bit'. Use `repo_type` argument if
needed.