### PR TITLE
quiet rust logs

### DIFF
--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -29,6 +29,9 @@ class _InterceptHandler(logging.Handler):
 
 def logger_setup(log_file: Path | None, verbosity: int = 0):
     """Set up logging for this process - formatting, file handles, verbosity and output"""
+
+    logging.getLogger("exo_pyo3_bindings").setLevel(logging.WARNING)
+
     logger.remove()
 
     # replace all stdlib loggers with _InterceptHandlers that log to loguru


### PR DESCRIPTION
rust logs were too verbose - now only warnings propagate to python

entirely happy not to merge this and to clean up rust logging instead, but this felt saner right now

## tests
it works i swear pls