### PR TITLE
nix: get rust build working on linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,10 @@
             ++ (pkgs.lib.optionals pkgs.stdenv.isLinux [
               # IFCONFIG
               unixtools.ifconfig
+
+              # Build dependencies for Linux
+              pkg-config
+              openssl
             ])
             ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin [
               # MACMON
@@ -100,6 +104,11 @@
           shellHook = ''
             # PYTHON
             export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.python313}/lib"
+            ${pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+              # Build environment for Linux
+              export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
+              export LD_LIBRARY_PATH="${pkgs.openssl.out}/lib:$LD_LIBRARY_PATH"
+            ''}
             echo
             echo "🍎🍎 Run 'just <recipe>' to get started"
             just --list


### PR DESCRIPTION
## Motivation

Currently on main insufficient dependencies are provided by Nix to run `cargo build` on Linux. Add the extra dependencies.

## Changes

Added `pkg-config` and `openssl` packages. Extended the existing manual environment variables in the devshell to use these too.

## Why It Works

Missing dependencies are now available.

## Test Plan

### Manual Testing
- Linux NixOS machine. `nix develop --command sh -c 'cargo clean && cargo build'` now works.

### Automated Testing
N/A for now.
