### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.vscode/
+.githooks/
+.github/
+.idea/
+.zed/
+target/

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,27 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            exo/exo:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:latest
+EXPOSE 52415
+ENV CARGO_HOME=/usr/local/cargo
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV PATH=/usr/local/cargo/bin:$PATH
+WORKDIR /home/exo
+COPY --from=rust:latest /usr/local/cargo /usr/local/cargo
+COPY --from=rust:latest /usr/local/rustup /usr/local/rustup
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY . . 
+RUN rustup toolchain install nightly && uv sync
+WORKDIR /home/exo/dashboard
+RUN npm install && npm run build
+WORKDIR /home/exo
+CMD [ "uv", "run", "exo" ]

--- a/README.md
+++ b/README.md
@@ -73,18 +73,21 @@ There are two ways to run exo:
 ### Run from Source (macOS)
 
 **Prerequisites:**
+
 - [brew](https://github.com/Homebrew/brew) (for simple package management on macOS)
-  
+
   ```bash
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   ```
+
 - [uv](https://github.com/astral-sh/uv) (for Python dependency management)
 - [macmon](https://github.com/vladkens/macmon) (for hardware monitoring on Apple Silicon)
 - [node](https://github.com/nodejs/node) (for building the dashboard)
-  
+
   ```bash
   brew install uv macmon node
   ```
+
 - [rust](https://github.com/rust-lang/rustup) (to build Rust bindings, nightly for now)
 
   ```bash
@@ -118,6 +121,7 @@ This starts the exo dashboard and API at http://localhost:52415/
 **Installation methods:**
 
 **Option 1: Using system package manager (Ubuntu/Debian example):**
+
 ```bash
 # Install Node.js and npm
 sudo apt update
@@ -132,6 +136,7 @@ rustup toolchain install nightly
 ```
 
 **Option 2: Using Homebrew on Linux (if preferred):**
+
 ```bash
 # Install Homebrew on Linux
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -181,6 +186,12 @@ exo follows the [XDG Base Directory Specification](https://specifications.freede
 
 You can override these locations by setting the corresponding XDG environment variables.
 
+### Run in Docker
+
+```bash
+docker run --gpus=all -v /.config/exo:/.config/exo/ -v /.local/share/exo/:/.local/share/exo/ -v /.cache/exo/:/.cache/exo/ -p 52415:52145 exo/exo:latest # or --privileged instead of --gpus=all to pass through all devices
+```
+
 ### macOS App
 
 exo ships a macOS app that runs in the background on your Mac.
@@ -217,6 +228,7 @@ sudo ./app/EXO/uninstall-exo.sh
 ```
 
 This removes:
+
 - Network setup LaunchDaemon
 - Network configuration script
 - Log files
@@ -302,7 +314,6 @@ curl -X POST http://localhost:52415/instance \
   }'
 ```
 
-
 Sample response:
 
 ```json
@@ -340,7 +351,7 @@ When you're done, delete the instance by its ID (find it via `/state` or `/insta
 curl -X DELETE http://localhost:52415/instance/YOUR_INSTANCE_ID
 ```
 
-**Other useful API endpoints*:**
+**Other useful API endpoints\*:**
 
 - List all models: `curl http://localhost:52415/models`
 - Inspect instance IDs and deployment state: `curl http://localhost:52415/state`
@@ -357,6 +368,7 @@ For further details, see:
 The `exo-bench` tool measures model prefill and token generation speed across different placement configurations. This helps you optimize model performance and validate improvements.
 
 **Prerequisites:**
+
 - Nodes should be running with `uv run exo` before benchmarking
 - The tool uses the `/bench/chat/completions` endpoint
 


### PR DESCRIPTION
## Motivation

Some people, and I as well, wanted to run the exo in the Docker image to virtualize the whole environment. Here in this PR, you can find the Dockerfile, and GitHub CI workflow, which build and publish the image to Dockerhub. The repository owner has to provide secrets to make it work.

Related issue: https://github.com/exo-explore/exo/issues/999

## Changes

- Added Dockerfile
- Added .dockerignore
- Added workflow to build and publish image to the Dockerhub
- Added instructions to the README.md, how to use the Docker image and formatted the README.md file 

## Test Plan

Idk, I'm not familiar with this repo. Maybe someone else will figure it out, how it can be tested in the complex way. I run that locally, and everything works as it should. Only the workflow is totally untested.

### Manual Testing

Anything that runs Docker, and can run any model. I run that on Windows 11 with WSL2, Docker, 128gb of ram, and an RTX 4090. 

### Automated Testing

If it fails, then it fails on the Docker build stage in CI.

## Additionial stuff

Please edit the target branch. I have set main, and I highly believe it shouldn't go to main