### PR TITLE
Error message timeout removed, added close button

### DIFF
--- a/exo/tinychat/index.css
+++ b/exo/tinychat/index.css
@@ -202,6 +202,22 @@ main {
     top: 0; /* Position at the top of the page */
     left: 0; /* Extend from the left edge */
     right: 0; /* Extend to the right edge */
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.toast-close-button {
+    background: none;
+    border: none;
+    color: white;
+    padding: 0 8px;
+    cursor: pointer;
+    font-size: 1.2em;
+}
+
+.toast-close-button:hover {
+    opacity: 0.8;
 }
 
 .hljs {

--- a/exo/tinychat/index.css
+++ b/exo/tinychat/index.css
@@ -191,20 +191,27 @@ main {
 }
 
 .toast {
-    width: 100%; /* Take up the full width of the page */
-    background-color: #fc2a2a; /* Dark background color */
-    color: #fff; /* White text color */
-    text-align: center; /* Centered text */
-    border-radius: 2px; /* Rounded borders */
-    padding: 16px; /* Padding */
-    position: fixed; /* Sit on top of the screen content */
-    z-index: 9999; /* Add a z-index if needed */
-    top: 0; /* Position at the top of the page */
-    left: 0; /* Extend from the left edge */
-    right: 0; /* Extend to the right edge */
+    width: 100%;
+    background-color: #fc2a2a;
+    color: #fff;
+    text-align: left;
+    border-radius: 2px;
+    padding: 16px;
+    position: fixed;
+    z-index: 9999;
+    top: 0;
+    left: 0;
+    right: 0;
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
+    white-space: pre-wrap;
+    font-family: monospace;
+}
+
+.toast span {
+    flex: 1;
+    margin-right: 16px;
 }
 
 .toast-close-button {

--- a/exo/tinychat/index.html
+++ b/exo/tinychat/index.html
@@ -26,7 +26,11 @@
 <body>
 <main x-data="state" x-init="console.log(endpoint)">
      <!-- Error Toast -->
-    <div x-show="errorMessage" x-transition.opacity x-text="errorMessage" class="toast">
+    <div x-show="errorMessage" x-transition.opacity class="toast">
+        <span x-text="errorMessage"></span>
+        <button @click="errorMessage = null" class="toast-close-button">
+            <i class="fas fa-times"></i>
+        </button>
     </div>
 <div class="model-selector">
 <select @change="if (cstate) cstate.selectedModel = $event.target.value" x-model="cstate.selectedModel">

--- a/exo/tinychat/index.js
+++ b/exo/tinychat/index.js
@@ -116,9 +116,15 @@ document.addEventListener("alpine:init", () => {
         localStorage.setItem("pendingMessage", value);
         this.processMessage(value);
       } catch (error) {
-        console.error('error', error)
-        this.lastErrorMessage = error.message || 'Unknown error on handleSend';
-        this.errorMessage = error.message || 'Unknown error on handleSend';
+        console.error('error', error);
+        const errorDetails = {
+            message: error.message || 'Unknown error on handleSend',
+            stack: error.stack,
+            name: error.name || 'Error'
+        };
+        
+        this.lastErrorMessage = errorDetails;
+        this.errorMessage = `${errorDetails.name}: ${errorDetails.message}\n\nStack Trace:\n${errorDetails.stack}`;
         this.generating = false;
       }
     },
@@ -235,9 +241,15 @@ document.addEventListener("alpine:init", () => {
           console.error("Failed to save histories to localStorage:", error);
         }
       } catch (error) {
-        console.error('error', error)
-        this.lastErrorMessage = error;
-        this.errorMessage = error;
+        console.error('error', error);
+        const errorDetails = {
+            message: error.message || 'Unknown error on processMessage',
+            stack: error.stack,
+            name: error.name || 'Error'
+        };
+        
+        this.lastErrorMessage = errorDetails;
+        this.errorMessage = `${errorDetails.name}: ${errorDetails.message}\n\nStack Trace:\n${errorDetails.stack}`;
       } finally {
         this.generating = false;
       }

--- a/exo/tinychat/index.js
+++ b/exo/tinychat/index.js
@@ -119,9 +119,6 @@ document.addEventListener("alpine:init", () => {
         console.error('error', error)
         this.lastErrorMessage = error.message || 'Unknown error on handleSend';
         this.errorMessage = error.message || 'Unknown error on handleSend';
-        setTimeout(() => {
-          this.errorMessage = null;
-        }, 5 * 1000)
         this.generating = false;
       }
     },
@@ -241,9 +238,6 @@ document.addEventListener("alpine:init", () => {
         console.error('error', error)
         this.lastErrorMessage = error;
         this.errorMessage = error;
-        setTimeout(() => {
-          this.errorMessage = null;
-        }, 5 * 1000)
       } finally {
         this.generating = false;
       }


### PR DESCRIPTION
I was having difficulty reading the error messages when the timeout was set to 5 seconds so I removed the timeout and added a close button instead.

I also added the error name and stack trace to be shown in the error box so that the user has more information when trying to debug.