### PR TITLE
CPU Mode Timeout Problem

### DIFF
--- a/exo/orchestration/node.py
+++ b/exo/orchestration/node.py
@@ -560,7 +560,10 @@ class Node:
         continue
 
       try:
-        other_topology = await asyncio.wait_for(peer.collect_topology(visited, max_depth=max_depth - 1), timeout=5.0)
+        # Collect topology from peer
+        # But CPU Mode Peer Is Made to Timeout Just 5 Seconds
+        # So i updated the timeout to 15 Seconds
+        other_topology = await asyncio.wait_for(peer.collect_topology(visited, max_depth=max_depth - 1), timeout=15.0)
         if DEBUG >= 2: print(f"Collected topology from: {peer.id()}: {other_topology}")
         next_topology.merge(peer.id(), other_topology)
       except Exception as e:


### PR DESCRIPTION

Low spec computers sometimes have timeouts.
Because all cores are executing matrix operations.
So I increased the timeout time because the gRPC server could not respond.