### PR TITLE
fix warmup order. should be rank!=0 then rank=0

### DIFF
--- a/src/exo/worker/plan.py
+++ b/src/exo/worker/plan.py
@@ -235,9 +235,8 @@ def _ready_to_warmup(
         assert device_rank < world_size
         assert device_rank >= 0
 
-        # TODO: Ensure these align with MLX distributeds expectations.
-        # Rank < n-1
-        accepting_ranks_ready = device_rank < world_size - 1 and all(
+        # Rank != 0
+        accepting_ranks_ready = device_rank > 0 and all(
             isinstance(
                 all_runners.get(global_runner_id, None),
                 (RunnerLoaded, RunnerWarmingUp),
@@ -245,8 +244,8 @@ def _ready_to_warmup(
             for global_runner_id in shard_assignments.runner_to_shard
         )
 
-        # Rank = n-1
-        connecting_rank_ready = device_rank == world_size - 1 and all(
+        # Rank = 0
+        connecting_rank_ready = device_rank == 0 and all(
             isinstance(all_runners.get(global_runner_id, None), RunnerWarmingUp)
             for global_runner_id in shard_assignments.runner_to_shard
             if global_runner_id != runner_id


### PR DESCRIPTION
## Motivation

Warmup was happening in the wrong order.

## Changes

Changed it to first run warmup on `rank!=0` then `rank=0`.

## Why It Works

This is in line with our pipeline parallel implementation where we require that we are first receiving on ranks `1` to `n-1` before we send on rank `0`.

Note that this is **not** how the mlx-lm implementation works, which does it the opposite way round and I think where this mistake came from. The mlx-lm implementation goes from `n-1` to `0` and therefore must be receiving on ranks `0` to `n-2` before sending on rank `n-1`.

## Test Plan

### Manual Testing
Warming up still works.
I suspect this would make things more stable in slow network conditions.