### PR TITLE
nix: drop noisy echos from devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -131,9 +131,6 @@
                 export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
                 export LD_LIBRARY_PATH="${pkgs.openssl.out}/lib:$LD_LIBRARY_PATH"
               ''}
-              echo
-              echo "🍎🍎 Run 'just <recipe>' to get started"
-              just --list
             '';
           };
         };


### PR DESCRIPTION
Drop all the printing when entering a devshell. It's annoying, and not a super accurate description of how to develop exo anyway.