### PR TITLE
 Add proxy and custom SSL certificate support for corporate networks

### DIFF
--- a/src/exo/worker/download/download_utils.py
+++ b/src/exo/worker/download/download_utils.py
@@ -245,12 +245,15 @@ def create_http_session(
         sock_read_timeout = 1800
         sock_connect_timeout = 60
 
-    ssl_context = ssl.create_default_context(cafile=certifi.where())
+    ssl_context = ssl.create_default_context(
+        cafile=os.getenv("SSL_CERT_FILE") or certifi.where()
+    )
     connector = aiohttp.TCPConnector(ssl=ssl_context)
 
     return aiohttp.ClientSession(
         auto_decompress=auto_decompress,
         connector=connector,
+        proxy=os.getenv("HTTPS_PROXY") or os.getenv("HTTP_PROXY") or None,
         timeout=aiohttp.ClientTimeout(
             total=total_timeout,
             connect=connect_timeout,


### PR DESCRIPTION
Support HTTPS_PROXY/HTTP_PROXY environment variables for proxy configuration and SSL_CERT_FILE for custom CA certificates, enabling use in corporate environments with SSL inspection.

## Motivation
Users in corporate environments often need to route traffic through HTTP proxies and use custom CA certificates for SSL inspection. Without this support, exo cannot download models in these network configurations.

## Changes
 - Added `HTTPS_PROXY`/`HTTP_PROXY` environment variable support to `create_http_session()` in `download_utils.py`
 - Added `SSL_CERT_FILE` environment variable support for custom CA certificate bundles, falling back to certifi's default bundle

## Why It Works
 - `aiohttp.ClientSession` natively supports the `proxy` parameter for routing requests through HTTP proxies
 - `ssl.create_default_context(cafile=...)` accepts a custom CA bundle path, allowing corporate CAs to be trusted
 - Using environment variables is consistent with the codebase's existing configuration patterns (e.g., `EXO_HOME`, `HF_ENDPOINT`)

## Test Plan
### Manual Testing
 - Set `HTTPS_PROXY` environment variable and verified model downloads route through proxy
 - Set `SSL_CERT_FILE` to custom CA bundle and verified SSL verification succeeds with corporate SSL inspection

### Automated Testing
 - No automated tests added; this change is configuration-only and does not alter existing behavior when environment variables are unset
