### PR TITLE
set KV_CACHE_BITS to None to disable quantized kv cache

### DIFF
--- a/src/exo/worker/engines/mlx/constants.py
+++ b/src/exo/worker/engines/mlx/constants.py
@@ -9,7 +9,7 @@ MAX_KV_SIZE: int | None = 3200
 KEEP_KV_SIZE: int | None = 1600
 QUANTIZE_MODEL_MODE: str | None = "affine"
 CACHE_GROUP_SIZE: int = 64
-KV_CACHE_BITS: int | None = 8
+KV_CACHE_BITS: int | None = None
 
 # TODO: We should really make this opt-in, but Kimi requires trust_remote_code=True
 TRUST_REMOTE_CODE: bool = True


### PR DESCRIPTION
## Motivation

We are unsure of the stability of quantized kv cache.
We have had issues getting gibberish and it could be because of quantized kv cache.
Therefore we are disabling this until we have evals that confirms the effect of quantized kv cache.

## Changes

Set `KV_CACHE_BITS` to None to disable quantized kv cache.

## Why It Works

In `make_kv_cache` we do not use quantized kv cache if `KV_CACHE_BITS` is `None`.

## Test Plan

Inference still works. Potentially more stable.
