### PR TITLE
Improvements to the ChatGPT API to more closely match the official OpenAI endpoint and improve compatibility

### DIFF
--- a/.github/bench.py
+++ b/.github/bench.py
@@ -265,6 +265,9 @@ async def measure_performance(api_endpoint: str, prompt: str, model: str) -> Dic
             if not line.startswith('data: '):
                 continue
 
+            if line == 'data: [DONE]':
+               break 
+
             data = json.loads(line[6:])  # Skip 'data: ' prefix
             if content := data.get('choices', [{}])[0].get('delta', {}).get('content'):
                 print(f"Received content: {content}", flush=True)

--- a/exo/api/chatgpt_api.py
+++ b/exo/api/chatgpt_api.py
@@ -387,7 +387,14 @@ class ChatGPTAPI:
             if not eos_token_id and hasattr(tokenizer, "_tokenizer"): eos_token_id = tokenizer.special_tokens_map.get("eos_token_id")
 
             finish_reason = None
-            if is_finished: finish_reason = "stop" if tokens[-1] == eos_token_id else "length"
+            if is_finished:
+              if tokens[-1] == eos_token_id:
+                # We do not return the EOS token in the response
+                tokens.pop(-1)
+                finish_reason = "stop"
+              else:
+                finish_reason = "length"
+
             if DEBUG >= 2: print(f"{eos_token_id=} {tokens[-1]=} {finish_reason=}")
 
             completion = generate_completion(
@@ -440,6 +447,8 @@ class ChatGPTAPI:
         if not eos_token_id and hasattr(tokenizer, "_tokenizer"): eos_token_id = tokenizer.special_tokens_map.get("eos_token_id")
         if DEBUG >= 2: print(f"Checking if end of tokens result {tokens[-1]=} is {eos_token_id=}")
         if tokens[-1] == eos_token_id:
+          # We do not return the EOS token in the response
+          tokens.pop(-1)
           finish_reason = "stop"
 
         return web.json_response(generate_completion(chat_request, tokenizer, prompt, request_id, tokens, stream, finish_reason, "chat.completion"))


### PR DESCRIPTION
Hey, as I mentioned on Discord, we are experimenting with a Mac mini Exo deploy at work and noticed that the ChatGPT API offered by Exo behaved differently than the official OpenAI endpoint in a way which made working with 3rd party chat clients difficult.

To make the Exo API behave more similarly to OpenAI's, we have done the following:

1. Remove the EOS token from the output.
    - This was the primary issue as 3rd party chat clients did not expect the EOS token (`<|eot_id|>` for LLAMA 3.2) to be included in the response, so they were not filtering them.
    - It did not manifest in the built-in Tinychat UI as the EOS token was only emitted with `finish_reason="stop"`, in which case Tinychat ignored the content of the delta.
2. When streaming, the API now emits a `data: [DONE]` event to indicate completion before terminating the stream.
3. When streaming, only include the message under the `delta` key rather than both that and the `message`, mirroring the OpenAI type.
4. If the streamed content is empty (as will occur for the finishing chunk now that the EOS token is stripped), set `delta: {}`.

## Testing

To test this you can use the [llm command line tool](https://github.com/simonw/llm) configured to talk to exo by editing the following file "~/Library/Application\ Support/io.datasette.llm/extra-openai-models.yaml" on macOS to contain the following,

```yaml
- model_id: llama-3.2-1b
  model_name: llama-3.2-1b
  api_base: "http://localhost:52415/v1"
```

### Old

```
❯ llm chat -m llama-3.2-1b
Chatting with llama-3.2-1b
Type 'exit' or 'quit' to exit
Type '!multi' to enter multiple lines, then '!end' to finish
> Hello
Hello! How can I assist you today?<|eot_id|>
```

### New

```
❯ llm chat -m llama-3.2-1b
Chatting with llama-3.2-1b
Type 'exit' or 'quit' to exit
Type '!multi' to enter multiple lines, then '!end' to finish
> Hello
Hello! How can I assist you today?
```

Note the lack of "<|eot_id|>" in the output.