### PR TITLE
Getting the setup script to work on Intel based Mac machines

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,12 +2,4 @@
 
 python3 -m venv .venv
 source .venv/bin/activate
-
-# Check if running on macOS with Apple Silicon
-if [[ "$(uname)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
-    echo "Installing with Apple Silicon support..."
-    pip install -e ".[apple_silicon]"
-else
-    echo "Installing without Apple Silicon support..."
-    pip install -e .
-fi
+pip install -e .

--- a/install.sh
+++ b/install.sh
@@ -2,4 +2,12 @@
 
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -e .
+
+# Check if running on macOS with Apple Silicon
+if [[ "$(uname)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
+    echo "Installing with Apple Silicon support..."
+    pip install -e ".[apple_silicon]"
+else
+    echo "Installing without Apple Silicon support..."
+    pip install -e .
+fi

--- a/setup.py
+++ b/setup.py
@@ -27,19 +27,16 @@ install_requires = [
   "tinygrad @ git+https://github.com/tinygrad/tinygrad.git@232edcfd4f8b388807c64fb1817a7668ce27cbad",
 ]
 
-# Add macOS-specific packages if on Darwin (macOS)
-if sys.platform.startswith("darwin"):
-  install_requires.extend([
-    "mlx==0.18.0",
-    "mlx-lm==0.18.2",
-  ])
-
 extras_require = {
   "linting": [
     "pylint==3.2.6",
     "ruff==0.5.5",
     "mypy==1.11.0",
     "yapf==0.40.2",
+  ],
+  "apple_silicon": [
+    "mlx==0.18.0",
+    "mlx-lm==0.18.2",
   ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import sys
+import platform
 
 from setuptools import find_packages, setup
 
@@ -39,6 +40,10 @@ extras_require = {
     "mlx-lm==0.18.2",
   ],
 }
+
+# Check if running on macOS with Apple Silicon
+if sys.platform.startswith("darwin") and platform.machine() == "arm64":
+  install_requires.extend(extras_require["apple_silicon"])
 
 setup(
   name="exo",


### PR DESCRIPTION
When trying to run the setup script on an Intel-based Mac I ran into the following issue installing MLX:

<img width="1016" alt="Screenshot 2024-10-22 at 1 54 33 AM" src="https://github.com/user-attachments/assets/0fc4601e-26f5-4d67-b49b-666893a26d40">

To fix the issue I updated the logic to check that they are using Arm64 in addition to Darwin before installing the MLX packages.
