### PR TITLE
Split NodePerformanceProfile state storage into separate mappings

### DIFF
--- a/src/exo/master/api.py
+++ b/src/exo/master/api.py
@@ -600,9 +600,8 @@ class API:
         """Calculate total available memory across all nodes in bytes."""
         total_available = Memory()
 
-        for node in self.state.topology.list_nodes():
-            if node.node_profile is not None:
-                total_available += node.node_profile.memory.ram_available
+        for memory in self.state.node_memories.values():
+            total_available += memory.ram_available
 
         return total_available
 

--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -113,6 +113,7 @@ def place_instance(
                 node.node_profile.memory.ram_available
                 for node in cycle
                 if node.node_profile is not None
+                and node.node_profile.memory is not None
             ),
             start=Memory(),
         ),

--- a/src/exo/shared/types/profiling.py
+++ b/src/exo/shared/types/profiling.py
@@ -52,13 +52,21 @@ class NetworkInterfaceInfo(CamelCaseModel):
     ip_address: str
 
 
-class NodePerformanceProfile(CamelCaseModel):
+class NodeIdentity(CamelCaseModel):
+    """Static identity info for a node."""
+
     model_id: str
     chip_id: str
     friendly_name: str
-    memory: MemoryPerformanceProfile
+
+
+class NodePerformanceProfile(CamelCaseModel):
+    model_id: str | None = None
+    chip_id: str | None = None
+    friendly_name: str | None = None
+    memory: MemoryPerformanceProfile | None = None
     network_interfaces: list[NetworkInterfaceInfo] = []
-    system: SystemPerformanceProfile
+    system: SystemPerformanceProfile | None = None
 
 
 class ConnectionProfile(CamelCaseModel):

--- a/src/exo/shared/types/state.py
+++ b/src/exo/shared/types/state.py
@@ -7,7 +7,12 @@ from pydantic.alias_generators import to_camel
 
 from exo.shared.topology import Topology, TopologySnapshot
 from exo.shared.types.common import NodeId
-from exo.shared.types.profiling import NodePerformanceProfile
+from exo.shared.types.profiling import (
+    MemoryPerformanceProfile,
+    NetworkInterfaceInfo,
+    NodeIdentity,
+    SystemPerformanceProfile,
+)
 from exo.shared.types.tasks import Task, TaskId
 from exo.shared.types.worker.downloads import DownloadProgress
 from exo.shared.types.worker.instances import Instance, InstanceId
@@ -35,7 +40,10 @@ class State(CamelCaseModel):
     runners: Mapping[RunnerId, RunnerStatus] = {}
     downloads: Mapping[NodeId, Sequence[DownloadProgress]] = {}
     tasks: Mapping[TaskId, Task] = {}
-    node_profiles: Mapping[NodeId, NodePerformanceProfile] = {}
+    node_identities: Mapping[NodeId, NodeIdentity] = {}
+    node_memories: Mapping[NodeId, MemoryPerformanceProfile] = {}
+    node_systems: Mapping[NodeId, SystemPerformanceProfile] = {}
+    node_networks: Mapping[NodeId, list[NetworkInterfaceInfo]] = {}
     last_seen: Mapping[NodeId, datetime] = {}
     topology: Topology = Field(default_factory=Topology)
     last_event_applied_idx: int = Field(default=-1, ge=-1)

--- a/src/exo/worker/utils/__init__.py
+++ b/src/exo/worker/utils/__init__.py
@@ -1,6 +1,15 @@
-from .profile import start_polling_memory_metrics, start_polling_node_metrics
+from .profile import (
+    IdentityMetrics,
+    start_polling_identity_metrics,
+    start_polling_memory_metrics,
+    start_polling_network_metrics,
+    start_polling_system_metrics,
+)
 
 __all__ = [
-    "start_polling_node_metrics",
+    "IdentityMetrics",
+    "start_polling_identity_metrics",
     "start_polling_memory_metrics",
+    "start_polling_network_metrics",
+    "start_polling_system_metrics",
 ]


### PR DESCRIPTION
## Motivation

The monolithic `NodePerformanceProfile` stored all node profile data together, but the data comes from different events with different update frequencies:
- Identity (model_id, chip_id, friendly_name) - updated every 30s
- Memory - updated every 0.5s
- System (GPU, temp, power) - updated every 1s
- Network interfaces - updated every 30s

Storing all this in a single mapping meant every update replaced the entire profile object. This refactor splits the storage to match the event structure, making updates more efficient and the code cleaner.

**Dashboard responsiveness:** This makes the dashboard much more responsive - we can immediately show the device name, type, and memory as soon as those events arrive, while slower metrics like temperature and GPU utilization follow shortly after. Previously, we had to wait for all metrics before displaying anything useful.

**Prerequisite for memory bandwidth profiling:** This is also a necessary prerequisite for adding memory bandwidth profiling, which is quite slow to measure and would block other metrics if bundled together.

## Changes

**Python State:**
- Added `NodeIdentity` class to `profiling.py` with `model_id`, `chip_id`, `friendly_name`
- Replaced `node_profiles: Mapping[NodeId, NodePerformanceProfile]` in `state.py` with four separate mappings:
  - `node_identities: Mapping[NodeId, NodeIdentity]`
  - `node_memories: Mapping[NodeId, MemoryPerformanceProfile]`
  - `node_systems: Mapping[NodeId, SystemPerformanceProfile]`
  - `node_networks: Mapping[NodeId, list[NetworkInterfaceInfo]]`
- Rewrote apply functions in `apply.py` to write to their specific storage
- Added `_reconstruct_profile()` helper to rebuild `NodePerformanceProfile` for topology updates
- Updated `api.py` memory calculation to use `state.node_memories` directly

**Worker Polling:**
- Changed `emit_identity_metrics` to `start_polling_identity_metrics` - now polls every 30s instead of emitting once
- All metrics now follow the same pattern: emit immediately, then poll periodically

**Dashboard:**
- Removed `RawNodeProfile` interface entirely
- Added split state interfaces: `RawNodeIdentity`, `RawNodeMemory`, `RawNodeSystem`, `RawNetworkInterface`
- Updated `RawStateResponse` to include split fields
- Simplified `transformTopology()` to use split types directly with safe defaults for missing data

## Why It Works

Each apply function now updates only its specific mapping, and the topology still gets a reconstructed full profile for placement logic compatibility. The dashboard gracefully handles partial data (e.g., if memory hasn't arrived yet, it defaults to 0). All metrics are emitted immediately on startup and then polled periodically.

## Test Plan

### Manual Testing
<!-- Hardware: (e.g., MacBook Pro M1 Max 32GB, Mac Mini M2 16GB, connected via Thunderbolt 4) -->
<!-- What you did: -->
<!-- - -->

### Automated Testing
- Type checker passes: `uv run basedpyright` - 0 errors
- All tests pass: `uv run pytest` - 151 passed
- Dashboard builds successfully: `npm run build`