### PR TITLE
tidy: use smallest model with ChatGPT API

### DIFF
--- a/exo/api/chatgpt_api.py
+++ b/exo/api/chatgpt_api.py
@@ -231,7 +231,7 @@ class ChatGPTAPI:
     stream = data.get("stream", False)
     chat_request = parse_chat_request(data, self.default_model)
     if chat_request.model and chat_request.model.startswith("gpt-"):  # to be compatible with ChatGPT tools, point all gpt- model requests to llama instead
-      chat_request.model = self.default_model if self.default_model.startswith("llama") else "llama-3.1-8b"
+      chat_request.model = self.default_model if self.default_model.startswith("llama") else "llama-3.2-1b"
     if not chat_request.model or chat_request.model not in model_base_shards:
       if DEBUG >= 1: print(f"Invalid model: {chat_request.model}. Supported: {list(model_base_shards.keys())}. Defaulting to {self.default_model}")
       chat_request.model = self.default_model

--- a/exo/api/chatgpt_api.py
+++ b/exo/api/chatgpt_api.py
@@ -163,7 +163,7 @@ class ChatGPTAPI:
     self.prompts: PrefixDict[str, PromptSession] = PrefixDict()
     self.prev_token_lens: Dict[str, int] = {}
     self.stream_tasks: Dict[str, asyncio.Task] = {}
-    self.default_model = "llama-3.1-8b"
+    self.default_model = "llama-3.2-1b"
 
     cors = aiohttp_cors.setup(self.app)
     cors_options = aiohttp_cors.ResourceOptions(


### PR DESCRIPTION
Use the smallest possible model as the fallback in chatGPT api #103 

We don't support llama-3.2-1b on tinygrad backend which could be annoying for Linux users. However, we still merged this change for the tinychat frontend (#399) so I think it's ok. 

If its available, I will work on that feature next since its a good beginner bounty (#378)