### PR TITLE
Fix: Pass missing KV cache constants to generation loop (#1036)

### DIFF
--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -12,7 +12,7 @@ from exo.shared.types.worker.runner_response import (
     GenerationResponse,
 )
 from exo.worker.engines.mlx import Model
-from exo.worker.engines.mlx.constants import KV_BITS, KV_GROUP_SIZE, MAX_TOKENS
+from exo.worker.engines.mlx.constants import KV_BITS, KV_GROUP_SIZE, MAX_TOKENS, MAX_KV_SIZE, KEEP_KV_SIZE
 from exo.worker.engines.mlx.utils_mlx import (
     apply_chat_template,
     make_kv_cache,
@@ -62,6 +62,8 @@ def warmup_inference(
 
     cache = make_kv_cache(
         model=model,
+        max_kv_size=MAX_KV_SIZE,
+        keep=KEEP_KV_SIZE or 0,
     )
 
     logger.info("Generating warmup tokens")
@@ -99,7 +101,7 @@ def mlx_generate(
         chat_task_data=task,
     )
 
-    caches = make_kv_cache(model=model)
+    caches = make_kv_cache(model=model,max_kv_size=MAX_KV_SIZE,keep=KEEP_KV_SIZE or 0)
 
     max_tokens = task.max_tokens or MAX_TOKENS
     for out in stream_generate(


### PR DESCRIPTION
Fixes #1036.

Currently, the memory management constants MAX_KV_SIZE and KEEP_KV_SIZE are defined in constants.py but are never passed to the make_kv_cache function in generate.py. This results in the model defaulting to an unlimited cache size, ignoring the defined safety limits and potentially causing Out-Of-Memory (OOM) errors during long-context generation.

**Changes**
Imports: Imported MAX_KV_SIZE and KEEP_KV_SIZE from exo.worker.engines.mlx.constants into generate.py.

**Logic Update:** Updated make_kv_cache calls in both warmup_inference and mlx_generate to explicitly pass these constants.

**Type Safety:** Added an or 0 fallback for keep_kv_size. This resolves a type mismatch where constants.py defines it as int | None but utils_mlx.py expects a strict int.

**Why It Works**
The make_kv_cache function in utils_mlx.py contains logic to initialize a RotatingKVCache (which enforces limits) only when max_kv_size is provided. By passing these arguments, we ensure the engine respects the memory constraints defined in the project constants instead of defaulting to an unbounded KVCache.

**Test Plan**
Manual Testing
Hardware: Windows / Code Inspection (No Apple Silicon available locally)

**Static Analysis:** Verified that the function signature in utils_mlx.py matches the arguments being passed.

**Type Checking:** Confirmed that KEEP_KV_SIZE or 0 correctly satisfies the type requirement for the keep parameter.

**Request for Reviewer:** Since I cannot run the mlx runtime locally, I request a reviewer with Apple Silicon to run a generation and verify the logs output: INFO: Using rotating KV cache... (confirming the arguments were received).

**Automated Testing**
N/A - This is a logic fix to ensure existing constants are utilized. Validated via static code analysis.