### PR TITLE
Tinygrad Quantization Support [WIP]

### DIFF
--- a/exo/inference/tinygrad/models/llama.py
+++ b/exo/inference/tinygrad/models/llama.py
@@ -59,7 +59,7 @@ def dequantize_asymmetric(weight: Tensor, scales: Tensor, biases: Tensor, group_
 class AffineQuantizedLinear:
   def __init__(self, in_features: int, out_features: int, group_size: int = 64, bias: bool = False):
     self.group_size = group_size
-    self.weight = Tensor.ones(out_features, in_features, dtype=dtypes.int8)
+    self.weight = Tensor.ones(out_features, in_features, dtype=dtypes.uint8)
     self.scales = Tensor.ones(out_features, in_features // group_size, dtype=dtypes.half)
     self.biases = Tensor.ones(out_features, in_features // group_size, dtype=dtypes.half)
 
@@ -86,7 +86,7 @@ class AffineQuantizedLinear:
 class AffineQuantizedEmbedding:
   def __init__(self, vocab_size: int, embed_size: int, group_size: int = 64):
     self.vocab_sz, self.embed_sz, self.group_size = vocab_size, embed_size, group_size
-    self.weight = Tensor.ones(vocab_size, embed_size, dtype=dtypes.int8)
+    self.weight = Tensor.ones(vocab_size, embed_size, dtype=dtypes.uint8)
     self.scales = Tensor.ones(vocab_size, embed_size // group_size, dtype=dtypes.half)
     self.biases = Tensor.ones(vocab_size, embed_size // group_size, dtype=dtypes.half)
 

--- a/exo/models.py
+++ b/exo/models.py
@@ -21,7 +21,7 @@ model_cards = {
     "layers": 16,
     "repo": {
       "MLXDynamicShardInferenceEngine": "mlx-community/Llama-3.2-1B-Instruct-8bit",
-      "TinygradDynamicShardInferenceEngine": "unsloth/Llama-3.2-1B-Instruct",
+      "TinygradDynamicShardInferenceEngine": "mlx-community/Llama-3.2-1B-Instruct-8bit",
     },
   },
   "llama-3.2-3b": {


### PR DESCRIPTION
What I did:

1. Define custom layers for Affine Quantized models, including integer weights, float16 scales and biases (zero point correction)
2. Load MLX-Community quantized model and unpack the weights.
3. Write the forward logic for quantized layers, following this [paper](https://arxiv.org/pdf/1712.05877) (see section 2.3)

Todo:

- [ ] write tests, test with multiple nodes and different llama models
- [ ] support 4-bit quantization
- [ ] do the forward math in Integer (see section 2.2 of mentioned paper)

With this first commit, you can run `exo --run-model="llama-3.2-1b-8bit"` with tinygrad backend and "mlx-community" model.