### PR TITLE
resolve issue #1025

### DIFF
--- a/dashboard/src/app.css
+++ b/dashboard/src/app.css
@@ -198,14 +198,34 @@
 	stroke: oklch(0.85 0.18 85 / 0.4);
 	stroke-width: 1.5px;
 	stroke-dasharray: 8, 8;
-	animation: flowAnimation 1s linear infinite;
+	animation: flowAnimation 1.5s linear infinite;
 	filter: drop-shadow(0 0 3px oklch(0.85 0.18 85 / 0.5));
+	/* GPU optimization - hint to browser this element will animate */
+	will-change: stroke-dashoffset;
 }
 
 .graph-link-active {
 	stroke: oklch(0.85 0.18 85 / 0.8);
 	stroke-width: 2px;
 	filter: drop-shadow(0 0 6px oklch(0.85 0.18 85 / 0.8));
+}
+
+/* Reduce motion for users who prefer it - also saves GPU */
+@media (prefers-reduced-motion: reduce) {
+	.graph-link {
+		animation: none;
+	}
+	
+	.shooting-star {
+		animation: none;
+		display: none;
+	}
+	
+	.status-pulse,
+	.cursor-blink,
+	.animate-pulse {
+		animation: none;
+	}
 }
 
 /* CRT Screen effect for topology */
@@ -266,13 +286,15 @@ input:focus, textarea:focus {
 	box-shadow: none;
 }
 
-/* Shooting Stars Animation */
+/* Shooting Stars Animation - GPU optimized */
 .shooting-stars {
 	position: fixed;
 	inset: 0;
 	overflow: hidden;
 	pointer-events: none;
 	z-index: 0;
+	/* Only render when visible */
+	content-visibility: auto;
 }
 
 .shooting-star {
@@ -285,6 +307,9 @@ input:focus, textarea:focus {
 	animation: shootingStar var(--duration, 3s) linear infinite;
 	animation-delay: var(--delay, 0s);
 	opacity: 0;
+	/* GPU optimization */
+	will-change: transform, opacity;
+	transform: translateZ(0);
 }
 
 .shooting-star::before {
@@ -318,5 +343,15 @@ input:focus, textarea:focus {
 	100% {
 		opacity: 0;
 		transform: translate(400px, 400px);
+	}
+}
+
+/* Pause animations when page is hidden to save resources */
+:root:has(body[data-page-hidden="true"]) {
+	.shooting-star,
+	.graph-link,
+	.status-pulse,
+	.cursor-blink {
+		animation-play-state: paused;
 	}
 }

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -1,7 +1,25 @@
 <script lang="ts">
 	import '../app.css';
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 	
 	let { children } = $props();
+	let isPageHidden = $state(false);
+	
+	onMount(() => {
+		if (!browser) return;
+		
+		// Listen for visibility changes to pause animations when hidden
+		const handleVisibilityChange = () => {
+			isPageHidden = document.visibilityState === 'hidden';
+		};
+		
+		document.addEventListener('visibilitychange', handleVisibilityChange);
+		
+		return () => {
+			document.removeEventListener('visibilitychange', handleVisibilityChange);
+		};
+	});
 </script>
 
 <svelte:head>
@@ -9,7 +27,7 @@
 	<meta name="description" content="EXO - Distributed AI Cluster Dashboard" />
 </svelte:head>
 
-<div class="min-h-screen bg-background text-foreground">
+<div class="min-h-screen bg-background text-foreground" data-page-hidden={isPageHidden}>
 	{@render children?.()}
 </div>
 


### PR DESCRIPTION
## Motivation

https://github.com/exo-explore/exo/issues/1025

## Changes

- Add JSON comparison in AppStore before state updates - only triggers Svelte reactivity when data actually changes
- Add visibility-based polling - skips fetches when browser tab is hidden
- Reduce poll interval from 1s to 2s
- Add hash-based render check in TopologyGraph to prevent unnecessary D3 re-renders
- Add will-change CSS hints and prefers-reduced-motion support
- Pause all CSS animations when page is hidden

## Why It Works

The root cause was Svelte reactivity triggering full re-renders on every 1s poll, even when data hadn't changed. By comparing JSON before state assignment, Svelte's reactivity system is only triggered when something actually changed. The TopologyGraph hash check provides an additional guard against unnecessary D3 SVG redraws.

## Test Plan

### Manual Testing
Hardware: MacBook Pro
- Tested with **fake** nodes only, some more testing with real nodes would be nice @AlexCheema :)

### Automated Testing
N/A
