### PR TITLE
AMD/ROCm: Changes required to detect and inference on AMD GPUs

### DIFF
--- a/exo/topology/device_capabilities.py
+++ b/exo/topology/device_capabilities.py
@@ -198,22 +198,19 @@ async def linux_device_capabilities() -> DeviceCapabilities:
       flops=CHIP_FLOPS.get(gpu_name, DeviceFlops(fp32=0, fp16=0, int8=0)),
     )
   elif Device.DEFAULT == "AMD":
-    # For AMD GPUs, pyrsmi is the way (Official python package for rocm-smi)
-    from pyrsmi import rocml
+    import pyamdgpuinfo
 
-    rocml.smi_initialize()
-    gpu_name = rocml.smi_get_device_name(0).upper()
-    gpu_memory_info = rocml.smi_get_device_memory_total(0)
+    gpu_raw_info = pyamdgpuinfo.get_gpu(0)
+    gpu_name = gpu_raw_info.name
+    gpu_memory_info = gpu_raw_info.memory_info["vram_size"]
 
     if DEBUG >= 2: print(f"AMD device {gpu_name=} {gpu_memory_info=}")
 
-    rocml.smi_shutdown()
-
     return DeviceCapabilities(
-      model="Linux Box ({gpu_name})",
+      model="Linux Box (" + gpu_name + ")",
       chip=gpu_name,
       memory=gpu_memory_info // 2**20,
-      flops=DeviceFlops(fp32=0, fp16=0, int8=0),
+      flops=CHIP_FLOPS.get(gpu_name, DeviceFlops(fp32=0, fp16=0, int8=0)),
     )
 
   else:

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ install_requires = [
   "prometheus-client==0.20.0",
   "protobuf==5.28.1",
   "psutil==6.0.0",
+  "pyamdgpuinfo==2.1.6;platform_system=='Linux'",
   "pydantic==2.9.2",
   "requests==2.32.3",
   "rich==13.7.1",


### PR DESCRIPTION
This is @BatSmacker84's fixes applied (replaces #417; closes #434) and tested against current exo, it replaces the `pyrsmi` implementation that never worked because:
1. [pyrsmi returns device family (i.e. `Navi 21 [Radeon RX 6800/6800 XT / 6900 XT]`) instead of specific device name (`AMD Radeon RX 6900 XT`) when queried](https://github.com/ROCm/pyrsmi/issues/21) which is useless and doesn't match anything in `CHIP_FLOPS` lookup table.
2. flops was hard coded to 0

For RX 6000-series (gfx1030) cards, tinygrad 0.10.3+ (or tinygrad master after Mar 5 '25) is needed because of a fix for [ctl stack size](https://github.com/tinygrad/tinygrad/commit/77f7ddf62a78218bee7b4f7b9ff925a0e581fcad).

Here is a screenshot of Exo doing inference on an AMD RX 6900XT (GPU at 99% on btop) at ~8 tok/s (vs <1 tok/s on CPU only):
![Image](https://github.com/user-attachments/assets/40daca1a-af01-44f7-8274-d400f8318ab0)