### PR TITLE
fix: bump MLX to 0.22.1 to restore installability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
 extras_require = {
   "formatting": ["yapf==0.40.2",],
   "apple_silicon": [
-    "mlx==0.22.0",
+    "mlx==0.22.1",
     "mlx-lm==0.21.1",
   ],
   "windows": ["pywin32==308",],


### PR DESCRIPTION
PyPI does not publish mlx==0.22.0, causing pip to fail with "No matching distribution found for mlx==0.22.0".
Upgrade to 0.22.1 (patch-level) to match an existing release.

Tested on: macOS arm64, Python 3.12
Install: pip install -e . 
>>> succeeded