### PR TITLE
Some adaptivity fixes in tinychat 

### DIFF
--- a/exo/tinychat/index.css
+++ b/exo/tinychat/index.css
@@ -139,6 +139,14 @@ main {
   padding: 0.5rem 1rem;
   border-radius: 20px;
 }
+
+@media(max-width: 1482px) {
+  .messages {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+}
+
 .message-role-assistant {
   background-color: var(--secondary-color);
   margin-right: auto;

--- a/exo/tinychat/index.css
+++ b/exo/tinychat/index.css
@@ -157,6 +157,12 @@ main {
   background-color: var(--primary-color);
   color: #000;
 }
+
+.message-role-user p {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
 .download-progress {
   position: fixed;
   bottom: 11rem;

--- a/exo/tinychat/index.html
+++ b/exo/tinychat/index.html
@@ -193,7 +193,7 @@
             otx = $event.changedTouches[0].clientX;
           " class="history" x-data="{ otx: 0, trigger: 75 }">
 <h3 x-text="new Date(_state.time).toLocaleString()"></h3>
-<p x-text="$truncate(_state.messages[0].content, 80)"></p>
+<p x-text="$truncate(_state.messages[0].content, 76)"></p>
 <!-- delete button -->
 <button @click.stop="removeHistory(_state);" class="history-delete-button">
 <i class="fas fa-trash"></i>


### PR DESCRIPTION
Hi, I've fixed a few minor css styling issues:

* Add adaptive padding for user and assistant messages on width <= 1480px to avoid ‘gluing’ the sidebar and message bubble together

<details>
  <summary>Before:</summary>

https://github.com/user-attachments/assets/634a0855-d689-4427-956e-467355a57fb8

</details>


<details>
  <summary>After:</summary>

https://github.com/user-attachments/assets/4e8a0a09-d5b4-4868-be2b-3a32936fa004

</details>

* Fix bubble behavior when user passes long text without any spaces

<details>
  <summary>Before:</summary>

<img width="1268" alt="image" src="https://github.com/user-attachments/assets/77264538-7b69-475e-ab8b-d5909b826f74" />

</details>

<details>
  <summary>After:</summary>

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/01de8a98-736b-4019-886d-31d266cbdd64" />

</details>

* Adjust truncate size in history list for text without any spaces

<details>
  <summary>Before:</summary>

<img width="1060" alt="image" src="https://github.com/user-attachments/assets/89ef5bac-bda8-4713-9e4c-9c91c593266e" />

</details>

<details>
  <summary>After:</summary>

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/0b0fd35e-a027-4c0b-bbfa-72d5367ecadc" />

</details>