### PR TITLE
NetworkSetupHelper: detect stale startup script content

### DIFF
--- a/app/EXO/EXO/Services/NetworkSetupHelper.swift
+++ b/app/EXO/EXO/Services/NetworkSetupHelper.swift
@@ -113,6 +113,13 @@ enum NetworkSetupHelper {
         let plistExists = manager.fileExists(atPath: plistDestination)
         guard scriptExists, plistExists else { return false }
         guard
+            let installedScript = try? String(contentsOfFile: scriptDestination, encoding: .utf8),
+            installedScript.trimmingCharacters(in: .whitespacesAndNewlines)
+                == setupScript.trimmingCharacters(in: .whitespacesAndNewlines)
+        else {
+            return false
+        }
+        guard
             let data = try? Data(contentsOf: URL(fileURLWithPath: plistDestination)),
             let plist = try? PropertyListSerialization.propertyList(
                 from: data, options: [], format: nil) as? [String: Any]


### PR DESCRIPTION
The daemonAlreadyInstalled() function checked that the startup script file existed and validated plist properties, but did not compare the actual script content. If the setupScript constant was updated in a new app version, the stale on-disk script would not be detected or replaced.

Added a guard clause that reads the installed script from disk and compares it against the expected setupScript content (with whitespace normalization). When content differs, the function returns false, triggering the reinstallation flow with an admin privileges prompt.

Test plan:
- Installed on a cluster that had the previous network config. Got the popup asking for permissions. After accepting I could run Kimi K2 Thinking Tensor RDMA on all 4 nodes.