### PR TITLE
nix: add macmon to PATH in wrapper scripts on Darwin

### DIFF
--- a/python/parts.nix
+++ b/python/parts.nix
@@ -69,7 +69,8 @@
           # Create wrapper scripts
           for script in exo exo-master exo-worker; do
             makeWrapper ${exoVenv}/bin/$script $out/bin/$script \
-              --set DASHBOARD_DIR ${self'.packages.dashboard}
+              --set DASHBOARD_DIR ${self'.packages.dashboard} \
+              ${lib.optionalString pkgs.stdenv.isDarwin "--prefix PATH : ${pkgs.macmon}/bin"}
           done
         '';
     in


### PR DESCRIPTION
`nix run .#exo` couldn't find `macmon` because the Nix wrapper scripts didn't include it in PATH, causing `shutil.which("macmon")` to fail.

Added `--prefix PATH : ${pkgs.macmon}/bin` to the `makeWrapper` call, conditional on Darwin via `lib.optionalString`, so macmon's binary is available at runtime without modifying the user's system PATH.

Test plan:
- Verified `nix build .#exo` succeeds
- Checked wrapper script contains macmon store path in PATH prefix
