### PR TITLE
fix(downloads): use certifi for robust SSL certificate verification

### DIFF
--- a/src/exo/worker/download/download_utils.py
+++ b/src/exo/worker/download/download_utils.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import os
 import shutil
+import ssl
 import time
 import traceback
 from datetime import timedelta
@@ -12,6 +13,7 @@ from urllib.parse import urljoin
 import aiofiles
 import aiofiles.os as aios
 import aiohttp
+import certifi
 from loguru import logger
 from pydantic import (
     BaseModel,
@@ -262,8 +264,12 @@ def create_http_session(
         sock_read_timeout = 1800
         sock_connect_timeout = 60
 
+    ssl_context = ssl.create_default_context(cafile=certifi.where())
+    connector = aiohttp.TCPConnector(ssl=ssl_context)
+
     return aiohttp.ClientSession(
         auto_decompress=auto_decompress,
+        connector=connector,
         timeout=aiohttp.ClientTimeout(
             total=total_timeout,
             connect=connect_timeout,


### PR DESCRIPTION
fix(downloads): use certifi for robust SSL certificate verification

## Description
This change updates the SSL context creation in \`download_utils.py\` to explicitly use the \`certifi\` CA bundle. This ensures that the application has access to a reliable, up-to-date set of root certificates, which is critical for verifying SSL connections to external services like Hugging Face.

## Problem
On macOS environments (and potentially others), Python's default SSL context often fails to locate the system's root certificates. This leads to \`aiohttp.client_exceptions.ClientConnectorCertificateError\` errors when attempting to download models.

## Solution
By passing \`cafile=certifi.where()\` to \`ssl.create_default_context()\`, we force the application to use the trusted certificate store provided by the \`certifi\` package. This is a standard best practice for cross-platform Python applications and resolves the verification failure.