### PR TITLE
Distribute model downloads via master

### DIFF
--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -6,8 +6,10 @@ from typing import AsyncIterator, Callable
 from loguru import logger
 
 from exo.download.download_utils import RepoDownloadProgress, download_shard
+from exo.download.node_address_book import NodeAddressBook
 from exo.download.shard_downloader import ShardDownloader
 from exo.shared.models.model_cards import MODEL_CARDS, ModelCard, ModelId
+from exo.shared.types.common import NodeId, SessionId
 from exo.shared.types.worker.shards import (
     PipelineShardMetadata,
     ShardMetadata,
@@ -17,6 +19,27 @@ from exo.shared.types.worker.shards import (
 def exo_shard_downloader(max_parallel_downloads: int = 8) -> ShardDownloader:
     return SingletonShardDownloader(
         CachedShardDownloader(ResumableShardDownloader(max_parallel_downloads))
+    )
+
+
+def exo_cluster_shard_downloader(
+    *,
+    node_id: NodeId,
+    session_id: SessionId,
+    node_address_book: NodeAddressBook,
+    model_store_port: int,
+    max_parallel_downloads: int = 8,
+) -> ShardDownloader:
+    return SingletonShardDownloader(
+        CachedShardDownloader(
+            ClusterAwareShardDownloader(
+                node_id=node_id,
+                session_id=session_id,
+                node_address_book=node_address_book,
+                model_store_port=model_store_port,
+                max_parallel_downloads=max_parallel_downloads,
+            )
+        )
     )
 
 
@@ -175,5 +198,113 @@ class ResumableShardDownloader(ShardDownloader):
     ) -> RepoDownloadProgress:
         _, progress = await download_shard(
             shard, self.on_progress_wrapper, skip_download=True
+        )
+        return progress
+
+
+class ClusterAwareShardDownloader(ShardDownloader):
+    """
+    A shard downloader that downloads from Hugging Face on the elected master node,
+    and from the master's model-store server on all other nodes.
+    """
+
+    def __init__(
+        self,
+        *,
+        node_id: NodeId,
+        session_id: SessionId,
+        node_address_book: NodeAddressBook,
+        model_store_port: int,
+        max_parallel_downloads: int = 8,
+    ) -> None:
+        self.node_id = node_id
+        self.session_id = session_id
+        self.node_address_book = node_address_book
+        self.model_store_port = model_store_port
+        self.max_parallel_downloads = max_parallel_downloads
+        self.on_progress_callbacks: list[
+            Callable[[ShardMetadata, RepoDownloadProgress], Awaitable[None]]
+        ] = []
+
+    def _resolve_model_store_endpoint(self) -> str | None:
+        if self.node_id == self.session_id.master_node_id:
+            return None
+
+        master_ipv4 = self.node_address_book.get_ipv4(self.session_id.master_node_id)
+        if master_ipv4 is None:
+            return None
+
+        return f"http://{master_ipv4}:{self.model_store_port}"
+
+    async def on_progress_wrapper(
+        self, shard: ShardMetadata, progress: RepoDownloadProgress
+    ) -> None:
+        for callback in self.on_progress_callbacks:
+            await callback(shard, progress)
+
+    def on_progress(
+        self,
+        callback: Callable[[ShardMetadata, RepoDownloadProgress], Awaitable[None]],
+    ) -> None:
+        self.on_progress_callbacks.append(callback)
+
+    async def ensure_shard(
+        self, shard: ShardMetadata, config_only: bool = False
+    ) -> Path:
+        allow_patterns = ["config.json"] if config_only else None
+        endpoint = self._resolve_model_store_endpoint()
+
+        if endpoint is None and self.node_id != self.session_id.master_node_id:
+            logger.warning(
+                "Model store endpoint unavailable; falling back to Hugging Face downloads."
+            )
+
+        target_dir, _ = await download_shard(
+            shard,
+            self.on_progress_wrapper,
+            max_parallel_downloads=self.max_parallel_downloads,
+            allow_patterns=allow_patterns,
+            endpoint=endpoint,
+            retry_on_not_found=(endpoint is not None),
+        )
+        return target_dir
+
+    async def get_shard_download_status(
+        self,
+    ) -> AsyncIterator[tuple[Path, RepoDownloadProgress]]:
+        async def _status_for_model(
+            model_id: ModelId,
+        ) -> tuple[Path, RepoDownloadProgress]:
+            shard = await build_full_shard(model_id)
+            endpoint = self._resolve_model_store_endpoint()
+            return await download_shard(
+                shard,
+                self.on_progress_wrapper,
+                skip_download=True,
+                endpoint=endpoint,
+                retry_on_not_found=(endpoint is not None),
+            )
+
+        tasks = [
+            asyncio.create_task(_status_for_model(model_card.model_id))
+            for model_card in MODEL_CARDS.values()
+        ]
+
+        for task in asyncio.as_completed(tasks):
+            try:
+                yield await task
+            except Exception as e:
+                logger.error("Error downloading shard:", e)
+
+    async def get_shard_download_status_for_shard(
+        self, shard: ShardMetadata
+    ) -> RepoDownloadProgress:
+        endpoint = self._resolve_model_store_endpoint()
+        _, progress = await download_shard(
+            shard,
+            self.on_progress_wrapper,
+            skip_download=True,
+            endpoint=endpoint,
+            retry_on_not_found=(endpoint is not None),
         )
         return progress

--- a/src/exo/download/model_store_server.py
+++ b/src/exo/download/model_store_server.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator, cast
+
+import aiofiles
+import aiofiles.os as aios
+import anyio
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import Response, StreamingResponse
+from hypercorn.asyncio import serve  # pyright: ignore[reportUnknownVariableType]
+from hypercorn.config import Config
+from hypercorn.typing import ASGIFramework
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, TypeAdapter
+
+from exo.download.download_utils import calc_hash
+from exo.shared.constants import EXO_MODELS_DIR
+from exo.shared.types.common import ModelId
+from exo.shared.types.worker.downloads import FileListEntry
+
+
+class ModelStoreFileMetadata(BaseModel):
+    etag: str
+    size: int
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+def _normalize_model_id(model_id: str) -> str:
+    return ModelId(model_id).normalize()
+
+
+def _model_dir(model_id: str) -> Path:
+    return EXO_MODELS_DIR / _normalize_model_id(model_id)
+
+
+def _safe_relative_path(rel_path: str) -> Path:
+    p = Path(rel_path)
+    if p.is_absolute() or ".." in p.parts:
+        raise HTTPException(status_code=400, detail="Invalid path")
+    return p
+
+
+def _metadata_root_dir(model_dir: Path) -> Path:
+    return model_dir / ".exo" / "download_metadata"
+
+
+def _metadata_path(model_dir: Path, rel_path: str) -> Path:
+    safe_rel = _safe_relative_path(rel_path)
+    return _metadata_root_dir(model_dir) / f"{safe_rel}.json"
+
+
+async def _read_metadata(model_dir: Path, rel_path: str) -> ModelStoreFileMetadata | None:
+    meta_path = _metadata_path(model_dir, rel_path)
+    if await aios.path.exists(meta_path):
+        async with aiofiles.open(meta_path, "r") as f:
+            return ModelStoreFileMetadata.model_validate_json(await f.read())
+    return None
+
+
+async def _write_metadata(
+    model_dir: Path, rel_path: str, metadata: ModelStoreFileMetadata
+) -> None:
+    meta_path = _metadata_path(model_dir, rel_path)
+    await aios.makedirs(meta_path.parent, exist_ok=True)
+    async with aiofiles.open(meta_path, "w") as f:
+        await f.write(metadata.model_dump_json())
+
+
+def _is_blocked_model_store_path(rel_path: str) -> bool:
+    safe_rel = _safe_relative_path(rel_path)
+    if safe_rel.parts and safe_rel.parts[0].startswith("."):
+        return True
+    return rel_path.endswith(".partial")
+
+
+async def _get_or_create_etag(model_dir: Path, rel_path: str, size: int) -> str:
+    existing = await _read_metadata(model_dir, rel_path)
+    if existing is not None and existing.size == size and existing.etag:
+        return existing.etag
+
+    # Fallback when no metadata exists (e.g. models downloaded before this feature).
+    # We use SHA-256 of file contents to keep client-side integrity checking intact.
+    file_path = model_dir / _safe_relative_path(rel_path)
+    etag = await calc_hash(file_path, hash_type="sha256")
+    await _write_metadata(model_dir, rel_path, ModelStoreFileMetadata(etag=etag, size=size))
+    return etag
+
+
+def _parse_range_header(range_header: str, size: int) -> tuple[int, int]:
+    # We only support a single bytes-range.
+    if not range_header.startswith("bytes="):
+        raise HTTPException(status_code=416, detail="Invalid Range header")
+    raw = range_header.removeprefix("bytes=").strip()
+    if "," in raw:
+        raise HTTPException(status_code=416, detail="Multiple ranges not supported")
+
+    start_s, end_s = (raw.split("-", 1) + [""])[:2]
+    if not start_s:
+        raise HTTPException(status_code=416, detail="Suffix ranges not supported")
+
+    try:
+        start = int(start_s)
+    except ValueError as exc:
+        raise HTTPException(status_code=416, detail="Invalid Range header") from exc
+
+    end: int
+    if end_s:
+        try:
+            end = int(end_s)
+        except ValueError as exc:
+            raise HTTPException(status_code=416, detail="Invalid Range header") from exc
+    else:
+        end = size - 1
+
+    if start < 0 or start >= size:
+        raise HTTPException(status_code=416, detail="Range start out of bounds")
+    if end < start:
+        raise HTTPException(status_code=416, detail="Invalid Range header")
+    end = min(end, size - 1)
+    return start, end
+
+
+async def _stream_file_range(
+    path: Path,
+    *,
+    start: int,
+    end_inclusive: int,
+    chunk_size: int = 8 * 1024 * 1024,
+) -> AsyncIterator[bytes]:
+    remaining = end_inclusive - start + 1
+    async with aiofiles.open(path, "rb") as f:
+        await f.seek(start)
+        while remaining > 0:
+            chunk = await f.read(min(chunk_size, remaining))
+            if not chunk:
+                break
+            remaining -= len(chunk)
+            yield chunk
+
+
+async def _walk_model_dir_for_files(model_dir: Path) -> list[FileListEntry]:
+    def _walk_sync() -> list[FileListEntry]:
+        out: list[FileListEntry] = []
+        for p in model_dir.rglob("*"):
+            if not p.is_file():
+                continue
+            rel = p.relative_to(model_dir).as_posix()
+            if _is_blocked_model_store_path(rel):
+                continue
+            out.append(FileListEntry(type="file", path=rel, size=p.stat().st_size))
+        return out
+
+    return await asyncio.to_thread(_walk_sync)
+
+
+class ModelStoreServer:
+    """
+    A lightweight HTTP server that exposes a HuggingFace-like subset of endpoints
+    backed by a local on-disk model cache.
+
+    It is intended for intra-cluster use so that only one node (the master) needs
+    to download from Hugging Face, while other nodes fetch model files over the
+    local network.
+    """
+
+    def __init__(self, *, port: int) -> None:
+        self.port = port
+        self.app = FastAPI()
+        self._setup_routes()
+
+    def _setup_routes(self) -> None:
+        self.app.get("/api/models/{model_id:path}/tree/{revision}")(self.tree)
+        self.app.get("/api/models/{model_id:path}/tree/{revision}/{subpath:path}")(
+            self.tree
+        )
+        self.app.head("/{model_id:path}/resolve/{revision}/{file_path:path}")(
+            self.head_resolve
+        )
+        self.app.get("/{model_id:path}/resolve/{revision}/{file_path:path}")(
+            self.get_resolve
+        )
+
+    async def tree(
+        self, model_id: str, revision: str, subpath: str = ""
+    ) -> list[FileListEntry]:
+        normalized_model_id = _normalize_model_id(model_id)
+        cache_file = (
+            EXO_MODELS_DIR
+            / "caches"
+            / normalized_model_id
+            / f"{normalized_model_id}--{revision}--file_list.json"
+        )
+        if await aios.path.exists(cache_file):
+            async with aiofiles.open(cache_file, "r") as f:
+                files = TypeAdapter(list[FileListEntry]).validate_json(await f.read())
+        else:
+            model_dir = _model_dir(model_id)
+            if not await aios.path.exists(model_dir):
+                raise HTTPException(status_code=404, detail="Model not found")
+            files = await _walk_model_dir_for_files(model_dir)
+
+        if subpath:
+            prefix = subpath.rstrip("/") + "/"
+            files = [f for f in files if f.path.startswith(prefix)]
+
+        return files
+
+    async def head_resolve(self, model_id: str, revision: str, file_path: str) -> Response:
+        _ = revision  # revision is currently informational only
+        if _is_blocked_model_store_path(file_path):
+            raise HTTPException(status_code=404, detail="File not found")
+
+        model_dir = _model_dir(model_id)
+        local_path = model_dir / _safe_relative_path(file_path)
+        if not await aios.path.exists(local_path):
+            raise HTTPException(status_code=404, detail="File not found")
+
+        size = (await aios.stat(local_path)).st_size
+        etag = await _get_or_create_etag(model_dir, file_path, size)
+
+        return Response(
+            status_code=200,
+            headers={
+                "Content-Length": str(size),
+                "ETag": etag,
+                "Accept-Ranges": "bytes",
+            },
+        )
+
+    async def get_resolve(
+        self, request: Request, model_id: str, revision: str, file_path: str
+    ) -> StreamingResponse:
+        _ = revision  # revision is currently informational only
+        if _is_blocked_model_store_path(file_path):
+            raise HTTPException(status_code=404, detail="File not found")
+
+        model_dir = _model_dir(model_id)
+        local_path = model_dir / _safe_relative_path(file_path)
+        if not await aios.path.exists(local_path):
+            raise HTTPException(status_code=404, detail="File not found")
+
+        size = (await aios.stat(local_path)).st_size
+        etag = await _get_or_create_etag(model_dir, file_path, size)
+
+        range_header = request.headers.get("range")
+        if range_header:
+            start, end = _parse_range_header(range_header, size)
+            content_length = end - start + 1
+            headers = {
+                "Content-Length": str(content_length),
+                "Content-Range": f"bytes {start}-{end}/{size}",
+                "ETag": etag,
+                "Accept-Ranges": "bytes",
+            }
+            return StreamingResponse(
+                _stream_file_range(local_path, start=start, end_inclusive=end),
+                status_code=206,
+                headers=headers,
+                media_type="application/octet-stream",
+            )
+
+        headers = {
+            "Content-Length": str(size),
+            "ETag": etag,
+            "Accept-Ranges": "bytes",
+        }
+        return StreamingResponse(
+            _stream_file_range(local_path, start=0, end_inclusive=size - 1),
+            status_code=200,
+            headers=headers,
+            media_type="application/octet-stream",
+        )
+
+    async def run(self) -> None:
+        cfg = Config()
+        cfg.bind = f"0.0.0.0:{self.port}"
+        cfg.accesslog = None
+        cfg.errorlog = "-"
+
+        logger.info(f"Starting model store server on :{self.port}")
+        await serve(
+            cast(ASGIFramework, self.app),
+            cfg,
+            shutdown_trigger=lambda: anyio.sleep_forever(),
+        )
+

--- a/src/exo/download/node_address_book.py
+++ b/src/exo/download/node_address_book.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from exo.shared.types.common import NodeId
+
+
+@dataclass
+class NodeAddressBook:
+    """
+    Tracks the most recently observed IPv4 address for each node.
+
+    This is populated from libp2p connection updates (via :class:`ConnectionMessage`)
+    and is used for local-network services (e.g. model distribution).
+    """
+
+    ipv4_by_node_id: dict[NodeId, str] = field(default_factory=dict)
+
+    def set_ipv4(self, node_id: NodeId, ipv4: str) -> None:
+        self.ipv4_by_node_id[node_id] = ipv4
+
+    def remove(self, node_id: NodeId) -> None:
+        self.ipv4_by_node_id.pop(node_id, None)
+
+    def get_ipv4(self, node_id: NodeId) -> str | None:
+        return self.ipv4_by_node_id.get(node_id)
+

--- a/src/exo/download/tests/test_download_utils_retry.py
+++ b/src/exo/download/tests/test_download_utils_retry.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+import exo.download.download_utils as download_utils
+from exo.shared.types.common import ModelId
+
+
+async def test_download_file_with_retry_retries_file_not_found(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: int = 0
+
+    async def fake_download_file(
+        model_id: ModelId,
+        revision: str,
+        path: str,
+        target_dir: Path,
+        on_progress: Callable[[int, int, bool], None],
+        *,
+        endpoint: str | None = None,
+    ) -> Path:
+        _ = endpoint
+        _ = on_progress
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise FileNotFoundError("Not ready yet")
+        return target_dir / path
+
+    async def fast_sleep(_: float) -> None: ...
+
+    monkeypatch.setattr(download_utils, "_download_file", fake_download_file)
+    monkeypatch.setattr(download_utils.asyncio, "sleep", fast_sleep)
+
+    out = await download_utils.download_file_with_retry(
+        model_id=ModelId("foo/bar"),
+        revision="main",
+        path="config.json",
+        target_dir=tmp_path,
+        retry_on_not_found=True,
+    )
+    assert out == tmp_path / "config.json"
+    assert calls == 3
+
+
+async def test_download_file_with_retry_does_not_retry_file_not_found_by_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: int = 0
+
+    async def fake_download_file(
+        model_id: ModelId,
+        revision: str,
+        path: str,
+        target_dir: Path,
+        on_progress: Callable[[int, int, bool], None],
+        *,
+        endpoint: str | None = None,
+    ) -> Path:
+        _ = endpoint
+        _ = on_progress
+        _ = target_dir
+        _ = model_id
+        _ = revision
+        _ = path
+        nonlocal calls
+        calls += 1
+        raise FileNotFoundError("Missing")
+
+    monkeypatch.setattr(download_utils, "_download_file", fake_download_file)
+
+    with pytest.raises(FileNotFoundError):
+        await download_utils.download_file_with_retry(
+            model_id=ModelId("foo/bar"),
+            revision="main",
+            path="config.json",
+            target_dir=tmp_path,
+        )
+    assert calls == 1
+

--- a/src/exo/download/tests/test_model_store_server.py
+++ b/src/exo/download/tests/test_model_store_server.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import httpx
+import pytest
+from pydantic import TypeAdapter
+
+from exo.download.model_store_server import ModelStoreServer
+from exo.shared.types.common import ModelId
+from exo.shared.types.worker.downloads import FileListEntry
+
+
+async def test_model_store_tree_and_resolve_supports_range(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    models_dir = tmp_path / "models"
+    models_dir.mkdir(parents=True, exist_ok=True)
+
+    import exo.download.model_store_server as model_store_server
+    import exo.shared.constants as constants
+
+    monkeypatch.setattr(constants, "EXO_MODELS_DIR", models_dir)
+    monkeypatch.setattr(model_store_server, "EXO_MODELS_DIR", models_dir)
+
+    model_id = "foo/bar"
+    normalized = ModelId(model_id).normalize()
+    model_dir = models_dir / normalized
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    content = b"hello world"
+    (model_dir / "config.json").write_bytes(content)
+
+    server = ModelStoreServer(port=0)
+    transport = httpx.ASGITransport(app=server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        tree_res = await client.get(f"/api/models/{model_id}/tree/main")
+        assert tree_res.status_code == 200
+        files = TypeAdapter(list[FileListEntry]).validate_json(tree_res.text)
+        assert any(f.path == "config.json" for f in files)
+
+        head_res = await client.head(f"/{model_id}/resolve/main/config.json")
+        assert head_res.status_code == 200
+        assert head_res.headers["content-length"] == str(len(content))
+        assert head_res.headers["etag"] == hashlib.sha256(content).hexdigest()
+
+        range_res = await client.get(
+            f"/{model_id}/resolve/main/config.json",
+            headers={"Range": "bytes=1-3"},
+        )
+        assert range_res.status_code == 206
+        assert range_res.content == content[1:4]
+        assert range_res.headers["content-range"] == f"bytes 1-3/{len(content)}"
+
+
+async def test_model_store_blocks_metadata_and_partial_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    models_dir = tmp_path / "models"
+    models_dir.mkdir(parents=True, exist_ok=True)
+
+    import exo.download.model_store_server as model_store_server
+    import exo.shared.constants as constants
+
+    monkeypatch.setattr(constants, "EXO_MODELS_DIR", models_dir)
+    monkeypatch.setattr(model_store_server, "EXO_MODELS_DIR", models_dir)
+
+    model_id = "foo/bar"
+    normalized = ModelId(model_id).normalize()
+    model_dir = models_dir / normalized
+    (model_dir / ".exo" / "download_metadata").mkdir(parents=True, exist_ok=True)
+
+    (model_dir / ".exo" / "download_metadata" / "secret.json").write_text("nope")
+    (model_dir / "weights.safetensors.partial").write_bytes(b"partial")
+
+    server = ModelStoreServer(port=0)
+    transport = httpx.ASGITransport(app=server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        res1 = await client.get(
+            f"/{model_id}/resolve/main/.exo/download_metadata/secret.json"
+        )
+        assert res1.status_code == 404
+
+        res2 = await client.get(f"/{model_id}/resolve/main/weights.safetensors.partial")
+        assert res2.status_code == 404
+


### PR DESCRIPTION
## Summary
- Add a master-only model-store server (HuggingFace-like `tree` + `resolve` w/ Range) to serve cached model files over the LAN.
- Make shard downloads cluster-aware: master downloads from Hugging Face; non-master nodes fetch from the master’s model-store endpoint (retrying while files are still being downloaded).
- When a worker needs a model, it also triggers a download on the elected master so other nodes can pull locally.

## Config
- `--model-store-port` (default: 52416)

## Why
Reduces redundant internet downloads in multi-node clusters while keeping existing download integrity checks.

Closes #1257

## Test plan
- `uv run pytest -q`
- `uv run ruff check ...`
- `uv run basedpyright`