### PR TITLE
remove dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,10 +291,10 @@ exo supports the following inference engines:
 - ✅ [UDP](exo/networking/udp)
 - ✅ [Manual](exo/networking/manual)
 - ✅ [Tailscale](exo/networking/tailscale)
-- 🚧 [Radio](TODO)
-- 🚧 [Bluetooth](TODO)
+- 🚧 Radio
+- 🚧 Bluetooth
 
 # Peer Networking Modules
 
 - ✅ [GRPC](exo/networking/grpc)
-- 🚧 [NCCL](TODO)
+- 🚧 NCCL


### PR DESCRIPTION
Hello there!

I've noticed that three links at the very bottom of the `README.md` file are dead - they link to a `TODO` file that no longer exists.

Until such a file (or a corresponding GitHub project) exists to link to, I figured it would be reasonable to remove those links. The text itself is still present - it just doesn't reference a non-existent file anymore.

Have a great day and keep up the great work.