### PR TITLE
Prioritise mlx jaccl coordinator ip (en0 -> en1 -> non-TB5 -> other)

### DIFF
--- a/src/exo/master/placement_utils.py
+++ b/src/exo/master/placement_utils.py
@@ -385,13 +385,14 @@ def get_mlx_jaccl_coordinators(
     address in format "X.X.X.X:PORT" per node.
     """
     rank_0_node = selected_cycle[0]
-    logger.info(f"Selecting coordinator from rank 0 node: {rank_0_node.node_id}")
+    logger.debug(f"Selecting coordinator from rank 0 node: {rank_0_node.node_id}")
 
     def get_ip_for_node(n: NodeInfo) -> str:
         if n.node_id == rank_0_node.node_id:
             return "0.0.0.0"
 
-        for ip, _ in _find_connection_ip(n, rank_0_node, cycle_digraph):
+        ip = _find_ip_prioritised(n, rank_0_node, cycle_digraph)
+        if ip:
             return ip
 
         logger.warning(


### PR DESCRIPTION
## Motivation

MlxJaccl backend requires an ip address `MLX_JACCL_COORDINATOR` which is the IP address of the rank 0 node in the group.

If this IP address is set to a TB5 IP address, it often leads to jaccl errors, likely something to do with macOS not liking traffic going over IP over TB5 and RDMA at the same time. Jeff Geerling reported something similar running HPC workloads over TB5 causing similar issues.

## Changes

Prioritise `MLX_JACCL_COORDINATOR` as follows: `en0` -> `en1` -> non-TB5 -> other.

## Why It Works

The way we prioritize works good enough for now, but this could be made better. The intention here is to prioritize the most reliable non-TB5 link.

- `en0` is Ethernet on Mac Studio, WiFi on MacBook.
- `en1` is WiFi on Mac Studio, TB5 on MacBook)

## Test Plan

### Manual Testing
Launched an RDMA instance where Ethernet is available -> always picks Ethernet IP as `MLX_JACCL_COORDINATOR`.
Launched an RDMA instance where Ethernet is not available but WiFi is available -> always picks WiFi IP as `MLX_JACCL_COORDINATOR`.
Launched an RDMA instance where neither Ethernet nor WiFi is available -> always picks TB5 IP as `MLX_JACCL_COORDINATOR`.