### PR TITLE
Fix null download progress bug

### DIFF
--- a/exo/tinychat/index.js
+++ b/exo/tinychat/index.js
@@ -350,6 +350,7 @@ document.addEventListener("alpine:init", () => {
                 }
               }
               this.lastErrorMessage = null;
+              this.downloadProgress = null;
             }
           } else {
             // No ongoing download


### PR DESCRIPTION
This PR addresses a bug introduced in my previous PR #339 . 
It ensures that the download status is set to null once all downloads have finished, allowing the status indicator to disappear as expected.

Changes:
- Set download status to null after all downloads are complete