### PR TITLE
Support changing manual configuration while running

### DIFF
--- a/exo/main.py
+++ b/exo/main.py
@@ -25,6 +25,8 @@ from exo.inference.tokenizers import resolve_tokenizer
 from exo.orchestration.node import Node
 from exo.models import model_base_shards
 from exo.viz.topology_viz import TopologyViz
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
 
 # parse args
 parser = argparse.ArgumentParser(description="Initialize GRPC Discovery")

--- a/exo/networking/manual/network_topology_config.py
+++ b/exo/networking/manual/network_topology_config.py
@@ -29,3 +29,8 @@ class NetworkTopology(BaseModel):
       return cls.model_validate_json(config_data)
     except ValidationError as e:
       raise ValueError(f"Error validating network topology config from {path}: {e}") from e
+
+  def reload(self, path: str) -> None:
+    """Reload the configuration from the file and update the peers attribute."""
+    new_topology = self.from_path(path)
+    self.peers = new_topology.peers


### PR DESCRIPTION
Related to #380

Add support for dynamic configuration updates while the application is running using a hot-reload approach.

* **ManualDiscovery (`exo/networking/manual/manual_discovery.py`)**
  - Add `start_file_watcher` method to initialize a file watcher using the `watchdog` library.
  - Add `reload_config` method to reload the network configuration dynamically.
  - Add `ConfigFileEventHandler` class to handle file modification events and trigger configuration reload.
  - Update `start` method to initialize the file watcher.
  - Update `stop` method to stop the file watcher.

* **NetworkTopology (`exo/networking/manual/network_topology_config.py`)**
  - Add `reload` method to reload the configuration from the file and update the `peers` attribute.

* **Main Application (`exo/main.py`)**
  - Import the `watchdog` library.

