### PR TITLE
pyproject: drop pathlib dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "filelock>=3.18.0",
     "aiosqlite>=0.21.0",
     "networkx>=3.5",
-    "pathlib>=1.0.1",
     "protobuf>=6.32.0",
     "rich>=14.1.0",
     "rustworkx>=0.17.1",

--- a/uv.lock
+++ b/uv.lock
@@ -336,7 +336,6 @@ dependencies = [
     { name = "mlx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "mlx-lm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "networkx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pathlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "psutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -378,7 +377,6 @@ requires-dist = [
     { name = "mlx", specifier = ">=0.29.3" },
     { name = "mlx-lm", specifier = ">=0.28.3" },
     { name = "networkx", specifier = ">=3.5" },
-    { name = "pathlib", specifier = ">=1.0.1" },
     { name = "protobuf", specifier = ">=6.32.0" },
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
@@ -949,15 +947,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
-]
-
-[[package]]
-name = "pathlib"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ac/aa/9b065a76b9af472437a0059f77e8f962fe350438b927cb80184c32f075eb/pathlib-1.0.1.tar.gz", hash = "sha256:6940718dfc3eff4258203ad5021090933e5c04707d5ca8cc9e73c94a7894ea9f", size = 49298, upload-time = "2014-09-03T15:41:57.18Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/f9/690a8600b93c332de3ab4a344a4ac34f00c8f104917061f779db6a918ed6/pathlib-1.0.1-py3-none-any.whl", hash = "sha256:f35f95ab8b0f59e6d354090350b44a80a80635d22efdedfa84c7ad1cf0a74147", size = 14363, upload-time = "2022-05-04T13:37:20.585Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Motivation

When packaging with `pyinstaller` we get issues like:

```
ERROR: The 'pathlib' package is an obsolete backport of a standard library package and is incompatible with PyInstaller. Please remove this package (located in /Users/runner/work/exo/exo/.venv/lib/python3.13/site-packages) using
    "/Users/runner/work/exo/exo/.venv/bin/python" -m pip uninstall pathlib
then try again.
```

## Changes

Drop pathlib as it's already in the standard library of the Python version we require.

## Test Plan

### Manual Testing

```sh
# started and loaded dashboard. looks good.
s1@s1s-Mac-Studio exo % uv run exo
Using CPython 3.13.11
Creating virtual environment at: .venv
      Built exo-pyo3-bindings @ file:///Users/s1/exo/rust/exo_pyo3_bindings
      Built exo @ file:///Users/s1/exo
Installed 87 packages in 194ms
[ 04:48:30.3095PM | INFO    ] Starting EXO
[ 04:48:30.3272PM | INFO    ] Subscribing to global_events
[ 04:48:30.3273PM | INFO    ] RUST: networking task started
[ 04:48:30.3280PM | INFO    ] RUST: other event NewListenAddr { listener_id: ListenerId(1), address: /ip4/127.0.0.1/tcp/52906 }
[ 04:48:30.3281PM | INFO    ] RUST: other event NewListenAddr { listener_id: ListenerId(1), address: /ip4/169.254.110.177/tcp/52906 }
[ 04:48:30.3283PM | INFO    ] RUST: other event NewListenAddr { listener_id: ListenerId(1), address: /ip4/169.254.168.173/tcp/52906 }
[ 04:48:30.3285PM | INFO    ] RUST: other event NewListenAddr { listener_id: ListenerId(1), address: /ip4/10.64.50.95/tcp/52906 }
[ 04:48:30.3286PM | INFO    ] RUST: other event NewListenAddr { listener_id: ListenerId(1), address: /ip4/100.74.104.109/tcp/52906 }
[ 04:48:30.3287PM | INFO    ] RUST: other event NewListenAddr { listener_id: ListenerId(1), address: /ip4/169.254.201.244/tcp/52906 }
[ 04:48:30.3287PM | INFO    ] RUST: other event NewListenAddr { listener_id: ListenerId(1), address: /ip4/169.254.238.111/tcp/52906 }
[ 04:48:30.3289PM | INFO    ] Subscribing to local_events
[ 04:48:30.3293PM | INFO    ] Subscribing to commands
[ 04:48:30.3296PM | INFO    ] Subscribing to election_messages
[ 04:48:30.3298PM | INFO    ] Subscribing to connection_messages
[ 04:48:30.3299PM | INFO    ] Starting node 12D3KooWQdmbPgD9echEh97ws7Gfm7Rdsf2exa1Vbf6The57r652

╔═══════════════════════════════════════════════════════════════════════╗
║                                                                       ║
║   ███████╗██╗  ██╗ ██████╗                                            ║
║   ██╔════╝╚██╗██╔╝██╔═══██╗                                           ║
║   █████╗   ╚███╔╝ ██║   ██║                                           ║
║   ██╔══╝   ██╔██╗ ██║   ██║                                           ║
║   ███████╗██╔╝ ██╗╚██████╔╝                                           ║
║   ╚══════╝╚═╝  ╚═╝ ╚═════╝                                            ║
║                                                                       ║
║   Distributed AI Inference Cluster                                    ║
║                                                                       ║
╚═══════════════════════════════════════════════════════════════════════╝

╔═══════════════════════════════════════════════════════════════════════╗
║                                                                       ║
║  🌐 Dashboard & API Ready                                             ║
║                                                                       ║
║  http://localhost:52415                                               ║
║                                                                       ║
║  Click the URL above to open the dashboard in your browser            ║
║                                                                       ║
╚═══════════════════════════════════════════════════════════════════════╝

[ 04:48:30.3342PM | INFO    ] Starting Worker
[ 04:48:30.3343PM | INFO    ] Starting Election
[ 04:48:30.3344PM | INFO    ] Starting Master
[ 04:48:30.3345PM | INFO    ] Starting API

[ 04:48:30.3391PM | INFO    ] Running on http://0.0.0.0:52415 (CTRL + C to quit)
[ 04:48:30.3392PM | INFO    ] Running on http://0.0.0.0:52415 (CTRL + C to quit)
[ 04:48:30.3395PM | INFO    ] Node elected Master
[ 04:48:30.3396PM | INFO    ] Unpausing API
```

### Automated Testing
