### PR TITLE
Fix: Handle NotImplementedError in asyncio on Windows (Addresses #184)

### DIFF
--- a/exo/main.py
+++ b/exo/main.py
@@ -342,7 +342,9 @@ async def main():
   def handle_exit():
     asyncio.ensure_future(shutdown(signal.SIGTERM, loop, node.server))
 
-  if platform.system() != "Windows":
+  # Signal handlers are not supported on Windows, KeyboardInterrupt is handled by the run() function
+  # Signal handlers are not supported on Windows, KeyboardInterrupt is handled by the run() function
+  if not psutil.WINDOWS:
     for s in [signal.SIGINT, signal.SIGTERM]:
       loop.add_signal_handler(s, handle_exit)
 


### PR DESCRIPTION
Addresses #184 by ensuring add_signal_handler is not called on Windows, as it's not supported. Graceful shutdown via KeyboardInterrupt is still handled by the run() function.