### PR TITLE
feat(macos-app): add custom namespace UI for cluster isolation

### DIFF
--- a/app/EXO/EXO/ContentView.swift
+++ b/app/EXO/EXO/ContentView.swift
@@ -20,6 +20,8 @@ struct ContentView: View {
     @State private var showDebugInfo = false
     @State private var bugReportInFlight = false
     @State private var bugReportMessage: String?
+    @State private var showAdvancedOptions = false
+    @State private var pendingNamespace: String = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -197,6 +199,8 @@ struct ContentView: View {
                 updater.checkForUpdates()
             }
             .padding(.bottom, 8)
+            advancedOptionsSection
+                .padding(.bottom, 8)
             debugSection
                 .padding(.bottom, 8)
             controlButton(title: "Quit", tint: .secondary) {
@@ -325,6 +329,47 @@ struct ContentView: View {
                 }
             }
         }
+    }
+
+    private var advancedOptionsSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Advanced Options")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Spacer()
+                collapseButton(isExpanded: $showAdvancedOptions)
+            }
+            .animation(nil, value: showAdvancedOptions)
+            if showAdvancedOptions {
+                VStack(alignment: .leading, spacing: 8) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Cluster Namespace")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                        HStack {
+                            TextField("optional", text: $pendingNamespace)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.caption2)
+                                .onAppear {
+                                    pendingNamespace = controller.customNamespace
+                                }
+                            Button("Save & Restart") {
+                                controller.customNamespace = pendingNamespace
+                                if controller.status == .running || controller.status == .starting {
+                                    controller.restart()
+                                }
+                            }
+                            .font(.caption2)
+                            .disabled(pendingNamespace == controller.customNamespace)
+                        }
+
+                    }
+                }
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: showAdvancedOptions)
     }
 
     private var debugSection: some View {

--- a/app/EXO/EXO/ExoProcessController.swift
+++ b/app/EXO/EXO/ExoProcessController.swift
@@ -2,6 +2,8 @@ import AppKit
 import Combine
 import Foundation
 
+private let customNamespaceKey = "EXOCustomNamespace"
+
 @MainActor
 final class ExoProcessController: ObservableObject {
     enum Status: Equatable {
@@ -27,6 +29,13 @@ final class ExoProcessController: ObservableObject {
     @Published private(set) var status: Status = .stopped
     @Published private(set) var lastError: String?
     @Published private(set) var launchCountdownSeconds: Int?
+    @Published var customNamespace: String = {
+        return UserDefaults.standard.string(forKey: customNamespaceKey) ?? ""
+    }() {
+        didSet {
+            UserDefaults.standard.set(customNamespace, forKey: customNamespaceKey)
+        }
+    }
 
     private var process: Process?
     private var runtimeDirectoryURL: URL?
@@ -180,7 +189,7 @@ final class ExoProcessController: ObservableObject {
     private func makeEnvironment(for runtimeURL: URL) -> [String: String] {
         var environment = ProcessInfo.processInfo.environment
         environment["EXO_RUNTIME_DIR"] = runtimeURL.path
-        environment["EXO_LIBP2P_NAMESPACE"] = buildTag()
+        environment["EXO_LIBP2P_NAMESPACE"] = computeNamespace()
 
         var paths: [String] = []
         if let existing = environment["PATH"], !existing.isEmpty {
@@ -216,6 +225,12 @@ final class ExoProcessController: ObservableObject {
             return short
         }
         return "dev"
+    }
+
+    private func computeNamespace() -> String {
+        let base = buildTag()
+        let custom = customNamespace.trimmingCharacters(in: .whitespaces)
+        return custom.isEmpty ? base : custom
     }
 }
 


### PR DESCRIPTION
## Overview

Add Advanced Options section with custom namespace field that allows users to override EXO_LIBP2P_NAMESPACE environment variable. This enables splitting machines that can see each other into separate clusters.

- Added customNamespace property with UserDefaults persistence
- Added Advanced Options collapsible section with text field
- Added Save & Restart button that auto-restarts exo process
- Namespace replaces buildTag when custom value is set
- Falls back to buildTag (version) when namespace is empty

## Motivation

EXO supports multiple p2p namespaces to split up clusters via the `EXO_LIBP2P_NAMESPACE` environment variable when building from source. However, when using the macOS app, this was hardcoded to the application version, making it impossible for users to isolate machines into separate clusters without rebuilding the app.

This PR adds a UI option in the macOS app to set a custom namespace, allowing users to split machines that can see each other into multiple logical clusters.

## Changes

- Added `customNamespace` property to [ExoProcessController.swift](cci:7://file:///exo/app/EXO/EXO/ExoProcessController.swift:0:0-0:0) with UserDefaults persistence
- Added "Advanced Options" collapsible section to [ContentView.swift](cci:7://file:///exo/app/EXO/EXO/ContentView.swift:0:0-0:0) (similar to existing Debug Info section)
- Added text field for entering custom namespace with "Save & Restart" button
- Modified `computeNamespace()` to use custom namespace when set, falling back to buildTag (app version) when empty
- Button is disabled when no changes are pending
- Automatically restarts exo process when namespace is saved (if running)

## Why It Works

The implementation modifies the `makeEnvironment()` function to set `EXO_LIBP2P_NAMESPACE` using the custom value from UserDefaults. When the namespace is changed and saved:

1. User enters namespace in text field (value stored in local state)
2. Clicking "Save & Restart" writes to UserDefaults and calls `controller.restart()`
3. On next launch, `computeNamespace()` returns the custom value instead of buildTag
4. This namespace is used when creating the exo process, isolating it from other clusters

## Test Plan

### Manual Testing
**Hardware:** MacBook Air M1 8GB (macOS 26.02)

**What I tested:**
- Verified namespace field appears in Advanced Options section
- Tested entering custom namespace (e.g., "my-cluster")
- Confirmed "Save & Restart" button restarts exo process
- Verified namespace persists across app restarts (UserDefaults)
- Tested empty namespace falls back to buildTag (app version)
- Confirmed button is disabled when no changes pending

### Automated Testing
No automated tests added.
