### PR TITLE
dashboard: show model total size on downloads page for pending downloads

### DIFF
--- a/dashboard/src/routes/downloads/+page.svelte
+++ b/dashboard/src/routes/downloads/+page.svelte
@@ -172,6 +172,33 @@
   }
 
   let downloadOverview = $state<NodeEntry[]>([]);
+  let models = $state<Array<{ id: string; storage_size_megabytes?: number }>>(
+    [],
+  );
+
+  async function fetchModels() {
+    try {
+      const response = await fetch("/models");
+      if (response.ok) {
+        const data = await response.json();
+        models = data.data || [];
+      }
+    } catch (error) {
+      console.error("Failed to fetch models:", error);
+    }
+  }
+
+  function getModelTotalBytes(
+    modelId: string,
+    downloadTotalBytes: number,
+  ): number {
+    if (downloadTotalBytes > 0) return downloadTotalBytes;
+    const model = models.find((m) => m.id === modelId);
+    if (model?.storage_size_megabytes) {
+      return model.storage_size_megabytes * 1024 * 1024;
+    }
+    return 0;
+  }
 
   $effect(() => {
     try {
@@ -346,6 +373,7 @@
   onMount(() => {
     // Ensure we fetch at least once when visiting downloads directly
     refreshState();
+    fetchModels();
   });
 </script>
 
@@ -454,7 +482,7 @@
                     {#if model.status !== "completed"}
                       <div class="text-[11px] text-exo-light-gray font-mono">
                         {formatBytes(model.downloadedBytes)} / {formatBytes(
-                          model.totalBytes,
+                          getModelTotalBytes(model.modelId, model.totalBytes),
                         )}
                       </div>
                     {/if}


### PR DESCRIPTION
The downloads page showed "0B / 0B" for models that haven't started downloading yet because the download progress data only gets populated after the file list is fetched from HuggingFace.

Added a fetch to the /models API endpoint on page mount and created a helper function that falls back to storage_size_megabytes when the download's totalBytes is 0.

This allows users to see the actual model size (e.g., "0 / 25GB") before a download begins, which is helpful for a future feature that lets you download models explicitly.

Test plan:
- Deployed to a cluster, the previous 0B now show sensible values.

<img width="934" height="896" alt="image" src="https://github.com/user-attachments/assets/5c0f7027-13d3-4352-92d1-98f30d63ba59" />