### PR TITLE
Fix MLX dependency versions for Apple Silicon compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ install_requires = [
 extras_require = {
   "formatting": ["yapf==0.40.2",],
   "apple_silicon": [
-    "mlx==0.22.0",
-    "mlx-lm==0.21.1",
+    "mlx>=0.26.0",
+    "mlx-lm>=0.21.1",
   ],
   "windows": ["pywin32==308",],
   "nvidia-gpu": ["nvidia-ml-py==12.560.30",],


### PR DESCRIPTION
## Summary
- Updated MLX dependency versions to resolve installation conflicts on newer Apple Silicon systems
- Changed `mlx==0.22.0` to `mlx>=0.26.0` for broader compatibility 
- Changed `mlx-lm==0.21.1` to `mlx-lm>=0.21.1` to prevent version conflicts

## Problem Solved
- Fixes psutil import errors caused by dependency resolution conflicts
- Resolves `ModuleNotFoundError: No module named 'mlx'` on fresh installations
- Prevents virtual environment corruption during package installation

## Testing Done
- ✅ Tested on Apple M4 Max (macOS)
- ✅ Virtual environment installation successful
- ✅ All exo modules import correctly (exo.main, exo.helpers, exo.topology.device_capabilities)
- ✅ Full cluster startup and operation verified
- ✅ Web interface and API endpoints functional
- ✅ Device capabilities detection working (M4 Max: 36GB RAM, 18.03 TFLOPS)

## Test Plan
- [ ] Verify installation on M1/M2/M3 Apple Silicon systems
- [ ] Confirm no regression on existing installations
- [ ] Test both single-node and multi-node cluster functionality

🤖 Generated with [Claude Code](https://claude.ai/code)