### PR TITLE
Non blocking

### DIFF
--- a/exo/download/hf/hf_helpers.py
+++ b/exo/download/hf/hf_helpers.py
@@ -391,25 +391,19 @@ def extract_layer_num(tensor_name: str) -> Optional[int]:
 
 
 def get_allow_patterns(weight_map: Dict[str, str], shard: Shard) -> List[str]:
-  default_patterns = [
-    "*.json",
-    "*.py",
-    "tokenizer.model",
-    "*.tiktoken",
-    "*.txt",
-  ]
-  shard_specific_patterns = []
+  default_patterns = set(["*.json","*.py","tokenizer.model","*.tiktoken","*.txt"])
+  shard_specific_patterns = set()
   if weight_map:
     for tensor_name, filename in weight_map.items():
       layer_num = extract_layer_num(tensor_name)
       if layer_num is not None and shard.start_layer <= layer_num <= shard.end_layer:
-        shard_specific_patterns.append(filename)
+        shard_specific_patterns.add(filename)
     sorted_file_names = sorted(weight_map.values())
     if shard.is_first_layer():
-      shard_specific_patterns.append(sorted_file_names[0])
+      shard_specific_patterns.add(sorted_file_names[0])
     elif shard.is_last_layer():
-      shard_specific_patterns.append(sorted_file_names[-1])
+      shard_specific_patterns.add(sorted_file_names[-1])
   else:
     shard_specific_patterns = ["*.safetensors"]
   if DEBUG >= 2: print(f"get_allow_patterns {weight_map=} {shard=} {shard_specific_patterns=}")
-  return list(set(default_patterns + shard_specific_patterns))  # Remove duplicates
+  return list(default_patterns | shard_specific_patterns)  # Remove duplicates

--- a/exo/download/hf/hf_helpers.py
+++ b/exo/download/hf/hf_helpers.py
@@ -406,4 +406,4 @@ def get_allow_patterns(weight_map: Dict[str, str], shard: Shard) -> List[str]:
   else:
     shard_specific_patterns = ["*.safetensors"]
   if DEBUG >= 2: print(f"get_allow_patterns {weight_map=} {shard=} {shard_specific_patterns=}")
-  return list(default_patterns | shard_specific_patterns)  # Remove duplicates
+  return list(default_patterns | shard_specific_patterns)

--- a/exo/inference/mlx/sharded_inference_engine.py
+++ b/exo/inference/mlx/sharded_inference_engine.py
@@ -16,32 +16,54 @@ class MLXDynamicShardInferenceEngine(InferenceEngine):
     self.shard_downloader = shard_downloader
     self.model_lock = threading.Lock()
     self.executor = ThreadPoolExecutor(max_workers=1)
+    self.inference_queue = asyncio.Queue()
+    self._worker_task = None
+
+  async def _ensure_worker(self):
+    if self._worker_task is None:
+      self._worker_task = asyncio.create_task(self._inference_worker())
 
   async def infer_prompt(self, request_id: str, shard: Shard, prompt: str, image_str: Optional[str] = None, inference_state: Optional[str] = None) -> (np.ndarray, str, bool):
     await self.ensure_shard(shard)
+    await self._ensure_worker()
+
     if image_str:
       image = await get_image_from_str(image_str)
       inputs = self.tokenizer(prompt, image, return_tensors="np")
       pixel_values = mx.array(inputs["pixel_values"])
       input_ids = mx.array(inputs["input_ids"])
-      output_data = await self._run_inference(request_id, input_ids, pixel_values)
+      output_data = await self._queue_inference(request_id, input_ids, pixel_values)
     else:
       input_ids = mx.array(self.tokenizer.encode(prompt))
-      output_data = await self._run_inference(request_id, input_ids)
+      output_data = await self._queue_inference(request_id, input_ids)
     return output_data, "", output_data.size == 1 and output_data.item() == self.tokenizer.eos_token_id
 
   async def infer_tensor(self, request_id: str, shard: Shard, input_data: np.ndarray, inference_state: Optional[str] = None) -> (np.ndarray, str, bool):
     await self.ensure_shard(shard)
+    await self._ensure_worker()
+
     input_tensor = mx.array(input_data)
-    output_data = await self._run_inference(request_id, input_tensor)
+    output_data = await self._queue_inference(request_id, input_tensor)
     return output_data, "", output_data.size == 1 and output_data.item() == self.tokenizer.eos_token_id
 
-  async def _run_inference(self, request_id: str, *args):
-    with self.model_lock:
-      return await asyncio.get_event_loop().run_in_executor(
-        self.executor,
-        lambda: np.array(self.stateful_sharded_model.step(request_id, *args))
-      )
+  async def _queue_inference(self, request_id: str, *args):
+    future = asyncio.get_running_loop().create_future()
+    await self.inference_queue.put((future, request_id, args))
+    return await future
+
+  async def _inference_worker(self):
+    while True:
+      future, request_id, args = await self.inference_queue.get()
+      try:
+        result = await asyncio.get_running_loop().run_in_executor(
+          self.executor,
+          lambda: np.array(self.stateful_sharded_model.step(request_id, *args))
+        )
+        future.set_result(result)
+      except Exception as e:
+        future.set_exception(e)
+      finally:
+        self.inference_queue.task_done()
 
   async def ensure_shard(self, shard: Shard):
     if self.shard == shard:

--- a/exo/inference/mlx/sharded_inference_engine.py
+++ b/exo/inference/mlx/sharded_inference_engine.py
@@ -6,12 +6,16 @@ from .sharded_utils import load_shard, get_image_from_str
 from ..shard import Shard
 from typing import Optional
 from exo.download.shard_download import ShardDownloader
-
+import threading
+from concurrent.futures import ThreadPoolExecutor
+import asyncio
 
 class MLXDynamicShardInferenceEngine(InferenceEngine):
   def __init__(self, shard_downloader: ShardDownloader):
     self.shard = None
     self.shard_downloader = shard_downloader
+    self.model_lock = threading.Lock()
+    self.executor = ThreadPoolExecutor(max_workers=1)
 
   async def infer_prompt(self, request_id: str, shard: Shard, prompt: str, image_str: Optional[str] = None, inference_state: Optional[str] = None) -> (np.ndarray, str, bool):
     await self.ensure_shard(shard)
@@ -20,21 +24,33 @@ class MLXDynamicShardInferenceEngine(InferenceEngine):
       inputs = self.tokenizer(prompt, image, return_tensors="np")
       pixel_values = mx.array(inputs["pixel_values"])
       input_ids = mx.array(inputs["input_ids"])
-      output_data: np.ndarray = np.array(self.stateful_sharded_model.step(request_id, input_ids, pixel_values))
+      output_data = await self._run_inference(request_id, input_ids, pixel_values)
     else:
-      output_data: np.ndarray = np.array(self.stateful_sharded_model.step(request_id, mx.array(self.tokenizer.encode(prompt))))
+      input_ids = mx.array(self.tokenizer.encode(prompt))
+      output_data = await self._run_inference(request_id, input_ids)
     return output_data, "", output_data.size == 1 and output_data.item() == self.tokenizer.eos_token_id
 
   async def infer_tensor(self, request_id: str, shard: Shard, input_data: np.ndarray, inference_state: Optional[str] = None) -> (np.ndarray, str, bool):
     await self.ensure_shard(shard)
-    output_data: np.ndarray = np.array(self.stateful_sharded_model.step(request_id, mx.array(input_data)))
+    input_tensor = mx.array(input_data)
+    output_data = await self._run_inference(request_id, input_tensor)
     return output_data, "", output_data.size == 1 and output_data.item() == self.tokenizer.eos_token_id
+
+  async def _run_inference(self, request_id: str, *args):
+    with self.model_lock:
+      return await asyncio.get_event_loop().run_in_executor(
+        self.executor,
+        lambda: np.array(self.stateful_sharded_model.step(request_id, *args))
+      )
 
   async def ensure_shard(self, shard: Shard):
     if self.shard == shard:
       return
 
     model_path = await self.shard_downloader.ensure_shard(shard)
-    model_shard, self.tokenizer = await load_shard(model_path, shard)
-    self.stateful_sharded_model = StatefulShardedModel(shard, model_shard)
-    self.shard = shard
+
+    with self.model_lock:
+      if self.shard != shard:
+        model_shard, self.tokenizer = await load_shard(model_path, shard)
+        self.stateful_sharded_model = StatefulShardedModel(shard, model_shard)
+        self.shard = shard

--- a/exo/inference/mlx/sharded_inference_engine.py
+++ b/exo/inference/mlx/sharded_inference_engine.py
@@ -25,7 +25,7 @@ class MLXDynamicShardInferenceEngine(InferenceEngine):
       input_ids = mx.array(inputs["input_ids"])
       output_data: np.ndarray = np.array(await loop.run_in_executor(self.executor, self.stateful_sharded_model.step, request_id, input_ids, pixel_values))
     else:
-      input_ids = await loop.run_in_executor(self.executor, lambda: mx.array(self.tokenizer.encode(prompt)))
+      input_ids = mx.array(await loop.run_in_executor(self.executor, self.tokenizer.encode, prompt))
       output_data: np.ndarray = np.array(await loop.run_in_executor(self.executor, self.stateful_sharded_model.step, request_id, input_ids))
     return output_data, "", output_data.size == 1 and output_data.item() == self.tokenizer.eos_token_id
 

--- a/exo/inference/mlx/sharded_inference_engine.py
+++ b/exo/inference/mlx/sharded_inference_engine.py
@@ -6,64 +6,39 @@ from .sharded_utils import load_shard, get_image_from_str
 from ..shard import Shard
 from typing import Optional
 from exo.download.shard_download import ShardDownloader
-import threading
-from concurrent.futures import ThreadPoolExecutor
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 
 class MLXDynamicShardInferenceEngine(InferenceEngine):
   def __init__(self, shard_downloader: ShardDownloader):
     self.shard = None
     self.shard_downloader = shard_downloader
-    self.model_lock = threading.Lock()
     self.executor = ThreadPoolExecutor(max_workers=1)
-    self.inference_queue = asyncio.Queue()
-    self._worker_task = None
-
-  async def _ensure_worker(self):
-    if self._worker_task is None:
-      self._worker_task = asyncio.create_task(self._inference_worker())
 
   async def infer_prompt(self, request_id: str, shard: Shard, prompt: str, image_str: Optional[str] = None, inference_state: Optional[str] = None) -> (np.ndarray, str, bool):
     await self.ensure_shard(shard)
-    await self._ensure_worker()
-
+    loop = asyncio.get_running_loop()
     if image_str:
       image = await get_image_from_str(image_str)
-      inputs = self.tokenizer(prompt, image, return_tensors="np")
+      inputs = await loop.run_in_executor(self.executor, self.tokenizer, prompt, image, return_tensors="np")
       pixel_values = mx.array(inputs["pixel_values"])
       input_ids = mx.array(inputs["input_ids"])
-      output_data = await self._queue_inference(request_id, input_ids, pixel_values)
+      output_data = await loop.run_in_executor(self.executor, self.stateful_sharded_model.step, request_id, input_ids, pixel_values)
     else:
-      input_ids = mx.array(self.tokenizer.encode(prompt))
-      output_data = await self._queue_inference(request_id, input_ids)
-    return output_data, "", output_data.size == 1 and output_data.item() == self.tokenizer.eos_token_id
+      input_ids = await loop.run_in_executor(self.executor, lambda: mx.array(self.tokenizer.encode(prompt)))
+      output_data = await loop.run_in_executor(self.executor, self.stateful_sharded_model.step, request_id, input_ids)
+    return np.array(output_data), "", output_data.size == 1 and output_data.item() == self.tokenizer.eos_token_id
 
   async def infer_tensor(self, request_id: str, shard: Shard, input_data: np.ndarray, inference_state: Optional[str] = None) -> (np.ndarray, str, bool):
     await self.ensure_shard(shard)
-    await self._ensure_worker()
-
     input_tensor = mx.array(input_data)
-    output_data = await self._queue_inference(request_id, input_tensor)
-    return output_data, "", output_data.size == 1 and output_data.item() == self.tokenizer.eos_token_id
-
-  async def _queue_inference(self, request_id: str, *args):
-    future = asyncio.get_running_loop().create_future()
-    await self.inference_queue.put((future, request_id, args))
-    return await future
-
-  async def _inference_worker(self):
-    while True:
-      future, request_id, args = await self.inference_queue.get()
-      try:
-        result = await asyncio.get_running_loop().run_in_executor(
-          self.executor,
-          lambda: np.array(self.stateful_sharded_model.step(request_id, *args))
-        )
-        future.set_result(result)
-      except Exception as e:
-        future.set_exception(e)
-      finally:
-        self.inference_queue.task_done()
+    output_data = await asyncio.get_running_loop().run_in_executor(
+      self.executor,
+      self.stateful_sharded_model.step,
+      request_id,
+      input_tensor
+    )
+    return np.array(output_data), "", output_data.size == 1 and output_data.item() == self.tokenizer.eos_token_id
 
   async def ensure_shard(self, shard: Shard):
     if self.shard == shard:
@@ -71,8 +46,23 @@ class MLXDynamicShardInferenceEngine(InferenceEngine):
 
     model_path = await self.shard_downloader.ensure_shard(shard)
 
-    with self.model_lock:
-      if self.shard != shard:
-        model_shard, self.tokenizer = await load_shard(model_path, shard)
-        self.stateful_sharded_model = StatefulShardedModel(shard, model_shard)
-        self.shard = shard
+    if self.shard != shard:
+      loop = asyncio.get_running_loop()
+
+      # Run load_shard in a separate thread
+      def load_shard_wrapper():
+        return asyncio.run(load_shard(model_path, shard))
+
+      model_shard, self.tokenizer = await loop.run_in_executor(
+        self.executor,
+        load_shard_wrapper
+      )
+
+      # Create StatefulShardedModel in the executor
+      self.stateful_sharded_model = await loop.run_in_executor(
+        self.executor,
+        StatefulShardedModel,
+        shard,
+        model_shard
+      )
+      self.shard = shard

--- a/exo/inference/mlx/sharded_inference_engine.py
+++ b/exo/inference/mlx/sharded_inference_engine.py
@@ -23,21 +23,15 @@ class MLXDynamicShardInferenceEngine(InferenceEngine):
       inputs = await loop.run_in_executor(self.executor, self.tokenizer, prompt, image, return_tensors="np")
       pixel_values = mx.array(inputs["pixel_values"])
       input_ids = mx.array(inputs["input_ids"])
-      output_data = np.array(await loop.run_in_executor(self.executor, self.stateful_sharded_model.step, request_id, input_ids, pixel_values))
+      output_data: np.ndarray = np.array(await loop.run_in_executor(self.executor, self.stateful_sharded_model.step, request_id, input_ids, pixel_values))
     else:
       input_ids = await loop.run_in_executor(self.executor, lambda: mx.array(self.tokenizer.encode(prompt)))
-      output_data = np.array(await loop.run_in_executor(self.executor, self.stateful_sharded_model.step, request_id, input_ids))
+      output_data: np.ndarray = np.array(await loop.run_in_executor(self.executor, self.stateful_sharded_model.step, request_id, input_ids))
     return output_data, "", output_data.size == 1 and output_data.item() == self.tokenizer.eos_token_id
 
   async def infer_tensor(self, request_id: str, shard: Shard, input_data: np.ndarray, inference_state: Optional[str] = None) -> (np.ndarray, str, bool):
     await self.ensure_shard(shard)
-    input_tensor = mx.array(input_data)
-    output_data = np.array(await asyncio.get_running_loop().run_in_executor(
-      self.executor,
-      self.stateful_sharded_model.step,
-      request_id,
-      input_tensor
-    ))
+    output_data: np.ndarray = np.array(await asyncio.get_running_loop().run_in_executor(self.executor, self.stateful_sharded_model.step, request_id, mx.array(input_data)))
     return output_data, "", output_data.size == 1 and output_data.item() == self.tokenizer.eos_token_id
 
   async def ensure_shard(self, shard: Shard):
@@ -48,21 +42,7 @@ class MLXDynamicShardInferenceEngine(InferenceEngine):
 
     if self.shard != shard:
       loop = asyncio.get_running_loop()
-
-      # Run load_shard in a separate thread
-      def load_shard_wrapper():
-        return asyncio.run(load_shard(model_path, shard))
-
-      model_shard, self.tokenizer = await loop.run_in_executor(
-        self.executor,
-        load_shard_wrapper
-      )
-
-      # Create StatefulShardedModel in the executor
-      self.stateful_sharded_model = await loop.run_in_executor(
-        self.executor,
-        StatefulShardedModel,
-        shard,
-        model_shard
-      )
+      def load_shard_wrapper(): return asyncio.run(load_shard(model_path, shard))
+      model_shard, self.tokenizer = await loop.run_in_executor(self.executor, load_shard_wrapper)
+      self.stateful_sharded_model = await loop.run_in_executor(self.executor, StatefulShardedModel, shard, model_shard)
       self.shard = shard

--- a/exo/inference/tinygrad/inference.py
+++ b/exo/inference/tinygrad/inference.py
@@ -64,7 +64,7 @@ class TinygradDynamicShardInferenceEngine(InferenceEngine):
     n_captured_toks = json.loads(inference_state or "{}").get("n_captured_toks", 0)
 
     toks = await asyncio.get_event_loop().run_in_executor(self.executor, self.tokenizer.encode, prompt)
-    h = await asyncio.get_event_loop().run_in_executor(self.executor, self.model, Tensor([toks]), start_pos, TEMPERATURE)
+    h = await asyncio.get_event_loop().run_in_executor(self.executor, lambda: self.model(Tensor([toks]), start_pos, TEMPERATURE).realize())
 
     if h.shape == (1,):
       start_pos += len(toks)
@@ -80,7 +80,7 @@ class TinygradDynamicShardInferenceEngine(InferenceEngine):
     start_pos = json.loads(inference_state or "{}").get("start_pos", 0)
     n_captured_toks = json.loads(inference_state or "{}").get("n_captured_toks", 0)
 
-    h = await asyncio.get_event_loop().run_in_executor(self.executor, self.model, Tensor(input_data), start_pos, TEMPERATURE)
+    h = await asyncio.get_event_loop().run_in_executor(self.executor, lambda: self.model(Tensor(input_data), start_pos, TEMPERATURE).realize())
 
     if h.shape == (1,):
       start_pos += n_captured_toks

--- a/exo/inference/tinygrad/inference.py
+++ b/exo/inference/tinygrad/inference.py
@@ -94,13 +94,7 @@ class TinygradDynamicShardInferenceEngine(InferenceEngine):
 
   async def _run_inference(self, input_tensor, start_pos):
     with self.model_lock:
-      return await asyncio.get_event_loop().run_in_executor(
-        self.executor,
-        self.model,
-        input_tensor,
-        start_pos,
-        TEMPERATURE
-      )
+      return await asyncio.get_event_loop().run_in_executor(self.executor, self.model, input_tensor, start_pos, TEMPERATURE)
 
   async def ensure_shard(self, shard: Shard):
     if self.shard == shard:
@@ -110,13 +104,7 @@ class TinygradDynamicShardInferenceEngine(InferenceEngine):
 
     with self.model_lock:
       if self.shard != shard:
-        self.model = await asyncio.get_event_loop().run_in_executor(
-          self.executor,
-          build_transformer,
-          model_path,
-          shard,
-          "8B" if "8b" in shard.model_id.lower() else "70B"
-        )
+        self.model = await asyncio.get_event_loop().run_in_executor(self.executor, build_transformer, model_path, shard, "8B" if "8b" in shard.model_id.lower() else "70B")
         tokenizer_path = str((model_path if model_path.is_dir() else model_path.parent))
         self.tokenizer = await resolve_tokenizer(tokenizer_path)
         self.shard = shard

--- a/exo/inference/tinygrad/inference.py
+++ b/exo/inference/tinygrad/inference.py
@@ -64,9 +64,7 @@ class TinygradDynamicShardInferenceEngine(InferenceEngine):
     n_captured_toks = json.loads(inference_state or "{}").get("n_captured_toks", 0)
 
     toks = await asyncio.get_event_loop().run_in_executor(self.executor, self.tokenizer.encode, prompt)
-    input_tensor = Tensor([toks])
-
-    h = await asyncio.get_event_loop().run_in_executor(self.executor, self.model, input_tensor, start_pos, TEMPERATURE)
+    h = await asyncio.get_event_loop().run_in_executor(self.executor, self.model, Tensor([toks]), start_pos, TEMPERATURE)
 
     if h.shape == (1,):
       start_pos += len(toks)

--- a/test/test_hf.py
+++ b/test/test_hf.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+# Add the project root to the Python path
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, project_root)
+
+import asyncio
+from exo.download.hf.hf_helpers import get_weight_map
+
+async def test_get_weight_map():
+  repo_ids = [
+    "mlx-community/quantized-gemma-2b",
+    "mlx-community/Meta-Llama-3.1-8B-4bit",
+    "mlx-community/Meta-Llama-3.1-70B-4bit",
+    "mlx-community/Meta-Llama-3.1-405B-4bit",
+  ]
+  for repo_id in repo_ids:
+    weight_map = await get_weight_map(repo_id)
+    assert weight_map is not None, "Weight map should not be None"
+    assert isinstance(weight_map, dict), "Weight map should be a dictionary"
+    assert len(weight_map) > 0, "Weight map should not be empty"
+    print(f"OK: {repo_id}")
+
+if __name__ == "__main__":
+  asyncio.run(test_get_weight_map())


### PR DESCRIPTION
- The issue was that MLX and Tinygrad block and don't have async API's
- Exo uses asyncio for everything and so stuff was getting blocked when MLX and Tinygrad would run. e.g. when they load al large model into memory, a lot of I/O would time out.
- Now uses ThreadPoolExecutor with 1 thread to ensure that MLX and Tinygrad operations always run on their own dedicated thread in a way that is asyncio compatible. Seems to work well, and even got some inference speedups