### PR TITLE
explicitly setting python version to 3.12

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-python3 -m venv .venv
+python3.12 -m venv .venv
 source .venv/bin/activate
 pip install -e .

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Check if Python 3.12 is installed
+if command -v python3.12 &>/dev/null; then
+    echo "Python 3.12 is installed, proceeding..."
+else
+    echo "This repo currently only works with Python 3.12, which is not installed on your machine. Please install Python 3.12 and try again."
+    exit 1
+fi
+
 python3.12 -m venv .venv
 source .venv/bin/activate
 pip install -e .


### PR DESCRIPTION
As stated in the README you must use Python>=3.12.0 however I was not able to create a venv and install the packages with version Python 3.13.0. I had to explicitly set the version to 3.12 to create a successful venv.

Is this a valid solution for now or is it worth trying to fix the issues with 3.13?

I am using a Mac M1. I can create the issue I was experiencing with 3.13 if needed.