### PR TITLE
Add `--gpu` CLI option so Linux users can choose a single GPU ID for tinygrad

### DIFF
--- a/exo/main.py
+++ b/exo/main.py
@@ -69,6 +69,7 @@ parser.add_argument("--save-checkpoint-dir", type=str, default="checkpoints", he
 parser.add_argument("--node-id", type=str, default=None, help="Node ID")
 parser.add_argument("--node-host", type=str, default="0.0.0.0", help="Node host")
 parser.add_argument("--node-port", type=int, default=None, help="Node port")
+parser.add_argument("--gpu", type=int, default=0, help="GPU ID to use")
 parser.add_argument("--models-seed-dir", type=str, default=None, help="Model seed directory")
 parser.add_argument("--listen-port", type=int, default=5678, help="Listening port for discovery")
 parser.add_argument("--download-quick-check", action="store_true", help="Quick check local path for model shards download")
@@ -103,6 +104,8 @@ shard_downloader: ShardDownloader = new_shard_downloader() if args.inference_eng
 inference_engine_name = args.inference_engine or ("mlx" if system_info == "Apple Silicon Mac" else "tinygrad")
 print(f"Inference engine name after selection: {inference_engine_name}")
 
+# Sets VISIBLE_DEVICES for tinygrad (only supports one GPU currently)
+os.environ["VISIBLE_DEVICES"] = str(args.gpu)
 inference_engine = get_inference_engine(inference_engine_name, shard_downloader)
 print(f"Using inference engine: {inference_engine.__class__.__name__} with shard downloader: {shard_downloader.__class__.__name__}")
 

--- a/exo/topology/device_capabilities.py
+++ b/exo/topology/device_capabilities.py
@@ -180,9 +180,12 @@ async def linux_device_capabilities() -> DeviceCapabilities:
   if DEBUG >= 2: print(f"tinygrad {Device.DEFAULT=}")
   if Device.DEFAULT == "CUDA" or Device.DEFAULT == "NV" or Device.DEFAULT == "GPU":
     import pynvml
-
+    from os import environ
+    # https://github.com/tinygrad/tinygrad/blob/master/docs/env_vars.md#global-variables
+    # FIXME: When other inference engines are added, this should be updated.
+    gpu = int(environ.get("VISIBLE_DEVICES", "0"))
     pynvml.nvmlInit()
-    handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+    handle = pynvml.nvmlDeviceGetHandleByIndex(gpu)
     gpu_raw_name = pynvml.nvmlDeviceGetName(handle).upper()
     gpu_name = gpu_raw_name.rsplit(" ", 1)[0] if gpu_raw_name.endswith("GB") else gpu_raw_name
     gpu_memory_info = pynvml.nvmlDeviceGetMemoryInfo(handle)


### PR DESCRIPTION
### Original Behavior

1. User has to set `VISIBLE_DEVICES` in shell for tinygrad to accept choice of GPUs.
2. Even if set to something other than `0`, `linux_device_capabilities()` will fetch only index 0 (this was hardcoded in).

### New Behavior

1. The user may specify `--gpu` followed by an integer. If parsed incorrectly or omitted, it will default to `0`. `VISIBLE_DEVICES` in the parent environment is effectively abstracted away from the user, so if they want to pick a device, they can pick only one for the instance.*
2. Device capabilities will fetched according to this index, and the user will see the correct GPU as confirmation in the TUI (see behavior of `topology.py`).

Users can run multiple GPUs at once by running multiple instances of exo. This workaround I wrote may be obsolete if we implement multi-GPU in a single instance of exo, but for now, this will allow users to take advantage of multiple GPUs in one device.