### PR TITLE
fix(networking): use milliseconds for mDNS TTL values

### DIFF
--- a/rust/networking/src/discovery.rs
+++ b/rust/networking/src/discovery.rs
@@ -30,8 +30,8 @@ mod managed {
     use std::io;
     use std::time::Duration;
 
-    const MDNS_RECORD_TTL: Duration = Duration::from_secs(2_500);
-    const MDNS_QUERY_INTERVAL: Duration = Duration::from_secs(1_500);
+    const MDNS_RECORD_TTL: Duration = Duration::from_millis(2_500);
+    const MDNS_QUERY_INTERVAL: Duration = Duration::from_millis(1_500);
     const PING_TIMEOUT: Duration = Duration::from_millis(2_500);
     const PING_INTERVAL: Duration = Duration::from_millis(2_500);
 


### PR DESCRIPTION
## Summary
Fix for issue #1043 - Nodes don't discover each other over Thunderbolt 5 after restart.

## The Bug
The `MDNS_RECORD_TTL` and `MDNS_QUERY_INTERVAL` constants were using `Duration::from_secs()` when they should have been using `Duration::from_millis()`.

```rust
// Before (WRONG - 41 minutes and 25 minutes!)
const MDNS_RECORD_TTL: Duration = Duration::from_secs(2_500);
const MDNS_QUERY_INTERVAL: Duration = Duration::from_secs(1_500);

// After (CORRECT - 2.5 seconds and 1.5 seconds)
const MDNS_RECORD_TTL: Duration = Duration::from_millis(2_500);
const MDNS_QUERY_INTERVAL: Duration = Duration::from_millis(1_500);
```

## Root Cause
When exo restarts, it gets a new OS-assigned listening port. But with a 41-minute mDNS TTL, other nodes still have the old port cached. They try to connect to the dead port, causing "Address already in use" errors.

## Evidence
The `PING_TIMEOUT` and `PING_INTERVAL` constants on adjacent lines correctly use `from_millis(2_500)`, confirming the intended unit was milliseconds.

## Testing
With this fix, mDNS records expire in 2.5 seconds instead of 41 minutes, so after restart nodes quickly discover the new listening ports.

Fixes #1043