### PR TITLE
updating installtion instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The current recommended way to install exo is from source.
 git clone https://github.com/exo-explore/exo.git
 cd exo
 pip install -e .
+pip install clang llvmlite
 # alternatively, with venv
 source install.sh
 ```

--- a/install.sh
+++ b/install.sh
@@ -9,3 +9,4 @@ else
 fi
 source .venv/bin/activate
 pip install -e .
+pip install clang llvmlite


### PR DESCRIPTION
When trying out exo I got errors that clang and llvmlite were not installed when querying through the Web-Interface. In the two commits, I've added the pip installation command for those into the install.sh file and noted it for manual installation in the README.md. 