### PR TITLE
We shouldn't fail on an HTTPException in the tier-2 discovery system.

### DIFF
--- a/src/exo/worker/utils/net_profile.py
+++ b/src/exo/worker/utils/net_profile.py
@@ -32,6 +32,8 @@ async def check_reachability(
             return NodeId(body) or None
         except OSError:
             return None
+        except http.client.HTTPException:
+            return None
         finally:
             connection.close()
 


### PR DESCRIPTION
## Motivation

Fixed a crash we found

## Changes

try/catch return None if we get an exception instead of crashing exo

## Test Plan

### Manual Testing
Exo launches. Couldn't repro the original case this arose.

