### PR TITLE
feat: partition by mem & node latency

### DIFF
--- a/exo/main.py
+++ b/exo/main.py
@@ -12,10 +12,19 @@ from exo.networking.udp.udp_discovery import UDPDiscovery
 from exo.networking.tailscale.tailscale_discovery import TailscaleDiscovery
 from exo.networking.grpc.grpc_peer_handle import GRPCPeerHandle
 from exo.topology.ring_memory_weighted_partitioning_strategy import RingMemoryWeightedPartitioningStrategy
+from exo.topology.latency_aware_partitioning_strategy import LatencyAwarePartitioningStrategy  # Added import
 from exo.api import ChatGPTAPI
 from exo.download.shard_download import ShardDownloader, RepoProgressEvent
 from exo.download.hf.hf_shard_download import HFShardDownloader
-from exo.helpers import print_yellow_exo, find_available_port, DEBUG, get_system_info, get_or_create_node_id, get_all_ip_addresses, terminal_link
+from exo.helpers import (
+    print_yellow_exo,
+    find_available_port,
+    DEBUG,
+    get_system_info,
+    get_or_create_node_id,
+    get_all_ip_addresses,
+    terminal_link,
+)
 from exo.inference.shard import Shard
 from exo.inference.inference_engine import get_inference_engine, InferenceEngine
 from exo.inference.tokenizers import resolve_tokenizer
@@ -23,7 +32,7 @@ from exo.orchestration.node import Node
 from exo.models import model_base_shards
 from exo.viz.topology_viz import TopologyViz
 
-# parse args
+# Parse arguments
 parser = argparse.ArgumentParser(description="Initialize GRPC Discovery")
 parser.add_argument("command", nargs="?", choices=["run"], help="Command to run")
 parser.add_argument("model_name", nargs="?", help="Model name to run")
@@ -31,22 +40,85 @@ parser.add_argument("--node-id", type=str, default=None, help="Node ID")
 parser.add_argument("--node-host", type=str, default="0.0.0.0", help="Node host")
 parser.add_argument("--node-port", type=int, default=None, help="Node port")
 parser.add_argument("--listen-port", type=int, default=5678, help="Listening port for discovery")
-parser.add_argument("--download-quick-check", action="store_true", help="Quick check local path for model shards download")
-parser.add_argument("--max-parallel-downloads", type=int, default=4, help="Max parallel downloads for model shards download")
-parser.add_argument("--prometheus-client-port", type=int, default=None, help="Prometheus client port")
-parser.add_argument("--broadcast-port", type=int, default=5678, help="Broadcast port for discovery")
-parser.add_argument("--discovery-module", type=str, choices=["udp", "tailscale"], default="udp", help="Discovery module to use")
-parser.add_argument("--discovery-timeout", type=int, default=30, help="Discovery timeout in seconds")
-parser.add_argument("--wait-for-peers", type=int, default=0, help="Number of peers to wait to connect to before starting")
-parser.add_argument("--chatgpt-api-port", type=int, default=8000, help="ChatGPT API port")
-parser.add_argument("--chatgpt-api-response-timeout", type=int, default=90, help="ChatGPT API response timeout in seconds")
-parser.add_argument("--max-generate-tokens", type=int, default=10000, help="Max tokens to generate in each request")
-parser.add_argument("--inference-engine", type=str, default=None, help="Inference engine to use")
-parser.add_argument("--disable-tui", action=argparse.BooleanOptionalAction, help="Disable TUI")
-parser.add_argument("--run-model", type=str, help="Specify a model to run directly")
-parser.add_argument("--prompt", type=str, help="Prompt for the model when using --run-model", default="Who are you?")
-parser.add_argument("--tailscale-api-key", type=str, default=None, help="Tailscale API key")
-parser.add_argument("--tailnet-name", type=str, default=None, help="Tailnet name")
+parser.add_argument(
+    "--download-quick-check",
+    action="store_true",
+    help="Quick check local path for model shards download",
+)
+parser.add_argument(
+    "--max-parallel-downloads",
+    type=int,
+    default=4,
+    help="Max parallel downloads for model shards download",
+)
+parser.add_argument(
+    "--prometheus-client-port", type=int, default=None, help="Prometheus client port"
+)
+parser.add_argument(
+    "--broadcast-port", type=int, default=5678, help="Broadcast port for discovery"
+)
+parser.add_argument(
+    "--discovery-module",
+    type=str,
+    choices=["udp", "tailscale"],
+    default="udp",
+    help="Discovery module to use",
+)
+parser.add_argument(
+    "--discovery-timeout", type=int, default=30, help="Discovery timeout in seconds"
+)
+parser.add_argument(
+    "--wait-for-peers",
+    type=int,
+    default=0,
+    help="Number of peers to wait to connect to before starting",
+)
+parser.add_argument(
+    "--chatgpt-api-port", type=int, default=8000, help="ChatGPT API port"
+)
+parser.add_argument(
+    "--chatgpt-api-response-timeout",
+    type=int,
+    default=90,
+    help="ChatGPT API response timeout in seconds",
+)
+parser.add_argument(
+    "--max-generate-tokens",
+    type=int,
+    default=10000,
+    help="Max tokens to generate in each request",
+)
+parser.add_argument(
+    "--inference-engine", type=str, default=None, help="Inference engine to use"
+)
+parser.add_argument(
+    "--disable-tui",
+    action=argparse.BooleanOptionalAction,
+    help="Disable TUI",
+)
+parser.add_argument(
+    "--run-model", type=str, help="Specify a model to run directly"
+)
+parser.add_argument(
+    "--prompt",
+    type=str,
+    help="Prompt for the model when using --run-model",
+    default="Who are you?",
+)
+parser.add_argument(
+    "--tailscale-api-key", type=str, default=None, help="Tailscale API key"
+)
+parser.add_argument(
+    "--tailnet-name", type=str, default=None, help="Tailnet name"
+)
+# Added partitioning strategy argument
+parser.add_argument(
+    "--partitioning-strategy",
+    type=str,
+    choices=["latency_aware", "ring_memory_weighted"],
+    default="latency_aware",
+    help="Partitioning strategy to use",
+)
 args = parser.parse_args()
 
 print_yellow_exo()
@@ -54,158 +126,231 @@ print_yellow_exo()
 system_info = get_system_info()
 print(f"Detected system: {system_info}")
 
-shard_downloader: ShardDownloader = HFShardDownloader(quick_check=args.download_quick_check, max_parallel_downloads=args.max_parallel_downloads)
-inference_engine_name = args.inference_engine or ("mlx" if system_info == "Apple Silicon Mac" else "tinygrad")
+shard_downloader: ShardDownloader = HFShardDownloader(
+    quick_check=args.download_quick_check, max_parallel_downloads=args.max_parallel_downloads
+)
+inference_engine_name = args.inference_engine or (
+    "mlx" if system_info == "Apple Silicon Mac" else "tinygrad"
+)
 inference_engine = get_inference_engine(inference_engine_name, shard_downloader)
-print(f"Using inference engine: {inference_engine.__class__.__name__} with shard downloader: {shard_downloader.__class__.__name__}")
+print(
+    f"Using inference engine: {inference_engine.__class__.__name__} with shard downloader: {shard_downloader.__class__.__name__}"
+)
 
 if args.node_port is None:
-  args.node_port = find_available_port(args.node_host)
-  if DEBUG >= 1: print(f"Using available port: {args.node_port}")
+    args.node_port = find_available_port(args.node_host)
+    if DEBUG >= 1:
+        print(f"Using available port: {args.node_port}")
 
 args.node_id = args.node_id or get_or_create_node_id()
-chatgpt_api_endpoints = [f"http://{ip}:{args.chatgpt_api_port}/v1/chat/completions" for ip in get_all_ip_addresses()]
+chatgpt_api_endpoints = [
+    f"http://{ip}:{args.chatgpt_api_port}/v1/chat/completions" for ip in get_all_ip_addresses()
+]
 web_chat_urls = [f"http://{ip}:{args.chatgpt_api_port}" for ip in get_all_ip_addresses()]
 if DEBUG >= 0:
-  print("Chat interface started:")
-  for web_chat_url in web_chat_urls:
-    print(f" - {terminal_link(web_chat_url)}")
-  print("ChatGPT API endpoint served at:")
-  for chatgpt_api_endpoint in chatgpt_api_endpoints:
-    print(f" - {terminal_link(chatgpt_api_endpoint)}")
+    print("Chat interface started:")
+    for web_chat_url in web_chat_urls:
+        print(f" - {terminal_link(web_chat_url)}")
+    print("ChatGPT API endpoint served at:")
+    for chatgpt_api_endpoint in chatgpt_api_endpoints:
+        print(f" - {terminal_link(chatgpt_api_endpoint)}")
 
 if args.discovery_module == "udp":
-  discovery = UDPDiscovery(args.node_id, args.node_port, args.listen_port, args.broadcast_port, lambda peer_id, address, device_capabilities: GRPCPeerHandle(peer_id, address, device_capabilities), discovery_timeout=args.discovery_timeout)
+    discovery = UDPDiscovery(
+        args.node_id,
+        args.node_port,
+        args.listen_port,
+        args.broadcast_port,
+        lambda peer_id, address, device_capabilities: GRPCPeerHandle(
+            peer_id, address, device_capabilities
+        ),
+        discovery_timeout=args.discovery_timeout,
+    )
 elif args.discovery_module == "tailscale":
-  discovery = TailscaleDiscovery(args.node_id, args.node_port, lambda peer_id, address, device_capabilities: GRPCPeerHandle(peer_id, address, device_capabilities), discovery_timeout=args.discovery_timeout, tailscale_api_key=args.tailscale_api_key, tailnet=args.tailnet_name)
-topology_viz = TopologyViz(chatgpt_api_endpoints=chatgpt_api_endpoints, web_chat_urls=web_chat_urls) if not args.disable_tui else None
+    discovery = TailscaleDiscovery(
+        args.node_id,
+        args.node_port,
+        lambda peer_id, address, device_capabilities: GRPCPeerHandle(
+            peer_id, address, device_capabilities
+        ),
+        discovery_timeout=args.discovery_timeout,
+        tailscale_api_key=args.tailscale_api_key,
+        tailnet=args.tailnet_name,
+    )
+topology_viz = (
+    TopologyViz(chatgpt_api_endpoints=chatgpt_api_endpoints, web_chat_urls=web_chat_urls)
+    if not args.disable_tui
+    else None
+)
+
+# Determine the partitioning strategy based on the argument
+if args.partitioning_strategy == "latency_aware":
+    partitioning_strategy = LatencyAwarePartitioningStrategy()
+elif args.partitioning_strategy == "ring_memory_weighted":
+    partitioning_strategy = RingMemoryWeightedPartitioningStrategy()
+else:
+    # Default to latency-aware
+    partitioning_strategy = LatencyAwarePartitioningStrategy()
+
 node = StandardNode(
-  args.node_id,
-  None,
-  inference_engine,
-  discovery,
-  partitioning_strategy=RingMemoryWeightedPartitioningStrategy(),
-  max_generate_tokens=args.max_generate_tokens,
-  topology_viz=topology_viz
+    args.node_id,
+    None,
+    inference_engine,
+    discovery,
+    partitioning_strategy=partitioning_strategy,
+    max_generate_tokens=args.max_generate_tokens,
+    topology_viz=topology_viz,
 )
 server = GRPCServer(node, args.node_host, args.node_port)
 node.server = server
 api = ChatGPTAPI(
-  node,
-  inference_engine.__class__.__name__,
-  response_timeout=args.chatgpt_api_response_timeout,
-  on_chat_completion_request=lambda req_id, __, prompt: topology_viz.update_prompt(req_id, prompt) if topology_viz else None
+    node,
+    inference_engine.__class__.__name__,
+    response_timeout=args.chatgpt_api_response_timeout,
+    on_chat_completion_request=lambda req_id, __, prompt: topology_viz.update_prompt(req_id, prompt)
+    if topology_viz
+    else None,
 )
 node.on_token.register("update_topology_viz").on_next(
-  lambda req_id, tokens, __: topology_viz.update_prompt_output(req_id, inference_engine.tokenizer.decode(tokens)) if topology_viz and hasattr(inference_engine, "tokenizer") else None
+    lambda req_id, tokens, __: topology_viz.update_prompt_output(
+        req_id, inference_engine.tokenizer.decode(tokens)
+    )
+    if topology_viz and hasattr(inference_engine, "tokenizer")
+    else None
 )
+
+
 def preemptively_start_download(request_id: str, opaque_status: str):
-  try:
-    status = json.loads(opaque_status)
-    if status.get("type") == "node_status" and status.get("status") == "start_process_prompt":
-      current_shard = node.get_current_shard(Shard.from_dict(status.get("shard")))
-      if DEBUG >= 2: print(f"Preemptively starting download for {current_shard}")
-      asyncio.create_task(shard_downloader.ensure_shard(current_shard))
-  except Exception as e:
-    if DEBUG >= 2:
-      print(f"Failed to preemptively start download: {e}")
-      traceback.print_exc()
+    try:
+        status = json.loads(opaque_status)
+        if (
+            status.get("type") == "node_status"
+            and status.get("status") == "start_process_prompt"
+        ):
+            current_shard = node.get_current_shard(Shard.from_dict(status.get("shard")))
+            if DEBUG >= 2:
+                print(f"Preemptively starting download for {current_shard}")
+            asyncio.create_task(shard_downloader.ensure_shard(current_shard))
+    except Exception as e:
+        if DEBUG >= 2:
+            print(f"Failed to preemptively start download: {e}")
+            traceback.print_exc()
+
+
 node.on_opaque_status.register("start_download").on_next(preemptively_start_download)
 
 if args.prometheus_client_port:
-  from exo.stats.metrics import start_metrics_server
-  start_metrics_server(node, args.prometheus_client_port)
+    from exo.stats.metrics import start_metrics_server
+
+    start_metrics_server(node, args.prometheus_client_port)
 
 last_broadcast_time = 0
+
 
 def throttled_broadcast(shard: Shard, event: RepoProgressEvent):
     global last_broadcast_time
     current_time = time.time()
     if event.status == "complete" or current_time - last_broadcast_time >= 0.1:
         last_broadcast_time = current_time
-        asyncio.create_task(node.broadcast_opaque_status("", json.dumps({
-            "type": "download_progress",
-            "node_id": node.id,
-            "progress": event.to_dict()
-        })))
+        asyncio.create_task(
+            node.broadcast_opaque_status(
+                "",
+                json.dumps(
+                    {
+                        "type": "download_progress",
+                        "node_id": node.id,
+                        "progress": event.to_dict(),
+                    }
+                ),
+            )
+        )
+
 
 shard_downloader.on_progress.register("broadcast").on_next(throttled_broadcast)
 
 
 async def shutdown(signal, loop):
-  """Gracefully shutdown the server and close the asyncio loop."""
-  print(f"Received exit signal {signal.name}...")
-  print("Thank you for using exo.")
-  print_yellow_exo()
-  server_tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-  [task.cancel() for task in server_tasks]
-  print(f"Cancelling {len(server_tasks)} outstanding tasks")
-  await asyncio.gather(*server_tasks, return_exceptions=True)
-  await server.stop()
-  loop.stop()
+    """Gracefully shutdown the server and close the asyncio loop."""
+    print(f"Received exit signal {signal.name}...")
+    print("Thank you for using exo.")
+    print_yellow_exo()
+    server_tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    [task.cancel() for task in server_tasks]
+    print(f"Cancelling {len(server_tasks)} outstanding tasks")
+    await asyncio.gather(*server_tasks, return_exceptions=True)
+    await server.stop()
+    loop.stop()
 
 
 async def run_model_cli(node: Node, inference_engine: InferenceEngine, model_name: str, prompt: str):
-  shard = model_base_shards.get(model_name, {}).get(inference_engine.__class__.__name__)
-  if not shard:
-    print(f"Error: Unsupported model '{model_name}' for inference engine {inference_engine.__class__.__name__}")
-    return
-  tokenizer = await resolve_tokenizer(shard.model_id)
-  request_id = str(uuid.uuid4())
-  callback_id = f"cli-wait-response-{request_id}"
-  callback = node.on_token.register(callback_id)
-  if topology_viz:
-    topology_viz.update_prompt(request_id, prompt)
-  prompt = tokenizer.apply_chat_template([{"role": "user", "content": prompt}], tokenize=False, add_generation_prompt=True)
+    shard = model_base_shards.get(model_name, {}).get(inference_engine.__class__.__name__)
+    if not shard:
+        print(
+            f"Error: Unsupported model '{model_name}' for inference engine {inference_engine.__class__.__name__}"
+        )
+        return
+    tokenizer = await resolve_tokenizer(shard.model_id)
+    request_id = str(uuid.uuid4())
+    callback_id = f"cli-wait-response-{request_id}"
+    callback = node.on_token.register(callback_id)
+    if topology_viz:
+        topology_viz.update_prompt(request_id, prompt)
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt}], tokenize=False, add_generation_prompt=True
+    )
 
-  try:
-    print(f"Processing prompt: {prompt}")
-    await node.process_prompt(shard, prompt, None, request_id=request_id)
+    try:
+        print(f"Processing prompt: {prompt}")
+        await node.process_prompt(shard, prompt, None, request_id=request_id)
 
-    _, tokens, _ = await callback.wait(lambda _request_id, tokens, is_finished: _request_id == request_id and is_finished, timeout=300)
+        _, tokens, _ = await callback.wait(
+            lambda _request_id, tokens, is_finished: _request_id == request_id and is_finished,
+            timeout=300,
+        )
 
-    print("\nGenerated response:")
-    print(tokenizer.decode(tokens))
-  except Exception as e:
-    print(f"Error processing prompt: {str(e)}")
-    traceback.print_exc()
-  finally:
-    node.on_token.deregister(callback_id)
+        print("\nGenerated response:")
+        print(tokenizer.decode(tokens))
+    except Exception as e:
+        print(f"Error processing prompt: {str(e)}")
+        traceback.print_exc()
+    finally:
+        node.on_token.deregister(callback_id)
 
 
 async def main():
-  loop = asyncio.get_running_loop()
+    loop = asyncio.get_running_loop()
 
-  # Use a more direct approach to handle signals
-  def handle_exit():
-    asyncio.ensure_future(shutdown(signal.SIGTERM, loop))
+    # Use a more direct approach to handle signals
+    def handle_exit():
+        asyncio.ensure_future(shutdown(signal.SIGTERM, loop))
 
-  for s in [signal.SIGINT, signal.SIGTERM]:
-    loop.add_signal_handler(s, handle_exit)
+    for s in [signal.SIGINT, signal.SIGTERM]:
+        loop.add_signal_handler(s, handle_exit)
 
-  await node.start(wait_for_peers=args.wait_for_peers)
+    await node.start(wait_for_peers=args.wait_for_peers)
 
-  if args.command == "run" or args.run_model:
-    model_name = args.model_name or args.run_model
-    if not model_name:
-      print("Error: Model name is required when using 'run' command or --run-model")
-      return
-    await run_model_cli(node, inference_engine, model_name, args.prompt)
-  else:
-    asyncio.create_task(api.run(port=args.chatgpt_api_port))  # Start the API server as a non-blocking task
-    await asyncio.Event().wait()
+    if args.command == "run" or args.run_model:
+        model_name = args.model_name or args.run_model
+        if not model_name:
+            print("Error: Model name is required when using 'run' command or --run-model")
+            return
+        await run_model_cli(node, inference_engine, model_name, args.prompt)
+    else:
+        asyncio.create_task(api.run(port=args.chatgpt_api_port))  # Start the API server as a non-blocking task
+        await asyncio.Event().wait()
 
 
 def run():
-  loop = asyncio.new_event_loop()
-  asyncio.set_event_loop(loop)
-  try:
-    loop.run_until_complete(main())
-  except KeyboardInterrupt:
-    print("Received keyboard interrupt. Shutting down...")
-  finally:
-    loop.run_until_complete(shutdown(signal.SIGTERM, loop))
-    loop.close()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(main())
+    except KeyboardInterrupt:
+        print("Received keyboard interrupt. Shutting down...")
+    finally:
+        loop.run_until_complete(shutdown(signal.SIGTERM, loop))
+        loop.close()
+
 
 if __name__ == "__main__":
-  run()
+    run()

--- a/exo/networking/grpc/node_service.proto
+++ b/exo/networking/grpc/node_service.proto
@@ -59,8 +59,13 @@ message Topology {
   map<string, Peers> peer_graph = 2;
 }
 
+message PeerConnection {
+  string peer_id = 1;
+  double latency = 2;
+}
+
 message Peers {
-    repeated string peer_ids = 1;
+    repeated PeerConnection connections = 1;
 }
 
 message DeviceFlops {

--- a/exo/networking/grpc/node_service_pb2.py
+++ b/exo/networking/grpc/node_service_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12node_service.proto\x12\x0cnode_service\"S\n\x05Shard\x12\x10\n\x08model_id\x18\x01 \x01(\t\x12\x13\n\x0bstart_layer\x18\x02 \x01(\x05\x12\x11\n\tend_layer\x18\x03 \x01(\x05\x12\x10\n\x08n_layers\x18\x04 \x01(\x05\"\xc3\x01\n\rPromptRequest\x12\"\n\x05shard\x18\x01 \x01(\x0b\x32\x13.node_service.Shard\x12\x0e\n\x06prompt\x18\x02 \x01(\t\x12\x16\n\timage_str\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x17\n\nrequest_id\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x1c\n\x0finference_state\x18\x05 \x01(\tH\x02\x88\x01\x01\x42\x0c\n\n_image_strB\r\n\x0b_request_idB\x12\n\x10_inference_state\"\xb3\x01\n\rTensorRequest\x12\"\n\x05shard\x18\x01 \x01(\x0b\x32\x13.node_service.Shard\x12$\n\x06tensor\x18\x02 \x01(\x0b\x32\x14.node_service.Tensor\x12\x17\n\nrequest_id\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1c\n\x0finference_state\x18\x04 \x01(\tH\x01\x88\x01\x01\x42\r\n\x0b_request_idB\x12\n\x10_inference_state\"/\n\x19GetInferenceResultRequest\x12\x12\n\nrequest_id\x18\x01 \x01(\t\"\\\n\x0fInferenceResult\x12)\n\x06tensor\x18\x01 \x01(\x0b\x32\x14.node_service.TensorH\x00\x88\x01\x01\x12\x13\n\x0bis_finished\x18\x02 \x01(\x08\x42\t\n\x07_tensor\";\n\x06Tensor\x12\x13\n\x0btensor_data\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\x05\x12\r\n\x05\x64type\x18\x03 \x01(\t\"<\n\x16\x43ollectTopologyRequest\x12\x0f\n\x07visited\x18\x01 \x03(\t\x12\x11\n\tmax_depth\x18\x02 \x01(\x05\"\x8e\x02\n\x08Topology\x12\x30\n\x05nodes\x18\x01 \x03(\x0b\x32!.node_service.Topology.NodesEntry\x12\x39\n\npeer_graph\x18\x02 \x03(\x0b\x32%.node_service.Topology.PeerGraphEntry\x1aN\n\nNodesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12/\n\x05value\x18\x02 \x01(\x0b\x32 .node_service.DeviceCapabilities:\x02\x38\x01\x1a\x45\n\x0ePeerGraphEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.node_service.Peers:\x02\x38\x01\"\x19\n\x05Peers\x12\x10\n\x08peer_ids\x18\x01 \x03(\t\"7\n\x0b\x44\x65viceFlops\x12\x0c\n\x04\x66p32\x18\x01 \x01(\x02\x12\x0c\n\x04\x66p16\x18\x02 \x01(\x02\x12\x0c\n\x04int8\x18\x03 \x01(\x02\"k\n\x12\x44\x65viceCapabilities\x12\r\n\x05model\x18\x01 \x01(\t\x12\x0c\n\x04\x63hip\x18\x02 \x01(\t\x12\x0e\n\x06memory\x18\x03 \x01(\x05\x12(\n\x05\x66lops\x18\x04 \x01(\x0b\x32\x19.node_service.DeviceFlops\"L\n\x11SendResultRequest\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\x0e\n\x06result\x18\x02 \x03(\x05\x12\x13\n\x0bis_finished\x18\x03 \x01(\x08\"=\n\x17SendOpaqueStatusRequest\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\x0e\n\x06status\x18\x02 \x01(\t\"\x14\n\x12HealthCheckRequest\")\n\x13HealthCheckResponse\x12\x12\n\nis_healthy\x18\x01 \x01(\x08\"\x07\n\x05\x45mpty2\xb4\x04\n\x0bNodeService\x12\x41\n\nSendPrompt\x12\x1b.node_service.PromptRequest\x1a\x14.node_service.Tensor\"\x00\x12\x41\n\nSendTensor\x12\x1b.node_service.TensorRequest\x1a\x14.node_service.Tensor\"\x00\x12^\n\x12GetInferenceResult\x12\'.node_service.GetInferenceResultRequest\x1a\x1d.node_service.InferenceResult\"\x00\x12Q\n\x0f\x43ollectTopology\x12$.node_service.CollectTopologyRequest\x1a\x16.node_service.Topology\"\x00\x12\x44\n\nSendResult\x12\x1f.node_service.SendResultRequest\x1a\x13.node_service.Empty\"\x00\x12P\n\x10SendOpaqueStatus\x12%.node_service.SendOpaqueStatusRequest\x1a\x13.node_service.Empty\"\x00\x12T\n\x0bHealthCheck\x12 .node_service.HealthCheckRequest\x1a!.node_service.HealthCheckResponse\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12node_service.proto\x12\x0cnode_service\"S\n\x05Shard\x12\x10\n\x08model_id\x18\x01 \x01(\t\x12\x13\n\x0bstart_layer\x18\x02 \x01(\x05\x12\x11\n\tend_layer\x18\x03 \x01(\x05\x12\x10\n\x08n_layers\x18\x04 \x01(\x05\"\xc3\x01\n\rPromptRequest\x12\"\n\x05shard\x18\x01 \x01(\x0b\x32\x13.node_service.Shard\x12\x0e\n\x06prompt\x18\x02 \x01(\t\x12\x16\n\timage_str\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x17\n\nrequest_id\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x1c\n\x0finference_state\x18\x05 \x01(\tH\x02\x88\x01\x01\x42\x0c\n\n_image_strB\r\n\x0b_request_idB\x12\n\x10_inference_state\"\xb3\x01\n\rTensorRequest\x12\"\n\x05shard\x18\x01 \x01(\x0b\x32\x13.node_service.Shard\x12$\n\x06tensor\x18\x02 \x01(\x0b\x32\x14.node_service.Tensor\x12\x17\n\nrequest_id\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x1c\n\x0finference_state\x18\x04 \x01(\tH\x01\x88\x01\x01\x42\r\n\x0b_request_idB\x12\n\x10_inference_state\"/\n\x19GetInferenceResultRequest\x12\x12\n\nrequest_id\x18\x01 \x01(\t\"\\\n\x0fInferenceResult\x12)\n\x06tensor\x18\x01 \x01(\x0b\x32\x14.node_service.TensorH\x00\x88\x01\x01\x12\x13\n\x0bis_finished\x18\x02 \x01(\x08\x42\t\n\x07_tensor\";\n\x06Tensor\x12\x13\n\x0btensor_data\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\x05\x12\r\n\x05\x64type\x18\x03 \x01(\t\"<\n\x16\x43ollectTopologyRequest\x12\x0f\n\x07visited\x18\x01 \x03(\t\x12\x11\n\tmax_depth\x18\x02 \x01(\x05\"\x8e\x02\n\x08Topology\x12\x30\n\x05nodes\x18\x01 \x03(\x0b\x32!.node_service.Topology.NodesEntry\x12\x39\n\npeer_graph\x18\x02 \x03(\x0b\x32%.node_service.Topology.PeerGraphEntry\x1aN\n\nNodesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12/\n\x05value\x18\x02 \x01(\x0b\x32 .node_service.DeviceCapabilities:\x02\x38\x01\x1a\x45\n\x0ePeerGraphEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.node_service.Peers:\x02\x38\x01\"2\n\x0ePeerConnection\x12\x0f\n\x07peer_id\x18\x01 \x01(\t\x12\x0f\n\x07latency\x18\x02 \x01(\x01\":\n\x05Peers\x12\x31\n\x0b\x63onnections\x18\x01 \x03(\x0b\x32\x1c.node_service.PeerConnection\"7\n\x0b\x44\x65viceFlops\x12\x0c\n\x04\x66p32\x18\x01 \x01(\x02\x12\x0c\n\x04\x66p16\x18\x02 \x01(\x02\x12\x0c\n\x04int8\x18\x03 \x01(\x02\"k\n\x12\x44\x65viceCapabilities\x12\r\n\x05model\x18\x01 \x01(\t\x12\x0c\n\x04\x63hip\x18\x02 \x01(\t\x12\x0e\n\x06memory\x18\x03 \x01(\x05\x12(\n\x05\x66lops\x18\x04 \x01(\x0b\x32\x19.node_service.DeviceFlops\"L\n\x11SendResultRequest\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\x0e\n\x06result\x18\x02 \x03(\x05\x12\x13\n\x0bis_finished\x18\x03 \x01(\x08\"=\n\x17SendOpaqueStatusRequest\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\x0e\n\x06status\x18\x02 \x01(\t\"\x14\n\x12HealthCheckRequest\")\n\x13HealthCheckResponse\x12\x12\n\nis_healthy\x18\x01 \x01(\x08\"\x07\n\x05\x45mpty2\xb4\x04\n\x0bNodeService\x12\x41\n\nSendPrompt\x12\x1b.node_service.PromptRequest\x1a\x14.node_service.Tensor\"\x00\x12\x41\n\nSendTensor\x12\x1b.node_service.TensorRequest\x1a\x14.node_service.Tensor\"\x00\x12^\n\x12GetInferenceResult\x12\'.node_service.GetInferenceResultRequest\x1a\x1d.node_service.InferenceResult\"\x00\x12Q\n\x0f\x43ollectTopology\x12$.node_service.CollectTopologyRequest\x1a\x16.node_service.Topology\"\x00\x12\x44\n\nSendResult\x12\x1f.node_service.SendResultRequest\x1a\x13.node_service.Empty\"\x00\x12P\n\x10SendOpaqueStatus\x12%.node_service.SendOpaqueStatusRequest\x1a\x13.node_service.Empty\"\x00\x12T\n\x0bHealthCheck\x12 .node_service.HealthCheckRequest\x1a!.node_service.HealthCheckResponse\"\x00\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -45,22 +45,24 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_TOPOLOGY_NODESENTRY']._serialized_end=967
   _globals['_TOPOLOGY_PEERGRAPHENTRY']._serialized_start=969
   _globals['_TOPOLOGY_PEERGRAPHENTRY']._serialized_end=1038
-  _globals['_PEERS']._serialized_start=1040
-  _globals['_PEERS']._serialized_end=1065
-  _globals['_DEVICEFLOPS']._serialized_start=1067
-  _globals['_DEVICEFLOPS']._serialized_end=1122
-  _globals['_DEVICECAPABILITIES']._serialized_start=1124
-  _globals['_DEVICECAPABILITIES']._serialized_end=1231
-  _globals['_SENDRESULTREQUEST']._serialized_start=1233
-  _globals['_SENDRESULTREQUEST']._serialized_end=1309
-  _globals['_SENDOPAQUESTATUSREQUEST']._serialized_start=1311
-  _globals['_SENDOPAQUESTATUSREQUEST']._serialized_end=1372
-  _globals['_HEALTHCHECKREQUEST']._serialized_start=1374
-  _globals['_HEALTHCHECKREQUEST']._serialized_end=1394
-  _globals['_HEALTHCHECKRESPONSE']._serialized_start=1396
-  _globals['_HEALTHCHECKRESPONSE']._serialized_end=1437
-  _globals['_EMPTY']._serialized_start=1439
-  _globals['_EMPTY']._serialized_end=1446
-  _globals['_NODESERVICE']._serialized_start=1449
-  _globals['_NODESERVICE']._serialized_end=2013
+  _globals['_PEERCONNECTION']._serialized_start=1040
+  _globals['_PEERCONNECTION']._serialized_end=1090
+  _globals['_PEERS']._serialized_start=1092
+  _globals['_PEERS']._serialized_end=1150
+  _globals['_DEVICEFLOPS']._serialized_start=1152
+  _globals['_DEVICEFLOPS']._serialized_end=1207
+  _globals['_DEVICECAPABILITIES']._serialized_start=1209
+  _globals['_DEVICECAPABILITIES']._serialized_end=1316
+  _globals['_SENDRESULTREQUEST']._serialized_start=1318
+  _globals['_SENDRESULTREQUEST']._serialized_end=1394
+  _globals['_SENDOPAQUESTATUSREQUEST']._serialized_start=1396
+  _globals['_SENDOPAQUESTATUSREQUEST']._serialized_end=1457
+  _globals['_HEALTHCHECKREQUEST']._serialized_start=1459
+  _globals['_HEALTHCHECKREQUEST']._serialized_end=1479
+  _globals['_HEALTHCHECKRESPONSE']._serialized_start=1481
+  _globals['_HEALTHCHECKRESPONSE']._serialized_end=1522
+  _globals['_EMPTY']._serialized_start=1524
+  _globals['_EMPTY']._serialized_end=1531
+  _globals['_NODESERVICE']._serialized_start=1534
+  _globals['_NODESERVICE']._serialized_end=2098
 # @@protoc_insertion_point(module_scope)

--- a/exo/networking/grpc/node_service_pb2_grpc.py
+++ b/exo/networking/grpc/node_service_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-from . import node_service_pb2 as node__service__pb2
+import node_service_pb2 as node__service__pb2
 
 GRPC_GENERATED_VERSION = '1.64.1'
 GRPC_VERSION = grpc.__version__

--- a/exo/topology/device_capabilities.py
+++ b/exo/topology/device_capabilities.py
@@ -1,7 +1,8 @@
 from exo import DEBUG
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 import subprocess
 import psutil
+from typing import Optional
 
 TFLOPS = 1.00
 
@@ -26,16 +27,20 @@ class DeviceCapabilities:
   chip: str
   memory: int
   flops: DeviceFlops
+  latency: Optional[float] = field(default=None)  # Latency in milliseconds
 
   def __str__(self):
-    return f"Model: {self.model}. Chip: {self.chip}. Memory: {self.memory}MB. Flops: {self.flops}"
+    return f"Model: {self.model}. Chip: {self.chip}. Memory: {self.memory}MB. Flops: {self.flops}. Latency: {self.latency}ms"
 
   def __post_init__(self):
     if isinstance(self.flops, dict):
       self.flops = DeviceFlops(**self.flops)
 
   def to_dict(self):
-    return {"model": self.model, "chip": self.chip, "memory": self.memory, "flops": self.flops.to_dict()}
+    data = {"model": self.model, "chip": self.chip, "memory": self.memory, "flops": self.flops.to_dict()}
+    if self.latency is not None:
+      data["latency"] = self.latency
+    return data
 
 
 UNKNOWN_DEVICE_CAPABILITIES = DeviceCapabilities(model="Unknown Model", chip="Unknown Chip", memory=0, flops=DeviceFlops(fp32=0, fp16=0, int8=0))

--- a/exo/topology/latency_aware_partitioning_strategy.py
+++ b/exo/topology/latency_aware_partitioning_strategy.py
@@ -1,0 +1,37 @@
+from typing import List
+from .partitioning_strategy import PartitioningStrategy
+from .topology import Topology
+from .partitioning_strategy import Partition
+
+class LatencyAwarePartitioningStrategy(PartitioningStrategy):
+    def partition(self, topology: Topology) -> List[Partition]:
+        nodes = list(topology.all_nodes())
+        node_scores = []
+
+        for node_id, capabilities in nodes:
+            neighbors = topology.get_neighbors(node_id)
+            # Compute average latency to neighbors; handle division by zero
+            if neighbors:
+                avg_latency = sum(neighbors.values()) / len(neighbors)
+            else:
+                avg_latency = float('inf')  # Assign high latency if no neighbors
+
+            # Compute score based on memory and latency
+            # Higher memory and lower latency should result in a higher score
+            # Avoid division by zero by adding a small epsilon
+            epsilon = 1e-6
+            latency_factor = 1 / (avg_latency + epsilon)
+            score = capabilities.memory * latency_factor
+            node_scores.append((node_id, score))
+
+        # Normalize scores to sum to 1
+        total_score = sum(score for node_id, score in node_scores)
+        partitions = []
+        start = 0.0
+        for node_id, score in node_scores:
+            proportion = score / total_score if total_score > 0 else 0
+            end = start + proportion
+            partitions.append(Partition(node_id, start, end))
+            start = end
+
+        return partitions

--- a/exo/topology/test_latency_aware_partitioning_strategy.py
+++ b/exo/topology/test_latency_aware_partitioning_strategy.py
@@ -1,0 +1,87 @@
+import unittest
+from exo.topology.latency_aware_partitioning_strategy import LatencyAwarePartitioningStrategy
+from exo.topology.topology import Topology
+from exo.topology.device_capabilities import DeviceCapabilities, DeviceFlops
+from exo.topology.partitioning_strategy import Partition
+
+
+class TestLatencyAwarePartitioningStrategy(unittest.TestCase):
+    def test_partition(self):
+        # Create a topology with three nodes
+        topology = Topology()
+        topology.update_node(
+            "node1",
+            DeviceCapabilities(model="Node1", chip="Chip1", memory=4000, flops=DeviceFlops(fp32=0, fp16=0, int8=0)),
+        )
+        topology.update_node(
+            "node2",
+            DeviceCapabilities(model="Node2", chip="Chip2", memory=2000, flops=DeviceFlops(fp32=0, fp16=0, int8=0)),
+        )
+        topology.update_node(
+            "node3",
+            DeviceCapabilities(model="Node3", chip="Chip3", memory=8000, flops=DeviceFlops(fp32=0, fp16=0, int8=0)),
+        )
+
+        # Add edges with latencies
+        # node1 <-> node2 with latency 10ms
+        # node2 <-> node3 with latency 20ms
+        # node3 <-> node1 with latency 30ms
+        topology.add_edge("node1", "node2", latency=10)
+        topology.add_edge("node2", "node3", latency=20)
+        topology.add_edge("node3", "node1", latency=30)
+
+        strategy = LatencyAwarePartitioningStrategy()
+        partitions = strategy.partition(topology)
+
+        # Expected scores calculation
+        # Node1:
+        # Average latency = (10 + 30) / 2 = 20ms
+        # Latency factor = 1 / (20 + epsilon)
+        # Score = 4000 * Latency factor = 4000 / 20 = 200
+
+        # Node2:
+        # Average latency = (10 + 20) / 2 = 15ms
+        # Latency factor = 1 / (15 + epsilon)
+        # Score = 2000 / 15 ≈ 133.333
+
+        # Node3:
+        # Average latency = (20 + 30) / 2 = 25ms
+        # Latency factor = 1 / (25 + epsilon)
+        # Score = 8000 / 25 = 320
+
+        # Total score = 200 + 133.333 + 320 = 653.333
+
+        # Compute proportions
+        total_score = 200 + 133.333 + 320
+        node1_proportion = 200 / total_score
+        node2_proportion = 133.333 / total_score
+        node3_proportion = 320 / total_score
+
+        # Expected partitions
+        expected_partitions = [
+            Partition("node1", 0.0, node1_proportion),
+            Partition("node2", node1_proportion, node1_proportion + node2_proportion),
+            Partition("node3", node1_proportion + node2_proportion, 1.0),
+        ]
+
+        # Assert that the number of partitions is correct
+        self.assertEqual(len(partitions), 3)
+
+        # Helper function to compare partitions within a tolerance
+        def partitions_almost_equal(p1, p2, tol=1e-4):
+            return (
+                p1.node_id == p2.node_id and
+                abs(p1.start - p2.start) <= tol and
+                abs(p1.end - p2.end) <= tol
+            )
+
+        # Compare each expected partition with the actual partition
+        for expected, actual in zip(expected_partitions, partitions):
+            self.assertTrue(
+                partitions_almost_equal(expected, actual),
+                f"Expected {expected}, got {actual}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/exo/topology/topology.py
+++ b/exo/topology/topology.py
@@ -3,47 +3,47 @@ from typing import Dict, Set, Optional
 
 
 class Topology:
-  def __init__(self):
-    self.nodes: Dict[str, DeviceCapabilities] = {}  # Maps node IDs to DeviceCapabilities
-    self.peer_graph: Dict[str, Set[str]] = {}  # Adjacency list representing the graph
-    self.active_node_id: Optional[str] = None
+    def __init__(self):
+        self.nodes: Dict[str, DeviceCapabilities] = {}
+        self.peer_graph: Dict[str, Dict[str, float]] = {}
+        self.active_node_id: Optional[str] = None
 
-  def update_node(self, node_id: str, device_capabilities: DeviceCapabilities):
-    self.nodes[node_id] = device_capabilities
+    def update_node(self, node_id: str, device_capabilities: DeviceCapabilities):
+        self.nodes[node_id] = device_capabilities
 
-  def get_node(self, node_id: str) -> DeviceCapabilities:
-    return self.nodes.get(node_id)
+    def get_node(self, node_id: str) -> DeviceCapabilities:
+        return self.nodes.get(node_id)
 
-  def all_nodes(self):
-    return self.nodes.items()
+    def all_nodes(self):
+        return self.nodes.items()
 
-  def add_edge(self, node1_id: str, node2_id: str):
-    if node1_id not in self.peer_graph:
-      self.peer_graph[node1_id] = set()
-    if node2_id not in self.peer_graph:
-      self.peer_graph[node2_id] = set()
-    self.peer_graph[node1_id].add(node2_id)
-    self.peer_graph[node2_id].add(node1_id)
+    def add_edge(self, node1_id: str, node2_id: str, latency: float):
+        if node1_id not in self.peer_graph:
+            self.peer_graph[node1_id] = {}
+        if node2_id not in self.peer_graph:
+            self.peer_graph[node2_id] = {}
+        self.peer_graph[node1_id][node2_id] = latency
+        self.peer_graph[node2_id][node1_id] = latency
 
-  def get_neighbors(self, node_id: str) -> Set[str]:
-    return self.peer_graph.get(node_id, set())
+    def get_neighbors(self, node_id: str) -> Dict[str, float]:
+        return self.peer_graph.get(node_id, {})
 
-  def all_edges(self):
-    edges = []
-    for node, neighbors in self.peer_graph.items():
-      for neighbor in neighbors:
-        if (neighbor, node) not in edges:  # Avoid duplicate edges
-          edges.append((node, neighbor))
-    return edges
+    def all_edges(self):
+        edges = []
+        for node, neighbors in self.peer_graph.items():
+            for neighbor, latency in neighbors.items():
+                if (neighbor, node, latency) not in edges:
+                    edges.append((node, neighbor, latency))
+        return edges
 
-  def merge(self, other: "Topology"):
-    for node_id, capabilities in other.nodes.items():
-      self.update_node(node_id, capabilities)
-    for node_id, neighbors in other.peer_graph.items():
-      for neighbor in neighbors:
-        self.add_edge(node_id, neighbor)
+    def merge(self, other: "Topology"):
+        for node_id, capabilities in other.nodes.items():
+            self.update_node(node_id, capabilities)
+        for node_id, neighbors in other.peer_graph.items():
+            for neighbor_id, latency in neighbors.items():
+                self.add_edge(node_id, neighbor_id, latency)
 
-  def __str__(self):
-    nodes_str = ", ".join(f"{node_id}: {cap}" for node_id, cap in self.nodes.items())
-    edges_str = ", ".join(f"{node}: {neighbors}" for node, neighbors in self.peer_graph.items())
-    return f"Topology(Nodes: {{{nodes_str}}}, Edges: {{{edges_str}}})"
+    def __str__(self):
+        nodes_str = ", ".join(f"{node_id}: {cap}" for node_id, cap in self.nodes.items())
+        edges_str = ", ".join(f"{node}: {neighbors}" for node, neighbors in self.peer_graph.items())
+        return f"Topology(Nodes: {{{nodes_str}}}, Edges: {{{edges_str}}})"


### PR DESCRIPTION
# Pull Request: Add Partitioning Strategy Flag with Latency-Aware Default

## Description

### Feature Added
- **Partitioning Strategy Flag:**  
  - Introduced `--partitioning-strategy` CLI flag in `main.py` to allow selection between partitioning strategies.
  - Set `latency_aware` as the default partitioning strategy.

### Implementation Details
- **Imports:**  
  - Imported `LatencyAwarePartitioningStrategy` alongside existing strategies.
- **Argument Parsing:**  
  - Updated `main.py` to parse the new `--partitioning-strategy` flag.
- **Strategy Selection:**  
  - Instantiated the selected partitioning strategy based on user input.
- **Node Initialization:**  
  - Modified `StandardNode` initialization to accept the chosen partitioning strategy.

### Testing
- **New Tests:**  
  - Added `TestLatencyAwarePartitioningStrategy` in `tests/test_latency_aware_partitioning.py` to validate the new strategy.

### Additional Changes
- **Protobuf Definitions:**  
  - Updated protobuf definitions to include latency in topology.
- **gRPC Files:**  
  - Regenerated `node_service_pb2.py` and `node_service_pb2_grpc.py` to reflect `.proto` updates.

## Usage

### Default (Latency-Aware)
```bash
python main.py run <model_name>
