### PR TITLE
Fix gpu capabilities display

### DIFF
--- a/exo/topology/device_capabilities.py
+++ b/exo/topology/device_capabilities.py
@@ -89,6 +89,7 @@ CHIP_FLOPS = {
   "NVIDIA GEFORCE RTX 2070": DeviceFlops(fp32=7.46*TFLOPS, fp16=14.93*TFLOPS, int8=29.86*TFLOPS),
   "NVIDIA GEFORCE RTX 2070 SUPER": DeviceFlops(fp32=9.06*TFLOPS, fp16=18.12*TFLOPS, int8=36.24*TFLOPS),
   "NVIDIA GEFORCE RTX 2080": DeviceFlops(fp32=10.07*TFLOPS, fp16=20.14*TFLOPS, int8=40.28*TFLOPS),
+  "NVIDIA GEFORCE RTX 2080 TI": DeviceFlops(fp32=13.45*TFLOPS, fp16=26.9*TFLOPS, int8=40.28*TFLOPS),
   "NVIDIA GEFORCE RTX 2080 SUPER": DeviceFlops(fp32=11.15*TFLOPS, fp16=22.30*TFLOPS, int8=44.60*TFLOPS),
   "NVIDIA TITAN RTX": DeviceFlops(fp32=16.31*TFLOPS, fp16=32.62*TFLOPS, int8=65.24*TFLOPS),
   # QUADRO RTX Ampere series
@@ -178,7 +179,8 @@ def linux_device_capabilities() -> DeviceCapabilities:
 
     pynvml.nvmlInit()
     handle = pynvml.nvmlDeviceGetHandleByIndex(0)
-    gpu_name = pynvml.nvmlDeviceGetName(handle).upper()
+    gpu_raw_name = pynvml.nvmlDeviceGetName(handle).upper()
+    gpu_name = gpu_raw_name.rsplit(" ", 1)[0] if gpu_raw_name.endswith("GB") else gpu_raw_name
     gpu_memory_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
 
     if DEBUG >= 2: print(f"NVIDIA device {gpu_name=} {gpu_memory_info=}")


### PR DESCRIPTION
This PR addresses #343 , the FLOPS display issue by splitting and deleting the VRAM size info from the GPU name.
In my case, the device name is `NVIDIA RTX A2000 12GB`, so it didn't show the info correctly.

**Before**
![CleanShot 2024-10-14 at 23 24 59@2x](https://github.com/user-attachments/assets/4f1ed2db-2d04-4218-8c51-58732c4feab6)

**After**
![CleanShot 2024-10-14 at 23 25 21@2x](https://github.com/user-attachments/assets/d06db3b0-1d86-4c88-a632-506e85aec1ae)



Also updated the info for RTX 2080 TI.