### PR TITLE
fix: clamp download progress percentage to 0-100 range

### DIFF
--- a/app/EXO/EXO/ViewModels/InstanceViewModel.swift
+++ b/app/EXO/EXO/ViewModels/InstanceViewModel.swift
@@ -10,11 +10,11 @@ struct DownloadProgressViewModel: Equatable {
 
     var fractionCompleted: Double {
         guard totalBytes > 0 else { return 0 }
-        return Double(downloadedBytes) / Double(totalBytes)
+        return min(1.0, max(0.0, Double(downloadedBytes) / Double(totalBytes)))
     }
 
     var percentCompleted: Double {
-        fractionCompleted * 100
+        min(100.0, fractionCompleted * 100)
     }
 
     var formattedProgress: String {

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -382,6 +382,11 @@ function toggleInstanceDownloadDetails(nodeId: string): void {
 		return (meta.model_id as string) ?? (meta.modelId as string) ?? null;
 	}
 
+	// Helper to clamp percentage between 0 and 100
+	function clampPercent(value: number): number {
+		return Math.min(100, Math.max(0, value));
+	}
+
 	// Helper to parse download progress from payload
 	function parseDownloadProgress(payload: Record<string, unknown>): DownloadProgress | null {
 		const progress = payload.download_progress ?? payload.downloadProgress;
@@ -408,16 +413,16 @@ function toggleInstanceDownloadDetails(nodeId: string): void {
 				downloadedBytes: fDownloaded,
 				speed: (fd.speed as number) ?? 0,
 				etaMs: (fd.eta_ms as number) ?? (fd.etaMs as number) ?? 0,
-				percentage: fTotal > 0 ? (fDownloaded / fTotal) * 100 : 0
+				percentage: clampPercent(fTotal > 0 ? (fDownloaded / fTotal) * 100 : 0)
 			});
 		}
-		
+
 		return {
 			totalBytes,
 			downloadedBytes,
 			speed,
 			etaMs: etaMs || (speed > 0 ? ((totalBytes - downloadedBytes) / speed) * 1000 : 0),
-			percentage: totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0,
+			percentage: clampPercent(totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0),
 			completedFiles,
 			totalFiles,
 			files
@@ -496,7 +501,7 @@ function toggleInstanceDownloadDetails(nodeId: string): void {
 				downloadedBytes,
 				speed: totalSpeed,
 				etaMs: totalSpeed > 0 ? ((totalBytes - downloadedBytes) / totalSpeed) * 1000 : 0,
-				percentage: totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0,
+				percentage: clampPercent(totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0),
 				completedFiles,
 				totalFiles,
 				files: allFiles
@@ -603,7 +608,7 @@ function toggleInstanceDownloadDetails(nodeId: string): void {
 				downloadedBytes,
 				speed: totalSpeed,
 				etaMs: totalSpeed > 0 ? ((totalBytes - downloadedBytes) / totalSpeed) * 1000 : 0,
-				percentage: totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0,
+				percentage: clampPercent(totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0),
 				completedFiles,
 				totalFiles,
 				files: allFiles


### PR DESCRIPTION
## Summary
- Clamp download progress percentage to 0-100 range to prevent display issues when downloading across multiple devices
- Applied fix to both Dashboard (TypeScript/Svelte) and macOS App (Swift)

Fixes #933

## Test plan
- [x] Verified existing Python tests pass
- [x] Verified TypeScript type checking passes (existing errors unrelated to this change)