### PR TITLE
feat: add Downloaded filter to model picker

### DIFF
--- a/dashboard/src/lib/components/ModelFilterPopover.svelte
+++ b/dashboard/src/lib/components/ModelFilterPopover.svelte
@@ -5,6 +5,7 @@
   interface FilterState {
     capabilities: string[];
     sizeRange: { min: number; max: number } | null;
+    downloadedOnly: boolean;
   }
 
   type ModelFilterPopoverProps = {
@@ -146,6 +147,36 @@
           </button>
         {/each}
       </div>
+    </div>
+
+    <!-- Downloaded only -->
+    <div>
+      <h4 class="text-xs font-mono text-white/50 mb-2">Availability</h4>
+      <button
+        type="button"
+        class="px-2 py-1 text-xs font-mono rounded transition-colors {filters.downloadedOnly
+          ? 'bg-green-500/20 text-green-400 border border-green-500/30'
+          : 'bg-white/5 text-white/60 hover:bg-white/10 border border-transparent'}"
+        onclick={() =>
+          onChange({ ...filters, downloadedOnly: !filters.downloadedOnly })}
+      >
+        <svg
+          class="w-3.5 h-3.5 inline-block"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path
+            class="text-white/40"
+            d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"
+          />
+          <path class="text-green-400" d="m9 13 2 2 4-4" />
+        </svg>
+        <span class="ml-1">Downloaded</span>
+      </button>
     </div>
 
     <!-- Size range -->


### PR DESCRIPTION
## Motivation

Users with many models in the picker want a quick way to see only models that are already downloaded and ready to run, without scrolling through the full list.

## Changes

- **ModelFilterPopover.svelte**: Added `downloadedOnly: boolean` to `FilterState`. Added a "Downloaded" toggle button in a new "Availability" section between Capabilities and Model Size. Uses green styling to distinguish from other filters.
- **ModelPickerModal.svelte**: Added `downloadedOnly` filter logic to `filteredGroups` — when active, groups are filtered to only those with at least one variant that has `DownloadCompleted` entries on any node. Updated `clearFilters`, `hasActiveFilters`, and the footer badge display.

## Why It Works

This builds on the `modelDownloadAvailability` map already computed in PR #1377. The filter simply checks if any variant in a group has a non-empty `nodeIds` list in that map, meaning the model has been fully downloaded on at least one node.

## Test Plan

### Manual Testing
- Open model picker, open filter popover
- Click "Downloaded" toggle — verify only downloaded models remain
- Verify the green "Downloaded" badge appears in the footer
- Click "Clear all filters" — verify all models reappear
- Combine with other filters (e.g., Downloaded + Vision) — verify intersection works

### Automated Testing
- Dashboard builds successfully (`npm run build`)

> **Note:** Chained PR. Base branch is `alexcheema/model-picker-download-availability` (#1377).

🤖 Generated with [Claude Code](https://claude.com/claude-code)