### PR TITLE
adding current model name to input container information

### DIFF
--- a/exo/tinychat/index.html
+++ b/exo/tinychat/index.html
@@ -342,6 +342,10 @@
 <div class="input-container">
 <div class="input-performance">
 <span class="input-performance-point">
+<p class="monospace" x-text="models[cstate.selectedModel]?.name || cstate.selectedModel"></p>
+<p class="megrim-regular">-</p>
+</span>
+<span class="input-performance-point">
 <p class="monospace" x-text="(time_till_first / 1000).toFixed(2)"></p>
 <p class="megrim-regular">SEC TO FIRST TOKEN</p>
 </span>


### PR DESCRIPTION
With the new collapsable model navigation in the sidebar, it is not immediately clear when the page loads what model is being used for the chat. 

My solution: I added the model name to the input container information but some other options would be:

1.  To put it in the header
2. To put a "Current Model" in the side bar under Network Topology that is always visible.
3. Expand the model selection to the model that is currently select.

Let me know if you would prefer an alternate solution.