### PR TITLE
Point `llama-3.1-70b-bf16` model to an actually bf16 version

### DIFF
--- a/exo/models.py
+++ b/exo/models.py
@@ -17,7 +17,7 @@ model_base_shards = {
     "TinygradDynamicShardInferenceEngine": Shard(model_id="NousResearch/Meta-Llama-3.1-70B-Instruct", start_layer=0, end_layer=0, n_layers=80),
   },
   "llama-3.1-70b-bf16": {
-    "MLXDynamicShardInferenceEngine": Shard(model_id="mlx-community/Meta-Llama-3.1-70B-Instruct-bf16", start_layer=0, end_layer=0, n_layers=80),
+    "MLXDynamicShardInferenceEngine": Shard(model_id="mlx-community/Meta-Llama-3.1-70B-Instruct-bf16-CORRECTED", start_layer=0, end_layer=0, n_layers=80),
     "TinygradDynamicShardInferenceEngine": Shard(model_id="NousResearch/Meta-Llama-3.1-70B-Instruct", start_layer=0, end_layer=0, n_layers=80),
   },
   "llama-3.1-405b": {"MLXDynamicShardInferenceEngine": Shard(model_id="mlx-community/Meta-Llama-3.1-405B-4bit", start_layer=0, end_layer=0, n_layers=126),},


### PR DESCRIPTION
# Why make this PR?
The hf repo `mlx-community/Meta-Llama-3.1-70B-Instruct-bf16` was not actually a bf16 version. First suspicion was how fast it was. No performance difference between this and the 4-bit version? Sus. Then looked at the file sizes and the parameters on that repo. I opened an issue raising how it's the exact same size as the 4-bit quant. Turns out it is a 4-bit quant.

I generated a bf16 mlx model myself and uploaded it, and then migrated it to the `mlx-community` in hf. That is what this now points to. 

I confirmed this works on Exo on my Mac Studio M2 Ultra 192gb.

# Some other notes
I have tagged the `mlx-community` admins on the bad repo to take it down so I can take over that repo's name, and get the one I uploaded added to the mlx-community's hf llama 3.1 collection.

## Related links below
https://huggingface.co/mlx-community/Meta-Llama-3.1-70B-Instruct-bf16/discussions/2
https://huggingface.co/mlx-community/Meta-Llama-3.1-70B-Instruct-bf16/discussions/4
https://huggingface.co/mlx-community/Meta-Llama-3.1-70B-Instruct-bf16-CORRECTED/discussions/2

# Plan for the name migration?
It seems like HF will still redirect requests for my old repo name to the new repo, so there shouldn't be any issues. But regardless, I will open an Exo PR to change the name in the `model.py` right before I hit the rename of the repo assuming the `mlx-community` admins will delete the incorrect repo as I've requested.