### PR TITLE
remove old tb_only flag from master

### DIFF
--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -77,7 +77,6 @@ class Node:
             global_event_sender=router.sender(topics.GLOBAL_EVENTS),
             local_event_receiver=router.receiver(topics.LOCAL_EVENTS),
             command_receiver=router.receiver(topics.COMMANDS),
-            tb_only=args.tb_only,
         )
 
         er_send, er_recv = channel[ElectionResult]()
@@ -207,7 +206,6 @@ class Args(CamelCaseModel):
     force_master: bool = False
     spawn_api: bool = False
     api_port: PositiveInt = 8000
-    tb_only: bool = False
 
     @classmethod
     def parse(cls) -> Self:
@@ -244,11 +242,6 @@ class Args(CamelCaseModel):
             type=int,
             dest="api_port",
             default=8000,
-        )
-        parser.add_argument(
-            "--tb-only",
-            action="store_true",
-            dest="tb_only",
         )
 
         args = parser.parse_args()

--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -57,7 +57,6 @@ class Master:
         # Send events to the forwarder to be indexed (usually from command processing)
         # Ideally these would be MasterForwarderEvents but type system says no :(
         global_event_sender: Sender[ForwarderEvent],
-        tb_only: bool = False,
     ):
         self.state = State()
         self._tg: TaskGroup = anyio.create_task_group()
@@ -76,7 +75,6 @@ class Master:
         self._multi_buffer = MultiSourceBuffer[NodeId, Event]()
         # TODO: not have this
         self._event_log: list[Event] = []
-        self.tb_only = tb_only
 
     async def run(self):
         logger.info("Starting Master")

--- a/src/exo/master/tests/test_master.py
+++ b/src/exo/master/tests/test_master.py
@@ -69,7 +69,6 @@ async def test_master():
         global_event_sender=ge_sender,
         local_event_receiver=le_receiver,
         command_receiver=co_receiver,
-        tb_only=False,
     )
     logger.info("run the master")
     async with anyio.create_task_group() as tg:


### PR DESCRIPTION
## Motivation
This flag was not used. We can re-add it in future, but it shouldn't be necessary with the new dashboard.

## Changes made
Removed references to tb_only in the master and arg parser.