### PR TITLE
fix end of request behaviour and add back broadcasting tokens to other nodes

### DIFF
--- a/exo/orchestration/standard_node.py
+++ b/exo/orchestration/standard_node.py
@@ -115,10 +115,11 @@ class StandardNode(Node):
       token = await self.inference_engine.sample(result)
       await self.inference_engine.ensure_shard(shard)
       self.buffered_token_output[request_id][0].append(token.item())
-      self.trigger_on_token_callbacks(request_id, self.buffered_token_output[request_id][0], is_finished)
       if DEBUG >= 2: print(f"[{request_id}] result size: {result.size}, is finished: {is_finished}, buffered tokens: {len(self.buffered_token_output[request_id][0])}")
       is_finished = token.item() == self.inference_engine.tokenizer.eos_token_id
       forward = token.reshape(1, -1)
+      self.trigger_on_token_callbacks(request_id, self.buffered_token_output[request_id][0], is_finished)
+      asyncio.create_task(self.broadcast_result(request_id, self.buffered_token_output[request_id][0], is_finished))
     else:
       forward = result
 


### PR DESCRIPTION
Some issues reported after https://github.com/exo-explore/exo/commit/822a01443364d3fbd8a04f8dfd674974e561c124#diff-64be7aebed54c4e8c49dea294e904fa716eb48190694f8fcf838e41f934de9a1L129

Issue 1 was requests never terminated because `is_finished` was not set before `trigger_on_token_callbacks`

Issue 2 was `broadcast_result` was removed so it wasn't broadcasting results to other nodes. That means if you did a request to any other node than the last node you wouldn't get any response back.