### PR TITLE
feat: conform to XDG Base Directory Specification on Linux

### DIFF
--- a/src/exo/shared/constants.py
+++ b/src/exo/shared/constants.py
@@ -1,27 +1,62 @@
 import os
+import sys
 from pathlib import Path
 
-EXO_HOME_RELATIVE_PATH = os.environ.get("EXO_HOME", ".exo")
-EXO_HOME = Path.home() / EXO_HOME_RELATIVE_PATH
 
+def _get_xdg_dir(env_var: str, fallback: str) -> Path:
+    """Get XDG directory with fallback. On non-Linux platforms, use ~/.exo."""
+    # On macOS/Windows, use traditional ~/.exo directory
+    if sys.platform != "linux":
+        return Path.home() / ".exo"
+
+    # On Linux, follow XDG Base Directory Specification
+    xdg_value = os.environ.get(env_var)
+    if xdg_value:
+        return Path(xdg_value) / "exo"
+    return Path.home() / fallback / "exo"
+
+
+# Support legacy EXO_HOME environment variable for backward compatibility
+_EXO_HOME_ENV = os.environ.get("EXO_HOME")
+if _EXO_HOME_ENV:
+    # Legacy mode: use EXO_HOME for all files
+    EXO_CONFIG_HOME = Path.home() / _EXO_HOME_ENV
+    EXO_DATA_HOME = Path.home() / _EXO_HOME_ENV
+    EXO_CACHE_HOME = Path.home() / _EXO_HOME_ENV
+else:
+    # XDG mode (Linux) or traditional mode (macOS/Windows)
+    EXO_CONFIG_HOME = _get_xdg_dir("XDG_CONFIG_HOME", ".config")
+    EXO_DATA_HOME = _get_xdg_dir("XDG_DATA_HOME", ".local/share")
+    EXO_CACHE_HOME = _get_xdg_dir("XDG_CACHE_HOME", ".cache")
+
+# Legacy alias for backward compatibility
+EXO_HOME = EXO_DATA_HOME
+
+# Models directory (data)
 EXO_MODELS_DIR_ENV = os.environ.get("EXO_MODELS_DIR")
-EXO_MODELS_DIR = Path(EXO_MODELS_DIR_ENV) if EXO_MODELS_DIR_ENV else EXO_HOME / "models"
+EXO_MODELS_DIR = (
+    Path(EXO_MODELS_DIR_ENV) if EXO_MODELS_DIR_ENV else EXO_DATA_HOME / "models"
+)
 
-EXO_GLOBAL_EVENT_DB = EXO_HOME / "global_events.db"
-EXO_WORKER_EVENT_DB = EXO_HOME / "worker_events.db"
-EXO_MASTER_STATE = EXO_HOME / "master_state.json"
-EXO_WORKER_STATE = EXO_HOME / "worker_state.json"
-EXO_MASTER_LOG = EXO_HOME / "master.log"
-EXO_WORKER_LOG = EXO_HOME / "worker.log"
-EXO_LOG = EXO_HOME / "exo.log"
-EXO_TEST_LOG = EXO_HOME / "exo_test.log"
+# Database and state files (data)
+EXO_GLOBAL_EVENT_DB = EXO_DATA_HOME / "global_events.db"
+EXO_WORKER_EVENT_DB = EXO_DATA_HOME / "worker_events.db"
+EXO_MASTER_STATE = EXO_DATA_HOME / "master_state.json"
+EXO_WORKER_STATE = EXO_DATA_HOME / "worker_state.json"
 
-EXO_NODE_ID_KEYPAIR = EXO_HOME / "node_id.keypair"
+# Log files (data/logs or cache)
+EXO_MASTER_LOG = EXO_DATA_HOME / "master.log"
+EXO_WORKER_LOG = EXO_DATA_HOME / "worker.log"
+EXO_LOG = EXO_DATA_HOME / "exo.log"
+EXO_TEST_LOG = EXO_DATA_HOME / "exo_test.log"
 
-EXO_WORKER_KEYRING_FILE = EXO_HOME / "worker_keyring"
-EXO_MASTER_KEYRING_FILE = EXO_HOME / "master_keyring"
+# Identity and keys (config)
+EXO_NODE_ID_KEYPAIR = EXO_CONFIG_HOME / "node_id.keypair"
+EXO_WORKER_KEYRING_FILE = EXO_CONFIG_HOME / "worker_keyring"
+EXO_MASTER_KEYRING_FILE = EXO_CONFIG_HOME / "master_keyring"
 
-EXO_IPC_DIR = EXO_HOME / "ipc"
+# IPC directory (runtime/cache)
+EXO_IPC_DIR = EXO_CACHE_HOME / "ipc"
 
 # libp2p topics for event forwarding
 LIBP2P_LOCAL_EVENTS_TOPIC = "worker_events"

--- a/src/exo/shared/tests/test_xdg_paths.py
+++ b/src/exo/shared/tests/test_xdg_paths.py
@@ -1,0 +1,118 @@
+"""Tests for XDG Base Directory Specification compliance."""
+
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+
+def test_xdg_paths_on_linux():
+    """Test that XDG paths are used on Linux when XDG env vars are set."""
+    with (
+        mock.patch.dict(
+            os.environ,
+            {
+                "XDG_CONFIG_HOME": "/tmp/test-config",
+                "XDG_DATA_HOME": "/tmp/test-data",
+                "XDG_CACHE_HOME": "/tmp/test-cache",
+            },
+            clear=False,
+        ),
+        mock.patch.object(sys, "platform", "linux"),
+    ):
+        # Re-import to pick up mocked values
+        import importlib
+
+        import exo.shared.constants as constants
+
+        importlib.reload(constants)
+
+        assert Path("/tmp/test-config/exo") == constants.EXO_CONFIG_HOME
+        assert Path("/tmp/test-data/exo") == constants.EXO_DATA_HOME
+        assert Path("/tmp/test-cache/exo") == constants.EXO_CACHE_HOME
+
+
+def test_xdg_default_paths_on_linux():
+    """Test that XDG default paths are used on Linux when env vars are not set."""
+    # Remove XDG env vars and EXO_HOME
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("XDG_") and k != "EXO_HOME"
+    }
+    with (
+        mock.patch.dict(os.environ, env, clear=True),
+        mock.patch.object(sys, "platform", "linux"),
+    ):
+        import importlib
+
+        import exo.shared.constants as constants
+
+        importlib.reload(constants)
+
+        home = Path.home()
+        assert home / ".config" / "exo" == constants.EXO_CONFIG_HOME
+        assert home / ".local/share" / "exo" == constants.EXO_DATA_HOME
+        assert home / ".cache" / "exo" == constants.EXO_CACHE_HOME
+
+
+def test_legacy_exo_home_takes_precedence():
+    """Test that EXO_HOME environment variable takes precedence for backward compatibility."""
+    with mock.patch.dict(
+        os.environ,
+        {
+            "EXO_HOME": ".custom-exo",
+            "XDG_CONFIG_HOME": "/tmp/test-config",
+        },
+        clear=False,
+    ):
+        import importlib
+
+        import exo.shared.constants as constants
+
+        importlib.reload(constants)
+
+        home = Path.home()
+        assert home / ".custom-exo" == constants.EXO_CONFIG_HOME
+        assert home / ".custom-exo" == constants.EXO_DATA_HOME
+
+
+def test_macos_uses_traditional_paths():
+    """Test that macOS uses traditional ~/.exo directory."""
+    # Remove EXO_HOME to ensure we test the default behavior
+    env = {k: v for k, v in os.environ.items() if k != "EXO_HOME"}
+    with (
+        mock.patch.dict(os.environ, env, clear=True),
+        mock.patch.object(sys, "platform", "darwin"),
+    ):
+        import importlib
+
+        import exo.shared.constants as constants
+
+        importlib.reload(constants)
+
+        home = Path.home()
+        assert home / ".exo" == constants.EXO_CONFIG_HOME
+        assert home / ".exo" == constants.EXO_DATA_HOME
+        assert home / ".exo" == constants.EXO_CACHE_HOME
+
+
+def test_node_id_in_config_dir():
+    """Test that node ID keypair is in the config directory."""
+    import exo.shared.constants as constants
+
+    assert constants.EXO_NODE_ID_KEYPAIR.parent == constants.EXO_CONFIG_HOME
+
+
+def test_models_in_data_dir():
+    """Test that models directory is in the data directory."""
+    # Clear EXO_MODELS_DIR to test default behavior
+    env = {k: v for k, v in os.environ.items() if k != "EXO_MODELS_DIR"}
+    with mock.patch.dict(os.environ, env, clear=True):
+        import importlib
+
+        import exo.shared.constants as constants
+
+        importlib.reload(constants)
+
+        assert constants.EXO_MODELS_DIR.parent == constants.EXO_DATA_HOME


### PR DESCRIPTION
## Summary
Implements XDG Base Directory Specification for Linux systems:
- Config files (node_id, keyring) in `$XDG_CONFIG_HOME/exo` (default: `~/.config/exo`)
- Data files (models, state, logs) in `$XDG_DATA_HOME/exo` (default: `~/.local/share/exo`)
- Cache files (ipc) in `$XDG_CACHE_HOME/exo` (default: `~/.cache/exo`)

Backward compatibility maintained:
- `EXO_HOME` env var still works for legacy setups
- macOS/Windows continue using `~/.exo` directory

Fixes #905

## Test plan
- [x] Added comprehensive tests for XDG path resolution
- [x] Tested Linux XDG paths with custom env vars
- [x] Tested Linux default XDG paths
- [x] Tested legacy EXO_HOME compatibility
- [x] Tested macOS traditional paths
- [x] All existing tests pass