### PR TITLE
restore the cursor to the terminal on exit from CLI

### DIFF
--- a/exo/main.py
+++ b/exo/main.py
@@ -9,6 +9,7 @@ import sys
 import time
 import traceback
 import uuid
+import atexit
 from exo.networking.manual.manual_discovery import ManualDiscovery
 from exo.networking.manual.network_topology_config import NetworkTopology
 from exo.orchestration.standard_node import StandardNode
@@ -28,6 +29,8 @@ from exo.orchestration.node import Node
 from exo.models import build_base_shard, get_repo
 from exo.viz.topology_viz import TopologyViz
 from exo.download.hf.hf_helpers import has_hf_home_read_access, has_hf_home_write_access, get_hf_home, move_models_to_hf
+
+
 
 # parse args
 parser = argparse.ArgumentParser(description="Initialize GRPC Discovery")
@@ -214,6 +217,13 @@ async def main():
       await move_models_to_hf(args.models_seed_dir)
     except Exception as e:
       print(f"Error moving models to .cache/huggingface: {e}")
+
+  def restore_cursor():
+    if platform.system() != "Windows":
+        os.system("tput cnorm")  # Show cursor
+
+  # Restore the cursor when the program exits
+  atexit.register(restore_cursor)
 
   # Use a more direct approach to handle signals
   def handle_exit():

--- a/exo/main.py
+++ b/exo/main.py
@@ -10,7 +10,6 @@ import sys
 import time
 import traceback
 import uuid
-
 from exo.networking.manual.manual_discovery import ManualDiscovery
 from exo.networking.manual.network_topology_config import NetworkTopology
 from exo.orchestration.standard_node import StandardNode

--- a/exo/main.py
+++ b/exo/main.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import atexit
 import signal
 import json
 import logging
@@ -9,7 +10,7 @@ import sys
 import time
 import traceback
 import uuid
-import atexit
+
 from exo.networking.manual.manual_discovery import ManualDiscovery
 from exo.networking.manual.network_topology_config import NetworkTopology
 from exo.orchestration.standard_node import StandardNode
@@ -29,8 +30,6 @@ from exo.orchestration.node import Node
 from exo.models import build_base_shard, get_repo
 from exo.viz.topology_viz import TopologyViz
 from exo.download.hf.hf_helpers import has_hf_home_read_access, has_hf_home_write_access, get_hf_home, move_models_to_hf
-
-
 
 # parse args
 parser = argparse.ArgumentParser(description="Initialize GRPC Discovery")


### PR DESCRIPTION
Running on a MacBook, the cursor disappears if I exit the CLI using CTRL + C. This is a minor change that restores the cursor on exit. 