### PR TITLE
Fix MLX dependency version from 0.22.0 to 0.22.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
 extras_require = {
   "formatting": ["yapf==0.40.2",],
   "apple_silicon": [
-    "mlx==0.22.0",
+    "mlx==0.22.1",
     "mlx-lm==0.21.1",
   ],
   "windows": ["pywin32==308",],


### PR DESCRIPTION
## Summary
- Updates MLX version from 0.22.0 to 0.22.1 in setup.py
- Fixes installation error where mlx==0.22.0 is not available on PyPI

## Problem
When running `uv pip install -e .` or `source install.sh`, the installation fails with:
```
ERROR: Could not find a version that satisfies the requirement mlx==0.22.0 (from exo)
ERROR: No matching distribution found for mlx==0.22.0
```

## Solution
Updated the MLX version requirement from 0.22.0 to 0.22.1, which is available on PyPI.

## Test plan
- [ ] Verify `uv pip install -e .` works without errors
- [ ] Verify `source install.sh` completes successfully
- [ ] Confirm MLX functionality remains intact