### PR TITLE
Disable smart downloads, Just use a wildcard.

### DIFF
--- a/src/exo/worker/download/download_utils.py
+++ b/src/exo/worker/download/download_utils.py
@@ -450,6 +450,11 @@ async def get_weight_map(repo_id: str, revision: str = "main") -> dict[str, str]
 
 
 async def resolve_allow_patterns(shard: ShardMetadata) -> list[str]:
+    # TODO: 'Smart' downloads are disabled because:
+    #  (i) We don't handle all kinds of files;
+    # (ii) We don't have sticky sessions.
+    # (iii) Tensor parallel requires all files.
+    return ["*"]
     try:
         weight_map = await get_weight_map(str(shard.model_meta.model_id))
         return get_allow_patterns(weight_map, shard)


### PR DESCRIPTION
## Motivation

Disabled this feature until we have a better way to do smart downloads.

Reasons:

1. We don't handle all kinds of files
2. We don't have sticky sessions.
3. Tensor parallel requires all files.

## Changes

Use a wildcard to download all files from huggingface repo.

## Why It Works

Instead of selecting individual file patterns, we just catch all with wildcard `*`.

## Test Plan

### Manual Testing
Tested a pipeline parallel download on two nodes to ensure that all model files are downloaded onto every node.
