### PR TITLE
fix allow patterns

### DIFF
--- a/exo/download/hf/hf_helpers.py
+++ b/exo/download/hf/hf_helpers.py
@@ -408,4 +408,4 @@ def get_allow_patterns(weight_map: Dict[str, str], shard: Shard) -> List[str]:
   if DEBUG >= 2: print(f"get_allow_patterns {weight_map=} {shard=} {shard_specific_patterns=}")
   allowed_patterns = list(default_patterns)
   allowed_patterns.extend(shard_specific_patterns)
-  return allowed_patterns
+  return list(set(allowed_patterns))

--- a/exo/download/hf/hf_helpers.py
+++ b/exo/download/hf/hf_helpers.py
@@ -404,8 +404,6 @@ def get_allow_patterns(weight_map: Dict[str, str], shard: Shard) -> List[str]:
     elif shard.is_last_layer():
       shard_specific_patterns.add(sorted_file_names[-1])
   else:
-    shard_specific_patterns = ["*.safetensors"]
+    shard_specific_patterns = set("*.safetensors")
   if DEBUG >= 2: print(f"get_allow_patterns {weight_map=} {shard=} {shard_specific_patterns=}")
-  allowed_patterns = list(default_patterns)
-  allowed_patterns.extend(shard_specific_patterns)
-  return list(set(allowed_patterns))
+  return list(default_patterns | shard_specific_patterns)

--- a/exo/download/hf/hf_helpers.py
+++ b/exo/download/hf/hf_helpers.py
@@ -406,4 +406,6 @@ def get_allow_patterns(weight_map: Dict[str, str], shard: Shard) -> List[str]:
   else:
     shard_specific_patterns = ["*.safetensors"]
   if DEBUG >= 2: print(f"get_allow_patterns {weight_map=} {shard=} {shard_specific_patterns=}")
-  return list(default_patterns | shard_specific_patterns)
+  allowed_patterns = list(default_patterns)
+  allowed_patterns.extend(shard_specific_patterns)
+  return allowed_patterns


### PR DESCRIPTION
A bitwise or is done in-case the weight map for the model does not exist, this returns an error. the ```default_patterns``` set should be converted to a list than extended with ```shard_specific_patterns```