### PR TITLE
fix: update macOS app to use correct API port (52415)

### DIFF
--- a/app/EXO/EXO/ContentView.swift
+++ b/app/EXO/EXO/ContentView.swift
@@ -212,7 +212,7 @@ struct ContentView: View {
 
     private var dashboardButton: some View {
         Button {
-            guard let url = URL(string: "http://localhost:8000/") else { return }
+            guard let url = URL(string: "http://localhost:52415/") else { return }
             NSWorkspace.shared.open(url)
         } label: {
             HStack {

--- a/app/EXO/EXO/Services/BugReportService.swift
+++ b/app/EXO/EXO/Services/BugReportService.swift
@@ -35,7 +35,7 @@ struct BugReportService {
     }
 
     func sendReport(
-        baseURL: URL = URL(string: "http://127.0.0.1:8000")!,
+        baseURL: URL = URL(string: "http://127.0.0.1:52415")!,
         now: Date = Date(),
         isManual: Bool = false
     ) async throws -> BugReportOutcome {

--- a/app/EXO/EXO/Services/ClusterStateService.swift
+++ b/app/EXO/EXO/Services/ClusterStateService.swift
@@ -15,7 +15,7 @@ final class ClusterStateService: ObservableObject {
     private let endpoint: URL
 
     init(
-        baseURL: URL = URL(string: "http://127.0.0.1:8000")!,
+        baseURL: URL = URL(string: "http://127.0.0.1:52415")!,
         session: URLSession = .shared
     ) {
         self.baseURL = baseURL


### PR DESCRIPTION
## Summary
- Update macOS app to use the correct default API port (52415) instead of 8000
- Fixed in ClusterStateService, ContentView, and BugReportService

Fixes #960

## Test plan
- [x] Verified the default port in main.py is 52415
- [x] Updated all Swift files that reference the API port