### PR TITLE
Update exo bench

### DIFF
--- a/bench/exo_bench.py
+++ b/bench/exo_bench.py
@@ -472,7 +472,9 @@ def main() -> int:
     # Log pairing mode
     use_combinations = args.all_combinations or len(pp_list) != len(tg_list)
     if use_combinations:
-        logger.info(f"pp/tg mode: combinations (product) - {len(pp_list) * len(tg_list)} pairs")
+        logger.info(
+            f"pp/tg mode: combinations (product) - {len(pp_list) * len(tg_list)} pairs"
+        )
     else:
         logger.info(f"pp/tg mode: tandem (zip) - {len(pp_list)} pairs")
 


### PR DESCRIPTION
## Motivation

Make exo bench faster for longer prompts, lengthen default timeouts and use pairs for pp and tg.

## Changes

- Uses binary search to find correct prompt
- Flag to force all combinations if that is desired

