### PR TITLE
Add Docker deployment capability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,6 +328,30 @@ jobs:
       - store_test_results:
           path: test-results
 
+  build_docker_image:
+    docker:
+      - image: circleci/python:3.12
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.7
+      - run:
+          name: Build Docker image
+          command: |
+            docker build -t exo:latest .
+      - run:
+          name: Tag Docker image
+          command: |
+            docker tag exo:latest your-dockerhub-username/exo:latest
+      - run:
+          name: Login to DockerHub
+          command: |
+            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+      - run:
+          name: Push Docker image
+          command: |
+            docker push your-dockerhub-username/exo:latest
+
 workflows:
   version: 2
   build_and_test:
@@ -344,3 +368,4 @@ workflows:
       - chatgpt_api_integration_test_tinygrad
       - chatgpt_api_integration_test_dummy
       - measure_pip_sizes
+      - build_docker_image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use a base image with Python 3.12
+FROM python:3.12-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the project files into the Docker image
+COPY . .
+
+# Install the project dependencies
+RUN pip install --upgrade pip
+RUN pip install -e .
+
+# Set the entry point to run the project
+ENTRYPOINT ["exo"]

--- a/README.md
+++ b/README.md
@@ -91,6 +91,31 @@ pip install -e .
 source install.sh
 ```
 
+### Using Docker
+
+You can also build and run exo using Docker.
+
+#### Build the Docker image
+
+```sh
+docker build -t exo:latest .
+```
+
+#### Run the Docker container
+
+```sh
+docker run -p 52415:52415 exo:latest
+```
+
+### Using Docker Compose
+
+You can use Docker Compose to run exo with multiple services.
+
+#### Build and run the services
+
+```sh
+docker-compose up --build
+```
 
 ### Troubleshooting
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  exo:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "52415:52415"
+    environment:
+      - DEBUG=1
+      - TINYGRAD_DEBUG=2


### PR DESCRIPTION
Add Docker deployment capability to the project.

* **Dockerfile**: Create a `Dockerfile` to define the Docker image for the project using Python 3.12, copy project files, install dependencies, and set the entry point.
* **docker-compose.yml**: Create a `docker-compose.yml` to define the Docker services, including building the project service, exposing necessary ports, and setting environment variables.
* **.circleci/config.yml**: Add a job to build and push the Docker image to a registry, and update the workflow to include the new Docker jobs.
* **README.md**: Add instructions to build and run the Docker image, and use `docker-compose` to run the services.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/exo-explore/exo/pull/562?shareId=e8c82597-cf77-4525-bf77-b7311d8e8f01).