### PR TITLE
nix: put treefmt in devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,9 @@
           packages =
             with pkgs;
             [
+              # FORMATTING
+              treefmtEval.config.build.wrapper
+
               # PYTHON
               python313
               uv


### PR DESCRIPTION
treefmt is a useful to be able to access directly for some formatters like `jj fix`. Expose it in the devshell.

Test plan:
- Used with `jj fix` on a large branch. It worked.