### PR TITLE
Implement Automatic FLOPS Estimation for Unlisted GPU Models

### DIFF
--- a/exo/viz/topology_viz.py
+++ b/exo/viz/topology_viz.py
@@ -219,7 +219,7 @@ class TopologyViz:
       if device_capabilities.flops_estimated:
         node_info.append("\n\n")
         node_info.append(f"This FLOPS is estimated by:")
-        node_info.append(f"{', '.join(device_capabilities.flops_estimated) if isinstance(device_capabilities.flops_estimated, list) else device_capabilities.flops_estimated}")
+        node_info.append(f"{', '.join(device_capabilities.flops_estimated)}")
 
       # Calculate info position based on angle
       info_distance_x = radius_x + 6

--- a/exo/viz/topology_viz.py
+++ b/exo/viz/topology_viz.py
@@ -216,6 +216,10 @@ class TopologyViz:
         f"{device_capabilities.flops.fp16}TFLOPS",
         f"[{partition.start:.2f}-{partition.end:.2f}]",
       ]
+      if device_capabilities.flops_estimated:
+        node_info.append("\n\n")
+        node_info.append(f"This FLOPS is estimated by:")
+        node_info.append(f"{', '.join(device_capabilities.flops_estimated) if isinstance(device_capabilities.flops_estimated, list) else device_capabilities.flops_estimated}")
 
       # Calculate info position based on angle
       info_distance_x = radius_x + 6


### PR DESCRIPTION
This pull request implemented an automatic FLOPS estimation for GPU models not found in our current lookup table. The main changes are:

1. Automatic FLOPS Estimation:
   - For GPU models not in the lookup table, we now estimate FLOPS by calculating the average of two adjacent GPU models.

2. Display of Estimated GPU Models:
   - When FLOPS are estimated, we clearly indicate this on the console.
   - The display includes the name of the GPU model used for estimation.

This implementation addresses the issue raised in #149.