### PR TITLE
fix(packaging): add missing stdlib modules to PyInstaller spec

### DIFF
--- a/packaging/pyinstaller/exo.spec
+++ b/packaging/pyinstaller/exo.spec
@@ -53,6 +53,13 @@ HIDDEN_IMPORTS = sorted(
         collect_submodules("mlx")
         + _safe_collect("mlx_lm")
         + _safe_collect("transformers")
+        + [
+            # Standard library modules required by torch that PyInstaller may miss
+            "timeit",
+            "cProfile",
+            "pstats",
+            "profile",
+        ]
     )
 )
 


### PR DESCRIPTION
## Summary
Fix for bundled EXO.app failing to run distributed inference due to missing Python standard library modules.

## The Bug
When running multi-node inference with the bundled EXO.app, remote runners crash with:
```
ModuleNotFoundError: No module named 'timeit'
```

The error occurs in:
```
torch/_strobelight/cli_function_profiler.py:11
    from timeit import default_timer as timer
```

## Root Cause
PyInstaller's dependency analysis doesn't capture all standard library modules that torch uses at runtime. The `timeit` module (and related profiling modules) are imported dynamically by torch's strobelight profiler.

## The Fix
Add missing stdlib modules to `HIDDEN_IMPORTS` in the PyInstaller spec:
- `timeit`
- `cProfile`
- `pstats`  
- `profile`

## Testing
This was discovered while testing multi-node pipeline/tensor parallelism on a 4x M3 Ultra cluster. Single-node inference works fine, but distributed inference fails because the remote runners crash when trying to import timeit.

## Impact
**Without this fix:** Multi-node inference is completely broken in bundled releases (v1.0.62+).
**With this fix:** Distributed inference should work across multiple Mac Studios.