### PR TITLE
[#253] removed </link> tag from index.html

### DIFF
--- a/exo/tinychat/index.html
+++ b/exo/tinychat/index.html
@@ -22,7 +22,7 @@
 <link href="/static/unpkg.com/@highlightjs/cdn-assets@11.9.0/styles/vs2015.min.css" rel="stylesheet"/>
 <link href="/index.css" rel="stylesheet"/>
 <link href="/common.css" rel="stylesheet"/>
-</link></head>
+</head>
 <body>
 <main x-data="state" x-init="console.log(endpoint)">
      <!-- Error Toast -->


### PR DESCRIPTION
This is a fix for #253. Removing `</link>` closing tag from `index.html`.

## resolved
- reset formatting to as it was
- only removed `<\link>` tag
- resolved conflicts with main branch