### PR TITLE
build-app: add branch trigger from named branch

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - "test-app"
 
 jobs:
   build-macos-app:
@@ -32,15 +34,21 @@ jobs:
 
       - name: Derive release version from tag
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          if [[ "$VERSION" == *-alpha* ]]; then
+          if [[ "$GITHUB_REF_NAME" == "test-app" ]]; then
+            VERSION="0.0.0-alpha.0"
             echo "IS_ALPHA=true" >> $GITHUB_ENV
           else
-            echo "IS_ALPHA=false" >> $GITHUB_ENV
+            VERSION="${GITHUB_REF_NAME#v}"
+            if [[ "$VERSION" == *-alpha* ]]; then
+              echo "IS_ALPHA=true" >> $GITHUB_ENV
+            else
+              echo "IS_ALPHA=false" >> $GITHUB_ENV
+            fi
           fi
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Ensure tag commit is on main
+        if: github.ref_type == 'tag'
         run: |
           git fetch origin main
           # Alpha tags can be on any branch, production tags must be on main
@@ -267,7 +275,7 @@ jobs:
           path: output/EXO-${{ env.RELEASE_VERSION }}.dmg
 
       - name: Upload to S3
-        if: env.SPARKLE_S3_BUCKET != ''
+        if: env.SPARKLE_S3_BUCKET != '' && github.ref_type == 'tag'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
As I've been working on the .dmg, it's become clear we need a way to test changes to the app. It's too hard to reproduce the full DMG locally to be reasonable and much more convenient to test if it's signed.

Add a feature to the build-app workflow where if you push specifically to the `test-app` branch it'll perform a build. The version is stubbed to `0.0.0-alpha.0`, which is about as low as it gets in semver so you'll always update away from it automatically with Sparkle. The resulting DMG won't be pushed to S3 but will be uploaded as a GitHub Actions artifact.

I've been using similar commits to this for a while for testing. It's worked well and not interfered with auto updating at all.

Test plan:
- Pushed this change to `test-app`.
- Generated action at https://github.com/exo-explore/exo/actions/runs/20447213358/job/58752909332
- Installed the DMG on a Mac. It worked as intended.