### PR TITLE
Update install.sh: handle when python is not installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
 
-if command -v python3.12 &>/dev/null; then
-    echo "Python 3.12 is installed, proceeding with python3.12..."
-    python3.12 -m venv .venv
-else
-    echo "The recommended version of Python to run exo with is Python 3.12, but $(python3 --version) is installed. Proceeding with $(python3 --version)"
-    python3 -m venv .venv
-fi
+RECOMMENDED_PYTHON_VER="3.12"
+PYTHON=$(basename $(command -v python${RECOMMENDED_PYTHON_VER} python3 | head -1) 2>/dev/null)
+
+case "${PYTHON}" in
+    python${RECOMMENDED_PYTHON_VER})
+        echo "Python ${RECOMMENDED_PYTHON_VER} is installed, proceeding with python${RECOMMENDED_PYTHON_VER}..."
+        ;;
+    python3)
+        echo "recommended version of Python to run exo with is Python ${RECOMMENDED_PYTHON_VER}, but $(python3 --version) is installed. Proceeding with $(python3 --version)"
+        ;;
+    *)
+        echo "Python ${RECOMMENDED_PYTHON_VER} is not installed, please install Python ${RECOMMENDED_PYTHON_VER}"
+        exit 1
+        ;;
+esac
+
+${PYTHON} -m venv .venv
 source .venv/bin/activate
 pip install -e .


### PR DESCRIPTION
Working on bring exo up on my Steam Deck, `install.sh` didn't handle Python3 not being installed...  
Refactored `install.sh` to handle that better, test below:

```sh
# ./install.sh # No python3
Python 3.12 is not installed, please install Python 3.12

# nix profile install nixpkgs#python310
# ./install.sh # python3.10
recommended version of Python to run exo with is Python 3.12, but Python 3.10.16 is installed. Proceeding with Python 3.10.16

# nix profile remove python310
# nix profile install nixpkgs#python312
# ./install.sh # python3.12
Python 3.12 is installed, proceeding with python3.12...
```