### PR TITLE
Adaptive Flops Partitioning Strategy

### DIFF
--- a/exo/topology/adaptive_flops_partitioning_strategy.py
+++ b/exo/topology/adaptive_flops_partitioning_strategy.py
@@ -1,0 +1,43 @@
+from typing import List, Dict
+from exo.topology.partitioning_strategy import PartitioningStrategy, Partition
+from exo.topology.topology import Topology
+from exo.inference.shard import Shard
+
+class AdaptiveFlopsPartitioningStrategy(PartitioningStrategy):
+    def __init__(self, ema_alpha: float = 0.2):
+        self.node_performance: Dict[str, float] = {}
+        self.total_flops: float = 0
+        self.ema_alpha = ema_alpha
+
+    def partition(self, topology: Topology) -> List[Partition]:
+        nodes = list(topology.all_nodes())
+        self.total_flops = sum(node[1].flops.fp16 for node in nodes)
+        
+        partitions = []
+        start = 0
+        total_performance = sum(self.node_performance.get(node[0], node[1].flops.fp16) for node in nodes)
+        
+        for node_id, capabilities in nodes:
+            if node_id not in self.node_performance:
+                # Use FLOPS as initial performance estimate
+                performance = capabilities.flops.fp16
+            else:
+                performance = self.node_performance[node_id]
+            
+            end = start + (performance / total_performance)
+            partitions.append(Partition(node_id, start, min(end, 1.0)))
+            start = end
+
+        return partitions
+
+    def update_node_performance(self, node_id: str, processing_time: float, shard: Shard):
+        shard_size = shard.end_layer - shard.start_layer + 1
+        current_performance = shard_size / processing_time
+
+        if node_id in self.node_performance:
+            # EMA
+            self.node_performance[node_id] = (self.ema_alpha * current_performance + 
+                                              (1 - self.ema_alpha) * self.node_performance[node_id])
+        else:
+            # First Measurement
+            self.node_performance[node_id] = current_performance

--- a/exo/topology/test_adaptive_flops_partitioning_strategy.py
+++ b/exo/topology/test_adaptive_flops_partitioning_strategy.py
@@ -1,0 +1,112 @@
+import unittest
+from exo.topology.adaptive_flops_partitioning_strategy import AdaptiveFlopsPartitioningStrategy
+from exo.topology.topology import Topology
+from exo.topology.device_capabilities import DeviceCapabilities, DeviceFlops
+from exo.inference.shard import Shard
+
+class TestAdaptiveFlopsPartitioningStrategy(unittest.TestCase):
+    def setUp(self):
+        self.strategy = AdaptiveFlopsPartitioningStrategy(ema_alpha=0.5)
+        self.topology = Topology()
+
+    def test_initial_partition_based_on_flops(self):
+        self.topology.update_node(
+            "node1",
+            DeviceCapabilities(model="test1", chip="test1", memory=3000, flops=DeviceFlops(fp32=0, fp16=100, int8=0))
+        )
+        self.topology.update_node(
+            "node2",
+            DeviceCapabilities(model="test2", chip="test2", memory=1000, flops=DeviceFlops(fp32=0, fp16=200, int8=0))
+        )
+        
+        partitions = self.strategy.partition(self.topology)
+        
+        self.assertEqual(len(partitions), 2)
+        self.assertAlmostEqual(partitions[0].start, 0.0)
+        self.assertAlmostEqual(partitions[0].end, 1/3)
+        self.assertAlmostEqual(partitions[1].start, 1/3)
+        self.assertAlmostEqual(partitions[1].end, 1.0)
+
+    def test_partition_after_performance_update(self):
+        self.topology.update_node(
+            "node1",
+            DeviceCapabilities(model="test1", chip="test1", memory=3000, flops=DeviceFlops(fp32=0, fp16=100, int8=0))
+        )
+        self.topology.update_node(
+            "node2",
+            DeviceCapabilities(model="test2", chip="test2", memory=1000, flops=DeviceFlops(fp32=0, fp16=100, int8=0))
+        )
+        
+        # Initial partition
+        initial_partitions = self.strategy.partition(self.topology)
+        
+        # Update performance for node1 (significantly better performance)
+        self.strategy.update_node_performance("node1", 0.1, Shard(model_id="test", start_layer=0, end_layer=49, n_layers=100))
+        
+        # New partition after update
+        updated_partitions = self.strategy.partition(self.topology)
+        
+        self.assertNotEqual(initial_partitions[0].end, updated_partitions[0].end)
+        self.assertGreater(updated_partitions[0].end, 0.5)  # node1 should now have a larger partition
+
+    def test_ema_smoothing(self):
+        self.topology.update_node(
+            "node1",
+            DeviceCapabilities(model="test1", chip="test1", memory=3000, flops=DeviceFlops(fp32=0, fp16=100, int8=0))
+        )
+        
+        # First update
+        self.strategy.update_node_performance("node1", 1.0, Shard(model_id="test", start_layer=0, end_layer=49, n_layers=100))
+        first_performance = self.strategy.node_performance["node1"]
+        
+        # Second update with worse performance
+        self.strategy.update_node_performance("node1", 2.0, Shard(model_id="test", start_layer=0, end_layer=49, n_layers=100))
+        second_performance = self.strategy.node_performance["node1"]
+        
+        # Check that performance decreased but not to half due to EMA
+        self.assertLess(second_performance, first_performance)
+        self.assertGreater(second_performance, first_performance / 2)
+
+    def test_adding_new_node(self):
+        self.topology.update_node(
+            "node1",
+            DeviceCapabilities(model="test1", chip="test1", memory=3000, flops=DeviceFlops(fp32=0, fp16=100, int8=0))
+        )
+        initial_partitions = self.strategy.partition(self.topology)
+        
+        self.topology.update_node(
+            "node2",
+            DeviceCapabilities(model="test2", chip="test2", memory=1000, flops=DeviceFlops(fp32=0, fp16=100, int8=0))
+        )
+        updated_partitions = self.strategy.partition(self.topology)
+        
+        self.assertEqual(len(initial_partitions), 1)
+        self.assertEqual(len(updated_partitions), 2)
+        self.assertAlmostEqual(updated_partitions[0].end, 0.5)
+        self.assertAlmostEqual(updated_partitions[1].start, 0.5)
+
+    def test_node_removal(self):
+        self.topology.update_node(
+            "node1",
+            DeviceCapabilities(model="test1", chip="test1", memory=3000, flops=DeviceFlops(fp32=0, fp16=100, int8=0))
+        )
+        self.topology.update_node(
+            "node2",
+            DeviceCapabilities(model="test2", chip="test2", memory=1000, flops=DeviceFlops(fp32=0, fp16=100, int8=0))
+        )
+        initial_partitions = self.strategy.partition(self.topology)
+        
+        # Create a new topology with only one node to simulate removal
+        new_topology = Topology()
+        new_topology.update_node(
+            "node1",
+            DeviceCapabilities(model="test1", chip="test1", memory=3000, flops=DeviceFlops(fp32=0, fp16=100, int8=0))
+        )
+        updated_partitions = self.strategy.partition(new_topology)
+        
+        self.assertEqual(len(initial_partitions), 2)
+        self.assertEqual(len(updated_partitions), 1)
+        self.assertAlmostEqual(updated_partitions[0].end, 1.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Issue: #284 

Since I cannot test Exo on a real cluster, I have made the following assumptions, and I would like to know which ones are true and which are false:

1) Exo does not partition the model across multiple machines.
2) instead, all machines execute the entire model.
3) The partitioning strategy applies to inference partitioning, specifically its layers.
4) All intermediate states of the chat are stored on all machines.
5) It is not possible to reassign partitions during tensor processing.
6) Partitions can only be reassigned between prompts.
7) Compared to the model, inference computation requires much less memory. For example, if the model takes up 16GB, 
     after each query the machines retain intermediate states ranging from around 100MB to 2GB, depending on the 
     complexity of the query and the length of the output to be generated.
8) Inter-node latency is not a critical factor in a non-geographically distributed cluster.

AdaptiveFlopsPartitioningStrategy:

1) Initial partitioning is based on FLOPs (floating point operations) rather than memory.
2) After each prompt, partitions are reassigned based on the performance of the nodes.
3) It implements the update_node_performance method, which can be modified to include other relevant metrics.
