### PR TITLE
Download progress box height increase

### DIFF
--- a/exo/tinychat/index.css
+++ b/exo/tinychat/index.css
@@ -167,6 +167,8 @@ main {
 .download-progress {
   margin-bottom: 12em;
   overflow-y: auto;
+  min-height: 300px;
+  padding: 2rem;
 }
 .message > pre {
   white-space: pre-wrap;

--- a/exo/tinychat/index.css
+++ b/exo/tinychat/index.css
@@ -167,7 +167,7 @@ main {
 .download-progress {
   margin-bottom: 12em;
   overflow-y: auto;
-  min-height: 300px;
+  min-height: 350px;
   padding: 2rem;
 }
 .message > pre {


### PR DESCRIPTION
Each time something was downloading I would go to scroll so I could see the full progress. I added a minimum height so the user can see the full download info. Also added some padding so it had some breathing room. See before and after images.

Before:
<img width="1687" alt="Screenshot 2024-11-17 at 5 51 27 PM" src="https://github.com/user-attachments/assets/94a3b536-788f-4b70-81be-779a1b5290a3">

After:
<img width="1726" alt="Screenshot 2024-11-17 at 5 56 44 PM" src="https://github.com/user-attachments/assets/7495fe14-5aa7-405b-9c86-00187ba0c223">

