### PR TITLE
Fix Kimi K2 Thinking download by adding tiktoken.model to download patterns

### DIFF
--- a/src/exo/worker/download/huggingface_utils.py
+++ b/src/exo/worker/download/huggingface_utils.py
@@ -95,7 +95,15 @@ def extract_layer_num(tensor_name: str) -> int | None:
 
 def get_allow_patterns(weight_map: dict[str, str], shard: ShardMetadata) -> list[str]:
     default_patterns = set(
-        ["*.json", "*.py", "tokenizer.model", "*.tiktoken", "*.txt", "*.jinja"]
+        [
+            "*.json",
+            "*.py",
+            "tokenizer.model",
+            "tiktoken.model",
+            "*.tiktoken",
+            "*.txt",
+            "*.jinja",
+        ]
     )
     shard_specific_patterns: set[str] = set()
     if weight_map:


### PR DESCRIPTION
Kimi-K2 Thinking uses tiktoken.model for its tokenizer, which wasn't being downloaded. This adds it to the default_patterns alongside tokenizer.model.
I'm a bit confused why this isn't a problem for other people - I know that others have used Kimi K2 (I wonder if they manually fixed the download).

## Motivation

I downloaded Kimi K2 Thinking and it didn't work because it didn't download tiktoken.model file.

## Changes

Added tiktoken.model to the default patterns.

## Why It Works

Now downloads the file.

## Test Plan

### Manual Testing

I have two Macbook Studio M3 Ultras, each with 512Gb ram, connected with Thunderbolt 5. I ran Kimi K2 Thinking with MLX Ring and Tensor Split. It ran successfully.

### Automated Testing
No automated test changes. I don't think they are needed.