### PR TITLE
ci: add workflow_dispatch trigger to build-app

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1,6 +1,7 @@
 name: Build EXO macOS DMG
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*"
@@ -35,7 +36,7 @@ jobs:
 
       - name: Derive release version from tag
         run: |
-          if [[ "$GITHUB_REF_NAME" == "test-app" ]]; then
+          if [[ "$GITHUB_REF_NAME" == "test-app" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             VERSION="0.0.0-alpha.0"
             echo "IS_ALPHA=true" >> $GITHUB_ENV
           else


### PR DESCRIPTION
Build app is the most convenient way to get a DMG for testing, but currently it's a bit limited. You have to push to test-app every time which is far from ideal and requires a bit too much force pushing for my liking.

Add the workflow_dispatch trigger. This adds a button in the actions UI to trigger a workflow for a named branch, which means you can use your normal dev branch instead of having to push to test-app. We'll leave that behaviour there for now too, though it may change in future.

Filter on `"${{ github.event_name }}" == "workflow_dispatch"` and set those to alpha as well. Will verify by pushing the first version from `main` just in case. Unfortunately we do have to merge this before we can test it.

Test plan:
- Looking really hard.