### PR TITLE
docs(templates): add GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,70 @@
+name: "🐛 Bug Report"
+description: Report a reproducible bug or regression.
+title: "[Bug]: "
+labels: ["Type: Bug", "Status: Triage"]
+body:
+    - type: textarea
+      id: description
+      attributes:
+          label: What is the issue?
+          description: What happened? What did you expect to happen?
+      validations:
+          required: true
+    - type: dropdown
+      id: os
+      attributes:
+          label: OS
+          description: Which operating system are you using?
+          multiple: true
+          options:
+              - Linux
+              - macOS
+              - Windows
+              - Docker
+              - WSL2
+              - Other
+      validations:
+          required: false
+    - type: dropdown
+      id: gpu
+      attributes:
+          label: GPU
+          description: Which GPU(s) are you using?
+          multiple: true
+          options:
+              - Nvidia
+              - AMD
+              - Intel
+              - Apple
+              - Other
+      validations:
+          required: false
+    - type: dropdown
+      id: cpu
+      attributes:
+          label: CPU
+          description: Which CPU(s) are you using?
+          multiple: true
+          options:
+              - Intel
+              - AMD
+              - Apple
+              - Other
+      validations:
+          required: false
+    - type: textarea
+      id: system-other
+      attributes:
+          label: Additional System Information
+          description: Any other system information you would like to share that might be relevant to the bug.
+          placeholder: e.g., software versions, configurations, GPU models, VRAM, etc.
+      validations:
+          required: false
+    - type: textarea
+      id: logs
+      attributes:
+        label: Logs or Console Output
+        description: Paste any relevant logs or console output here (**DO NOT INCLUDE PRIVATE INFORMATION**).
+        placeholder: "Error messages, warnings, etc."
+      validations:
+        required: false

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,24 @@
+name: "✨ Feature Request"
+description: Suggest new features for consideration.
+title: "[Request]: "
+labels: ["Type: Idea"]
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like?
+      description: A clear description of the feature or enhancement.
+      placeholder: I'd like to be able to...
+    validations:
+      required: true
+  - type: textarea
+    id: reason
+    attributes:
+      label: Why is this needed?
+      description: A clear description of why this would be useful to have.
+      placeholder: I want this because...
+  - type: textarea
+    id: other
+    attributes:
+      label: Other information
+      placeholder: Any other details?

--- a/.github/ISSUE_TEMPLATE/9-help-request.yml
+++ b/.github/ISSUE_TEMPLATE/9-help-request.yml
@@ -1,0 +1,55 @@
+name: "🤔 Questions and Help"
+description: Ask a general support question.
+title: "[Question]: "
+labels: ["Type: Support"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: Describe your question or the issue you're facing.
+      placeholder: "How can I..."
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      description: Which operating system are you using?
+      multiple: true
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Docker
+        - WSL2
+        - Other
+    validations:
+      required: false
+  - type: dropdown
+    id: gpu
+    attributes:
+      label: GPU
+      description: Which GPU(s) are you using?
+      multiple: true
+      options:
+        - Nvidia
+        - AMD
+        - Intel
+        - Apple
+        - Other
+    validations:
+      required: false
+  - type: dropdown
+    id: cpu
+    attributes:
+      label: CPU
+      description: Which CPU(s) are you using?
+      multiple: true
+      options:
+        - Intel
+        - AMD
+        - Apple
+        - Other
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- Provide a general summary of your changes in the title above. -->
+
+# Description
+<!--
+What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
+Describe your changes in detail and, if relevant, explain which choices you have made and why.
+-->
+
+## Related issues/external references
+<!--
+Format issues on GitHub as `#XXX`.
+-->
+
+## Types of changes
+<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
+- Bug fix _(non-breaking change which fixes an issue)_
+- New feature _(non-breaking change which adds functionality)_
+- Breaking change _(fix or feature that would cause existing functionality to change)_
+- Documentation improvement
+- Style _(Change that do not affect the functionality of the code)_
+- CI/CD _(Changes to the CI/CD configuration)_


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Looking through the issues to find something to pick up is quite difficult as it is largely instructed and uncategorized (bug reports, support requests and features). I looked over them to find the most commonly requested information and tried to wrap those up in issue templates.

It could also be considered to _not_ have support questions in GitHub issues (as is common practice) but have a separate support channel. Given that there are already quite a lot of support questions it might be nicer to just embrace them and label them as such.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`.
-->

## Types of changes
- Documentation improvement