### PR TITLE
Error Message - Out of memory

### DIFF
--- a/exo/api/chatgpt_api.py
+++ b/exo/api/chatgpt_api.py
@@ -268,7 +268,13 @@ class ChatGPTAPI:
     callback = self.node.on_token.register(callback_id)
 
     if DEBUG >= 2: print(f"Sending prompt from ChatGPT api {request_id=} {shard=} {prompt=} {image_str=}")
-    asyncio.create_task(self.node.process_prompt(shard, prompt, image_str, request_id=request_id))
+    try:
+        await asyncio.gather(self.node.process_prompt(shard, prompt, image_str, request_id=request_id))
+    except Exception as e:
+        if DEBUG >= 2:
+            traceback.print_exc()
+        return web.json_response({"detail": f"Error processing prompt (see logs with DEBUG>=2): {str(e)}"}, status=500)
+
 
     try:
       if DEBUG >= 2: print(f"Waiting for response to finish. timeout={self.response_timeout}s")


### PR DESCRIPTION
When there isn't enough memory for the model to calculate a response, exo used to display an "out of memory" error, but now that error only appears in the console and not in tinychat.

Issue: #275 