### PR TITLE
Only collect topology if peers changed

### DIFF
--- a/exo/orchestration/node.py
+++ b/exo/orchestration/node.py
@@ -542,8 +542,8 @@ class Node:
       try:
         did_peers_change = await self.update_peers()
         if DEBUG >= 2: print(f"{did_peers_change=}")
-        await self.collect_topology(set())
         if did_peers_change:
+          await self.collect_topology(set())
           await self.select_best_inference_engine()
       except Exception as e:
         print(f"Error collecting topology: {e}")


### PR DESCRIPTION
Doing this topology collection even if peers don't change seems to be a significant performance bottleneck and is unnecessary