### PR TITLE
feat(project): add pyproject.toml for PEP 621 metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,68 @@
+[build-system]
+requires = [
+  "setuptools>=66.0", 
+  "wheel"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "exo"
+version = "0.0.1"
+description = "Distributed LLM inference framework"
+readme = "README.md"            # adjust if you use another file
+requires-python = ">=3.12.0"
+dependencies = [
+  "aiohttp==3.10.11",
+  "aiohttp_cors==0.7.0",
+  "aiofiles==24.1.0",
+  "grpcio==1.70.0",
+  "grpcio-tools==1.70.0",
+  "Jinja2==3.1.4",
+  "numpy==2.0.0",
+  "nuitka==2.5.1",
+  "nvidia-ml-py==12.560.30",
+  "opencv-python==4.10.0.84",
+  "pillow==10.4.0",
+  "prometheus-client==0.20.0",
+  "protobuf==5.28.1",
+  "psutil==6.0.0",
+  "pyamdgpuinfo==2.1.6; platform_system=='Linux'",
+  "pydantic==2.9.2",
+  "requests==2.32.3",
+  "rich==13.7.1",
+  "scapy==2.6.1",
+  "tqdm==4.66.4",
+  "transformers==4.46.3",
+  "uuid==1.30",
+  "uvloop==0.21.0",
+  "tinygrad @ git+https://github.com/tinygrad/tinygrad.git@ec120ce6b9ce8e4ff4b5692566a683ef240e8bc8",
+]
+
+[project.optional-dependencies]
+formatting = [
+  "yapf==0.40.2",
+]
+apple_silicon = [
+  "mlx==0.22.0",
+  "mlx-lm==0.21.1",
+]
+windows = [
+  "pywin32==308",
+]
+nvidia-gpu = [
+  "nvidia-ml-py==12.560.30",
+]
+amd-gpu = [
+  "pyrsmi==0.2.0",
+]
+
+[project.scripts]
+exo = "exo.main:run"
+
+[tool.setuptools.packages.find]
+where = ["."]
+# you can add exclude = ["tests*"] if you have tests you don't want packaged
+
+[tool.setuptools.package-data]
+"exo" = ["tinychat/**/*"]
+


### PR DESCRIPTION
- define project metadata (name, version, requires-python) and dependencies in pyproject.toml
- configure setuptools.build_meta as build-backend for PEP 660 editable installs
- replace setup.py install_requires & entry_points with PEP 621 fields
- include package-data and optional-dependencies for apple_silicon, nvidia-gpu, etc.

Background
The project currently relies solely on setup.py to declare its dependencies and entry points. This prevents full compatibility with PEP 660 editable installs and modern tooling like uv sync and pip install -e ., causing some dependencies to be skipped. We need a pyproject.toml so that build back-ends and dependency managers can understand our metadata natively.

Changes
Add pyproject.toml using PEP 621 to declare:

Project metadata: name, version, description, requires-python

dependencies: migrated from install_requires

optional-dependencies: migrated from extras_require

scripts: replaces entry_points for the exo console script

package-data: includes tinychat assets under exo

Retain the existing setup.py for backward compatibility; it can be removed once downstream consumers have migrated.

Update CI workflows (if any) to run pip install -e . and/or uv sync against both setup.py and pyproject.toml flows.