### PR TITLE
fix: prevent form submission during IME composition

### DIFF
--- a/exo/tinychat/index.js
+++ b/exo/tinychat/index.js
@@ -381,7 +381,13 @@ document.addEventListener("alpine:init", () => {
     },
 
     async handleEnter(event) {
-      // if shift is not pressed
+      // Check if an IME (Input Method Editor) composition is in progress
+      if (event.isComposing || event.keyCode === 229) {
+        // Allow the default Enter behavior for IME composition
+        return;
+      }
+      
+      // Only send message if shift is not pressed and not in IME composition
       if (!event.shiftKey) {
         event.preventDefault();
         await this.handleSend();


### PR DESCRIPTION
Fix issue with Enter key handling during Chinese (and other IME-based) text input

Add detection for IME composition state using event.isComposing flag
Add fallback check for keyCode 229 which indicates IME processing
Prevent message submission when Enter is pressed during active IME composition
Allow normal Enter behavior for confirming IME selections
Maintains existing Shift+Enter functionality for line breaks

Before:

https://github.com/user-attachments/assets/2685e0b9-9a5f-43c7-9d4b-10569b697a70

After:

https://github.com/user-attachments/assets/272563fc-760a-4c6b-b35e-d834d1d7d218


