### PR TITLE
Improve Thunderbolt Bridge detection by checking interface name

### DIFF
--- a/src/exo/master/placement_utils.py
+++ b/src/exo/master/placement_utils.py
@@ -181,7 +181,13 @@ def get_hosts_from_subgraph(cycle_digraph: Topology) -> list[Host]:
                 connection.local_node_id == current_node.node_id
                 and connection.send_back_node_id == next_node.node_id
             ):
-                if get_thunderbolt and not connection.is_thunderbolt():
+                # Use topology method for reliable Thunderbolt Bridge detection
+                if (
+                    get_thunderbolt
+                    and not cycle_digraph.is_connection_on_thunderbolt_bridge(
+                        connection
+                    )
+                ):
                     continue
                 assert connection.send_back_multiaddr is not None
                 host = Host(


### PR DESCRIPTION
Previously, Thunderbolt was detected by IP prefix (169.254.x.x), but this incorrectly matched IPs on Ethernet adapters.

Now uses Topology.is_connection_on_thunderbolt_bridge() which checks if the connection IP belongs to a bridge* interface (bridge0, bridge1, etc.) on the target node's network_interfaces list.

This ensures distributed MLX inference reliably uses the fast Thunderbolt connection (~40-80Gbps) instead of potentially falling back to slower Ethernet.

## Motivation

I was finding that the prefill on Kimi K2 Thinking was running at around 10-20t/s. With this change, the prefill now runs at around 250-300t/s.

## Changes

Added a new function is_connection_on_thunderbolt_bridge which looks for an interface with a "bridge" prefix. This is the main thunderbolt connection.
 
## Why It Works

I had two 169.254.x.x addresses. But only one of them was using the bridge interface.

## Test Plan

### Manual Testing

I have two Macbook Studio M3 Ultras, each with 512Gb ram, connected with Thunderbolt 5. I ran Kimi K2 Thinking with MLX Ring and Tensor Split. Without this patch, I was getting 10-20t/s prefill and with this patch 250-300t/s prefill. The token generation has also improved from around 8t/s to 10t/s.

### Automated Testing

No changes to automated testing.
