### PR TITLE
Implement Metal Inference Engine for exo

### DIFF
--- a/exo/inference/metal/__init__.py
+++ b/exo/inference/metal/__init__.py
@@ -1,0 +1,4 @@
+from .inference import MetalDynamicShardInferenceEngine
+from .metal_model_shard import MetalModelShard, MetalKernelMetadata
+from .swift_code_generator import SwiftCodeGenerator
+

--- a/exo/inference/metal/inferernce.py
+++ b/exo/inference/metal/inferernce.py
@@ -131,3 +131,20 @@ class MetalDynamicShardInferenceEngine:
             weights=metal_weights,
             config=config
         )
+
+    async def _run_inference_kernels(self, request_id: str, input_buffer: Any):
+        """Execute the inference kernels on Metal"""
+        # Get kernel sequence for inference
+        kernel_sequence = self.shard.config["inference_sequence"]
+        
+        # Execute kernels in sequence
+        current_output = input_buffer
+        for kernel_name in kernel_sequence:
+            kernel_inputs = [current_output]
+            if kernel_name in self.shard.weights:
+                kernel_inputs.append(self.shard.weights[kernel_name])
+                
+            current_output = await self.metal_engine.execute(
+                kernel_name,
+                kernel_inputs
+            )

--- a/exo/inference/metal/inferernce.py
+++ b/exo/inference/metal/inferernce.py
@@ -76,3 +76,19 @@ class MetalDynamicShardInferenceEngine:
         is_finished = (output_data.size == 1 and 
                       output_data.item() == self.tokenizer.eos_token_id)
         return output_data, "", is_finished
+
+    async def infer_tensor(self, request_id: str, shard: MetalModelShard,
+                          input_data: np.ndarray,
+                          inference_state: Optional[str] = None) -> Tuple[np.ndarray, str, bool]:
+        """Run inference on raw tensor input"""
+        await self.ensure_shard(shard)
+        
+        # Convert numpy array to Metal buffer
+        input_buffer = await self._numpy_to_metal_buffer(input_data)
+        
+        # Run inference kernels
+        output_data = await self._run_inference_kernels(request_id, input_buffer)
+        
+        is_finished = (output_data.size == 1 and 
+                      output_data.item() == self.tokenizer.eos_token_id)
+        return output_data, "", is_finished

--- a/exo/inference/metal/inferernce.py
+++ b/exo/inference/metal/inferernce.py
@@ -11,3 +11,13 @@ from dataclasses import dataclass
 from metal_kernel_compiler import MetalKernelCompiler
 from swift_code_generator import SwiftCodeGenerator
 from .sharded_utils import load_shard, get_image_from_str
+
+class MetalDynamicShardInferenceEngine:
+    def __init__(self, shard_downloader):
+        self.shard = None
+        self.shard_downloader = shard_downloader
+        self.executor = ThreadPoolExecutor(max_workers=1)
+        self.metal_compiler = MetalKernelCompiler()
+        self.swift_generator = SwiftCodeGenerator()
+        self.metal_engine = None
+        self.tokenizer = None

--- a/exo/inference/metal/inferernce.py
+++ b/exo/inference/metal/inferernce.py
@@ -12,6 +12,9 @@ from metal_kernel_compiler import MetalKernelCompiler
 from swift_code_generator import SwiftCodeGenerator
 from .sharded_utils import load_shard, get_image_from_str
 
+
+
+
 class MetalDynamicShardInferenceEngine:
     def __init__(self, shard_downloader):
         self.shard = None
@@ -21,7 +24,7 @@ class MetalDynamicShardInferenceEngine:
         self.swift_generator = SwiftCodeGenerator()
         self.metal_engine = None
         self.tokenizer = None
-
+        
     async def initialize_metal_engine(self, model_shard: MetalModelShard):
         """Initialize the Metal engine with compiled kernels"""
         # Compile all kernels in the model
@@ -37,7 +40,7 @@ class MetalDynamicShardInferenceEngine:
         
         # Initialize Metal engine through Swift bridge
         self.metal_engine = await self._initialize_swift_metal_engine(swift_code)
-
+        
     async def infer_prompt(self, request_id: str, shard: MetalModelShard, 
                           prompt: str, image_str: Optional[str] = None,
                           inference_state: Optional[str] = None) -> Tuple[np.ndarray, str, bool]:
@@ -115,7 +118,7 @@ class MetalDynamicShardInferenceEngine:
             # Initialize Metal engine with new shard
             await self.initialize_metal_engine(model_shard)
             self.shard = shard
-
+            
     async def _load_metal_shard(self, path: str, shard: MetalModelShard):
         """Load model weights and convert to Metal format"""
         # Load weights and config
@@ -131,7 +134,7 @@ class MetalDynamicShardInferenceEngine:
             weights=metal_weights,
             config=config
         )
-
+        
     async def _run_inference_kernels(self, request_id: str, input_buffer: Any):
         """Execute the inference kernels on Metal"""
         # Get kernel sequence for inference
@@ -148,3 +151,5 @@ class MetalDynamicShardInferenceEngine:
                 kernel_name,
                 kernel_inputs
             )
+            
+        return await self._metal_buffer_to_numpy(current_output)

--- a/exo/inference/metal/inferernce.py
+++ b/exo/inference/metal/inferernce.py
@@ -1,0 +1,13 @@
+from typing import Dict, List, Any , Tuple
+import numpy as np
+from tinygrad import dtypes
+from .metal_model_shard import MetalModelShard, MetalKernelMetadata
+from .utils import KernelOperation , Linearizer,Kernel
+from typing import Optional, List, Dict
+from exo.download.shard_download import ShardDownloader
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from metal_kernel_compiler import MetalKernelCompiler
+from swift_code_generator import SwiftCodeGenerator
+from .sharded_utils import load_shard, get_image_from_str

--- a/exo/inference/metal/inferernce.py
+++ b/exo/inference/metal/inferernce.py
@@ -115,3 +115,19 @@ class MetalDynamicShardInferenceEngine:
             # Initialize Metal engine with new shard
             await self.initialize_metal_engine(model_shard)
             self.shard = shard
+
+    async def _load_metal_shard(self, path: str, shard: MetalModelShard):
+        """Load model weights and convert to Metal format"""
+        # Load weights and config
+        weights, config = await load_shard(path, shard)
+        
+        # Convert weights to Metal buffers
+        metal_weights = {}
+        for name, weight in weights.items():
+            metal_weights[name] = await self._numpy_to_metal_buffer(weight)
+            
+        return MetalModelShard(
+            kernel_metadata=shard.kernel_metadata,
+            weights=metal_weights,
+            config=config
+        )

--- a/exo/inference/metal/metal_kernel_compiler.py
+++ b/exo/inference/metal/metal_kernel_compiler.py
@@ -1,0 +1,5 @@
+from typing import Dict, List, Any , Tuple
+import numpy as np
+from tinygrad import dtypes
+from .metal_model_shard import MetalModelShard, MetalKernelMetadata
+from .utils import KernelOperation , Linearizer,Kernel

--- a/exo/inference/metal/metal_kernel_compiler.py
+++ b/exo/inference/metal/metal_kernel_compiler.py
@@ -16,3 +16,6 @@ class MetalKernelCompiler:
             bindings.append(f"device const float* input{i} [[buffer({i})]]")
         bindings.append(f"device float* output [[buffer({num_inputs})]]")
         return ",\n            ".join(bindings)
+
+    def _convert_shape_to_metal(self, shape: List[int]) -> str:
+        return f"uint3({', '.join(str(x) for x in shape)})"

--- a/exo/inference/metal/metal_kernel_compiler.py
+++ b/exo/inference/metal/metal_kernel_compiler.py
@@ -9,3 +9,10 @@ class MetalKernelCompiler:
         self.kernels: Dict[str, str] = {}
         self.kernel_order: List[str] = []
         self.kernel_metadata: Dict[str, MetalKernelMetadata] = {}
+
+    def _generate_buffer_bindings(self, num_inputs: int) -> str:
+        bindings = []
+        for i in range(num_inputs):
+            bindings.append(f"device const float* input{i} [[buffer({i})]]")
+        bindings.append(f"device float* output [[buffer({num_inputs})]]")
+        return ",\n            ".join(bindings)

--- a/exo/inference/metal/metal_kernel_compiler.py
+++ b/exo/inference/metal/metal_kernel_compiler.py
@@ -27,3 +27,16 @@ class MetalKernelCompiler:
             return "gid.x + grid_size.x * gid.y"
         else:
             return "gid.x + grid_size.x * (gid.y + grid_size.y * gid.z)"
+
+    def _convert_dtype_to_metal(self, dtype: Any) -> str:
+        dtype_map = {
+            dtypes.float32: "float",
+            dtypes.float16: "half",
+            dtypes.int32: "int",
+            dtypes.int16: "short",
+            dtypes.int8: "char",
+            dtypes.uint32: "uint",
+            dtypes.uint16: "ushort",
+            dtypes.uint8: "uchar",
+        }
+        return dtype_map.get(dtype, "float")

--- a/exo/inference/metal/metal_kernel_compiler.py
+++ b/exo/inference/metal/metal_kernel_compiler.py
@@ -3,3 +3,9 @@ import numpy as np
 from tinygrad import dtypes
 from .metal_model_shard import MetalModelShard, MetalKernelMetadata
 from .utils import KernelOperation , Linearizer,Kernel
+
+class MetalKernelCompiler:
+    def __init__(self):
+        self.kernels: Dict[str, str] = {}
+        self.kernel_order: List[str] = []
+        self.kernel_metadata: Dict[str, MetalKernelMetadata] = {}

--- a/exo/inference/metal/metal_kernel_compiler.py
+++ b/exo/inference/metal/metal_kernel_compiler.py
@@ -169,3 +169,12 @@ class MetalKernelCompiler:
         """
         
         return metal_code, metadata
+
+    def _generate_temp_declarations(self, ops: List[KernelOperation]) -> str:
+        """Generate declarations for temporary variables"""
+        temp_vars = set()
+        for op in ops:
+            temp_vars.add(op.output)
+            temp_vars.update(op.inputs)
+        
+        return "\n            ".join(f"float {var};" for var in temp_vars if not var.startswith("input") and not var.startswith("output"))

--- a/exo/inference/metal/metal_kernel_compiler.py
+++ b/exo/inference/metal/metal_kernel_compiler.py
@@ -19,3 +19,11 @@ class MetalKernelCompiler:
 
     def _convert_shape_to_metal(self, shape: List[int]) -> str:
         return f"uint3({', '.join(str(x) for x in shape)})"
+
+    def _generate_index_calculation(self, dims: int) -> str:
+        if dims == 1:
+            return "gid.x"
+        elif dims == 2:
+            return "gid.x + grid_size.x * gid.y"
+        else:
+            return "gid.x + grid_size.x * (gid.y + grid_size.y * gid.z)"

--- a/exo/inference/metal/metal_model_shard.py
+++ b/exo/inference/metal/metal_model_shard.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+from typing import List, Dict, Tuple, Any, Optional, Union
+import numpy as np
+from tinygrad import dtypes
+from tinygrad.codegen.kernel import Kernel
+from .utils import KernelOperation , Linearizer,Kernel

--- a/exo/inference/metal/metal_model_shard.py
+++ b/exo/inference/metal/metal_model_shard.py
@@ -14,3 +14,9 @@ class MetalKernelMetadata:
     global_size: Tuple[int, int, int]
     buffer_sizes: List[int]
     op_sequence: List[KernelOperation]
+
+@dataclass
+class MetalModelShard:
+    kernel_metadata: Dict[str, MetalKernelMetadata]
+    weights: Dict[str, np.ndarray]
+    config: Dict[str, Any]

--- a/exo/inference/metal/metal_model_shard.py
+++ b/exo/inference/metal/metal_model_shard.py
@@ -4,3 +4,13 @@ import numpy as np
 from tinygrad import dtypes
 from tinygrad.codegen.kernel import Kernel
 from .utils import KernelOperation , Linearizer,Kernel
+
+@dataclass
+class MetalKernelMetadata:
+    name: str
+    input_shapes: List[List[int]]
+    output_shape: List[int]
+    work_group_size: Tuple[int, int, int]
+    global_size: Tuple[int, int, int]
+    buffer_sizes: List[int]
+    op_sequence: List[KernelOperation]

--- a/exo/inference/metal/swift_code_generator.py
+++ b/exo/inference/metal/swift_code_generator.py
@@ -143,13 +143,16 @@ class MLXMetalEngine {{
 }}
 """
         def _generate_kernel_metadata_initialization(self, kernel_metadata: Dict[str, MetalKernelMetadata]) -> str:
-        initializations = []
-        for name, metadata in kernel_metadata.items():
-            init = f'"{name}": KernelMetadata('
-            init += f'inputShapes: {metadata.input_shapes}, '
-            init += f'outputShape: {metadata.output_shape}, '
-            init += f'workGroupSize: {metadata.work_group_size}, '
-            init += f'globalSize: {metadata.global_size}, '
-            init += f'bufferSizes: {metadata.buffer_sizes})'
-            initializations.append(init)
-        return ",\n            ".join(initializations)
+            initializations = []
+            for name, metadata in kernel_metadata.items():
+                init = f'"{name}": KernelMetadata('
+                init += f'inputShapes: {metadata.input_shapes}, '
+                init += f'outputShape: {metadata.output_shape}, '
+                init += f'workGroupSize: {metadata.work_group_size}, '
+                init += f'globalSize: {metadata.global_size}, '
+                init += f'bufferSizes: {metadata.buffer_sizes})'
+                initializations.append(init)
+            return ",\n            ".join(initializations)
+
+        def _generate_metal_kernel_source(self, kernel_metadata: Dict[str, MetalKernelMetadata]) -> str:
+            return "\n\n".join(metadata.metal_code for metadata in kernel_metadata.values())

--- a/exo/inference/metal/swift_code_generator.py
+++ b/exo/inference/metal/swift_code_generator.py
@@ -142,17 +142,18 @@ class MLXMetalEngine {{
     }}
 }}
 """
-        def _generate_kernel_metadata_initialization(self, kernel_metadata: Dict[str, MetalKernelMetadata]) -> str:
-            initializations = []
-            for name, metadata in kernel_metadata.items():
-                init = f'"{name}": KernelMetadata('
-                init += f'inputShapes: {metadata.input_shapes}, '
-                init += f'outputShape: {metadata.output_shape}, '
-                init += f'workGroupSize: {metadata.work_group_size}, '
-                init += f'globalSize: {metadata.global_size}, '
-                init += f'bufferSizes: {metadata.buffer_sizes})'
-                initializations.append(init)
-            return ",\n            ".join(initializations)
 
-        def _generate_metal_kernel_source(self, kernel_metadata: Dict[str, MetalKernelMetadata]) -> str:
-            return "\n\n".join(metadata.metal_code for metadata in kernel_metadata.values())
+    def _generate_kernel_metadata_initialization(self, kernel_metadata: Dict[str, MetalKernelMetadata]) -> str:
+        initializations = []
+        for name, metadata in kernel_metadata.items():
+            init = f'"{name}": KernelMetadata('
+            init += f'inputShapes: {metadata.input_shapes}, '
+            init += f'outputShape: {metadata.output_shape}, '
+            init += f'workGroupSize: {metadata.work_group_size}, '
+            init += f'globalSize: {metadata.global_size}, '
+            init += f'bufferSizes: {metadata.buffer_sizes})'
+            initializations.append(init)
+        return ",\n            ".join(initializations)
+
+    def _generate_metal_kernel_source(self, kernel_metadata: Dict[str, MetalKernelMetadata]) -> str:
+        return "\n\n".join(metadata.metal_code for metadata in kernel_metadata.values())

--- a/exo/inference/metal/swift_code_generator.py
+++ b/exo/inference/metal/swift_code_generator.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+from typing import List, Dict, Tuple, Any, Optional, Union
+import numpy as np
+from tinygrad import dtypes
+from tinygrad.codegen.kernel import Kernel
+from .metal_model_shard import MetalKernelMetadata

--- a/exo/inference/metal/swift_code_generator.py
+++ b/exo/inference/metal/swift_code_generator.py
@@ -4,3 +4,141 @@ import numpy as np
 from tinygrad import dtypes
 from tinygrad.codegen.kernel import Kernel
 from .metal_model_shard import MetalKernelMetadata
+
+class SwiftCodeGenerator:
+    def generate_swift_wrapper(self, kernel_metadata: Dict[str, MetalKernelMetadata]) -> str:
+        """Generate Swift wrapper code for Metal kernels"""
+        return f"""
+import Metal
+import MetalKit
+
+enum MLXMetalError: Error {{
+    case deviceNotFound
+    case commandQueueCreationFailed
+    case libraryCompilationFailed
+    case kernelCreationFailed
+    case bufferCreationFailed
+    case encoderCreationFailed
+    case invalidInputSize
+}}
+
+@available(iOS 11.0, macOS 10.13, *)
+class MLXMetalEngine {{
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    private var kernels: [String: MTLComputePipelineState] = [:]
+    private let kernelMetadata: [String: KernelMetadata]
+    
+    struct KernelMetadata {{
+        let inputShapes: [[Int]]
+        let outputShape: [Int]
+        let workGroupSize: (Int, Int, Int)
+        let globalSize: (Int, Int, Int)
+        let bufferSizes: [Int]
+    }}
+    
+    init() throws {{
+        guard let device = MTLCreateSystemDefaultDevice() else {{
+            throw MLXMetalError.deviceNotFound
+        }}
+        self.device = device
+        
+        guard let commandQueue = device.makeCommandQueue() else {{
+            throw MLXMetalError.commandQueueCreationFailed
+        }}
+        self.commandQueue = commandQueue
+        
+        self.kernelMetadata = [
+            {self._generate_kernel_metadata_initialization(kernel_metadata)}
+        ]
+        
+        try compileKernels()
+    }}
+    
+    private func compileKernels() throws {{
+        let source = """
+        {self._generate_metal_kernel_source(kernel_metadata)}
+        """
+        
+        let library: MTLLibrary
+        do {{
+            library = try device.makeLibrary(source: source, options: nil)
+        }} catch {{
+            throw MLXMetalError.libraryCompilationFailed
+        }}
+        
+        for kernelName in kernelMetadata.keys {{
+            guard let function = library.makeFunction(name: kernelName) else {{
+                throw MLXMetalError.kernelCreationFailed
+            }}
+            
+            do {{
+                kernels[kernelName] = try device.makeComputePipelineState(function: function)
+            }} catch {{
+                throw MLXMetalError.kernelCreationFailed
+            }}
+        }}
+    }}
+    
+    func createBuffer<T>(_ data: [T]) throws -> MTLBuffer {{
+        let size = MemoryLayout<T>.stride * data.count
+        guard let buffer = device.makeBuffer(bytes: data, length: size, options: .storageModeShared) else {{
+            throw MLXMetalError.bufferCreationFailed
+        }}
+        return buffer
+    }}
+    
+    func execute(kernelName: String, inputs: [[Float]]) throws -> [Float] {{
+        guard let kernel = kernels[kernelName],
+              let metadata = kernelMetadata[kernelName] else {{
+            throw MLXMetalError.kernelCreationFailed
+        }}
+        
+        for (input, expectedShape) in zip(inputs, metadata.inputShapes) {{
+            guard input.count == expectedShape.reduce(1, *) else {{
+                throw MLXMetalError.invalidInputSize
+            }}
+        }}
+        
+        let inputBuffers = try inputs.map {{ try createBuffer($0) }}
+        
+        let outputSize = metadata.outputShape.reduce(1, *)
+        let outputBuffer = device.makeBuffer(length: outputSize * MemoryLayout<Float>.size,
+                                             options: .storageModeShared)!
+        
+        guard let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder() else {{
+            throw MLXMetalError.encoderCreationFailed
+        }}
+        
+        encoder.setComputePipelineState(kernel)
+        
+        for (index, buffer) in inputBuffers.enumerated() {{
+            encoder.setBuffer(buffer, offset: 0, index: index)
+        }}
+        
+        encoder.setBuffer(outputBuffer, offset: 0, index: inputBuffers.count)
+        
+        let (w, h, d) = metadata.globalSize
+        let threadsPerThreadgroup = MTLSize(width: 32, height: 1, depth: 1)
+        let threadgroupsPerGrid = MTLSize(
+            width: (w + 31) / 32,
+            height: h,
+            depth: d
+        )
+        
+        encoder.dispatchThreadgroups(threadgroupsPerGrid,
+                                     threadsPerThreadgroup: threadsPerThreadgroup)
+        
+        encoder.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+        
+        let outputPtr = outputBuffer.contents().bindMemory(
+            to: Float.self,
+            capacity: outputSize
+        )
+        return Array(UnsafeBufferPointer(start: outputPtr, count: outputSize))
+    }}
+}}
+"""

--- a/exo/inference/metal/swift_code_generator.py
+++ b/exo/inference/metal/swift_code_generator.py
@@ -142,3 +142,14 @@ class MLXMetalEngine {{
     }}
 }}
 """
+        def _generate_kernel_metadata_initialization(self, kernel_metadata: Dict[str, MetalKernelMetadata]) -> str:
+        initializations = []
+        for name, metadata in kernel_metadata.items():
+            init = f'"{name}": KernelMetadata('
+            init += f'inputShapes: {metadata.input_shapes}, '
+            init += f'outputShape: {metadata.output_shape}, '
+            init += f'workGroupSize: {metadata.work_group_size}, '
+            init += f'globalSize: {metadata.global_size}, '
+            init += f'bufferSizes: {metadata.buffer_sizes})'
+            initializations.append(init)
+        return ",\n            ".join(initializations)

--- a/exo/inference/metal/utils.py
+++ b/exo/inference/metal/utils.py
@@ -97,3 +97,14 @@ class Linearizer:
                     used_vars.remove(uop.args[0])
         
         return optimized_uops
+
+@dataclass
+class KernelOperation:
+    op_type: str
+    inputs: List[str]
+    output: str
+    attributes: Dict[str, Any] = None
+
+    def __post_init__(self):
+        if self.attributes is None:
+            self.attributes = {}

--- a/exo/inference/metal/utils.py
+++ b/exo/inference/metal/utils.py
@@ -21,3 +21,10 @@ class ASTNode:
         self.op = op
         self.dtype = dtype
         self.args = args
+
+class Linearizer:
+    def __init__(self, name: str, ast: List[ASTNode], opts: Dict[str, Any]):
+        self.name = name
+        self.ast = ast
+        self.opts = opts
+        self.uops: List[UOp] = []

--- a/exo/inference/metal/utils.py
+++ b/exo/inference/metal/utils.py
@@ -60,3 +60,19 @@ class Linearizer:
         self.uops = self.ast_to_uop(modified_ast)
         self.uops = self.optimize_uops(self.uops)
         return Kernel(self.name, self.uops)
+
+    def ast_to_uop(self, ast: List[ASTNode]) -> List[UOp]:
+        uops = []
+        for node in ast:
+            if node.op == 'const':
+                uops.append(UOp(op='load_const', dtype=node.dtype, args=node.args))
+            elif node.op in ['add', 'mul', 'sub', 'div']:
+                for arg in node.args:
+                    if not isinstance(arg, (int, float)):
+                        uops.append(UOp(op='load', dtype=node.dtype, args=[arg]))
+                uops.append(UOp(op=node.op, dtype=node.dtype, args=node.args))
+            elif node.op == 'assign':
+                uops.append(UOp(op='store', dtype=node.dtype, args=node.args))
+            else:
+                uops.append(UOp(op=node.op, dtype=node.dtype, args=node.args))
+        return uops

--- a/exo/inference/metal/utils.py
+++ b/exo/inference/metal/utils.py
@@ -54,3 +54,9 @@ class Linearizer:
             return args[0] / args[1]
         else:
             raise ValueError(f"Unsupported operation for constant folding: {op}")
+
+    def linearize(self) -> Kernel:
+        modified_ast = self.get_optimized_ast()
+        self.uops = self.ast_to_uop(modified_ast)
+        self.uops = self.optimize_uops(self.uops)
+        return Kernel(self.name, self.uops)

--- a/exo/inference/metal/utils.py
+++ b/exo/inference/metal/utils.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+from typing import List, Dict, Tuple, Any, Optional, Union
+import numpy as np
+from tinygrad import dtypes
+from tinygrad.codegen.kernel import Kernel
+# from tinygrad import Linearizer

--- a/exo/inference/metal/utils.py
+++ b/exo/inference/metal/utils.py
@@ -4,3 +4,9 @@ import numpy as np
 from tinygrad import dtypes
 from tinygrad.codegen.kernel import Kernel
 # from tinygrad import Linearizer
+
+@dataclass
+class UOp:
+    op: str
+    dtype: Any
+    args: List[Any]

--- a/exo/inference/metal/utils.py
+++ b/exo/inference/metal/utils.py
@@ -15,3 +15,9 @@ class UOp:
 class Kernel:
     name: str
     uops: List[UOp]
+
+class ASTNode:
+    def __init__(self, op: str, dtype: Any, args: List[Any]):
+        self.op = op
+        self.dtype = dtype
+        self.args = args

--- a/exo/inference/metal/utils.py
+++ b/exo/inference/metal/utils.py
@@ -28,3 +28,15 @@ class Linearizer:
         self.ast = ast
         self.opts = opts
         self.uops: List[UOp] = []
+
+    def get_optimized_ast(self) -> List[ASTNode]:
+        # Simple constant folding optimization
+        optimized_ast = []
+        for node in self.ast:
+            if node.op in ['add', 'mul', 'sub', 'div'] and all(isinstance(arg, (int, float)) for arg in node.args):
+                # Constant folding
+                result = self.evaluate_constant_expression(node)
+                optimized_ast.append(ASTNode('const', node.dtype, [result]))
+            else:
+                optimized_ast.append(node)
+        return optimized_ast

--- a/exo/inference/metal/utils.py
+++ b/exo/inference/metal/utils.py
@@ -10,3 +10,8 @@ class UOp:
     op: str
     dtype: Any
     args: List[Any]
+
+@dataclass
+class Kernel:
+    name: str
+    uops: List[UOp]

--- a/exo/inference/metal/utils.py
+++ b/exo/inference/metal/utils.py
@@ -40,3 +40,17 @@ class Linearizer:
             else:
                 optimized_ast.append(node)
         return optimized_ast
+
+    def evaluate_constant_expression(self, node: ASTNode) -> Union[int, float]:
+        op = node.op
+        args = node.args
+        if op == 'add':
+            return args[0] + args[1]
+        elif op == 'mul':
+            return args[0] * args[1]
+        elif op == 'sub':
+            return args[0] - args[1]
+        elif op == 'div':
+            return args[0] / args[1]
+        else:
+            raise ValueError(f"Unsupported operation for constant folding: {op}")

--- a/exo/main.py
+++ b/exo/main.py
@@ -56,7 +56,7 @@ print(f"Detected system: {system_info}")
 
 shard_downloader: ShardDownloader = HFShardDownloader(quick_check=args.download_quick_check, max_parallel_downloads=args.max_parallel_downloads)
 inference_engine_name = args.inference_engine or ("mlx" if system_info == "Apple Silicon Mac" else "tinygrad")
-inference_engine = get_inference_engine(inference_engine_name, shard_downloader)
+inference_engine = get_inference_engine("metal", shard_downloader) #placeholder implemtation , to run the metal for test every single time , aiming to make this another option in the final PR 
 print(f"Using inference engine: {inference_engine.__class__.__name__} with shard downloader: {shard_downloader.__class__.__name__}")
 
 if args.node_port is None:

--- a/exo/models.py
+++ b/exo/models.py
@@ -4,6 +4,8 @@ model_base_shards = {
   ### llama
   "llama-3.2-1b": {
     "MLXDynamicShardInferenceEngine": Shard(model_id="mlx-community/Llama-3.2-1B-Instruct-4bit", start_layer=0, end_layer=0, n_layers=16),
+    "MetalDynamicShardInferenceEngine": Shard(model_id="metal-tinygrad-llama-3.2-1b", start_layer=0, end_layer=0, n_layers=16), #unsure of the model_id yet , current string is placeholder 
+
   },
   "llama-3.2-3b": {
     "MLXDynamicShardInferenceEngine": Shard(model_id="mlx-community/Llama-3.2-3B-Instruct-4bit", start_layer=0, end_layer=0, n_layers=28),


### PR DESCRIPTION
## What I Did

1. Created a new folder `@metal` with the following files:
   - `inference.py`
   - `metal_kernel_compiler.py`
   - `metal_model_shard.py`
   - `swift_code_generator.py`
   - `utils.py`

2. Implemented `MetalDynamicShardInferenceEngine` class in `inference.py`, which is designed to use Metal for GPU acceleration on Apple Silicon Macs.

3. Created `MetalKernelCompiler` in `metal_kernel_compiler.py` to compile TinyGrad kernels to Metal shaders.

4. Defined `MetalModelShard` and `MetalKernelMetadata` in `metal_model_shard.py` to represent Metal-specific model shards and kernel metadata.

5. Implemented `SwiftCodeGenerator` in `swift_code_generator.py` to generate Swift wrapper code for Metal kernels.

6. Added utility classes and functions in `utils.py`, including `Linearizer` for optimizing the abstract syntax tree (AST) of kernels.

7. Updated `models.py` to include Metal-specific model configurations:


8. Modified `main.py` to support the new Metal inference engine:


## What I Couldn't Do / Current Errors

1. **Integration Error**: The `MetalDynamicShardInferenceEngine` is not fully integrated with the existing codebase. I'm encountering an attribute error:

   ```
   'MetalDynamicShardInferenceEngine' object has no attribute '_numpy_to_metal_buffer'
   ```

   This error suggests that I need to implement the `_numpy_to_metal_buffer` method in the `MetalDynamicShardInferenceEngine` class.

2. **Compilation Issues**: I haven't been able to successfully compile the Metal shaders or integrate them with the Swift runtime. This requires further investigation and possibly bridging between Python and Swift/Metal.

3. **Inconsistent capturing of kernels** : At times the code is simply unable to capture the kernels of the model . i am unsure why that is happening . 

## What I Need Help With

1. Implementing the `_numpy_to_metal_buffer` method in `MetalDynamicShardInferenceEngine`. This method should convert numpy arrays to Metal buffers.

2. Guidance on how to properly compile Metal shaders and integrate them with the Swift runtime from Python.

3. Assistance with bridging the gap between the Python code and the Metal/Swift implementation.

5. Review of the Metal kernel compilation process to ensure it's correctly translating TinyGrad operations to Metal operations.

6. Advice on how to properly initialize and manage Metal devices and command queues from within the Python environment.

## Next Steps

1. Implement the missing `_numpy_to_metal_buffer` method.
2. Set up a proper bridge between Python and Swift/Metal, possibly using a library like `pyobjc`.
3. Implement proper error handling and logging for Metal-specific operations.
4. Create unit tests for the Metal implementation.
5. Benchmark the Metal implementation against existing CPU and GPU implementations.

## Questions for Reviewers

1. Is the current approach of translating TinyGrad kernels to Metal shaders the most efficient way, or should we consider a different approach?
2. How should we handle memory management between Python and Metal?
3. Are there any specific Metal optimizations we should be considering for large language models?
4. How can we ensure thread safety when dealing with Metal resources from Python?

I would greatly appreciate any guidance or suggestions on how to proceed with this implementation. Thank you for your time and assistance!