### PR TITLE
Tokenizer loading: replace model-id matching with architecture fingerprints

### DIFF
--- a/src/exo/worker/engines/mlx/model_fingerprint.py
+++ b/src/exo/worker/engines/mlx/model_fingerprint.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+
+@dataclass(frozen=True)
+class ModelFingerprint:
+    """Lightweight fingerprint derived from local `config.json`."""
+
+    model_type: str | None = None
+    architectures: tuple[str, ...] = ()
+    tokenizer_class: str | None = None
+
+
+def load_model_fingerprint(model_path: Path) -> ModelFingerprint:
+    """Parse `config.json` from the local model directory.
+
+    Some models embed relevant fields under `text_config`. We prefer those values
+    when present to avoid special-casing at call sites.
+    """
+
+    config_path = model_path / "config.json"
+    try:
+        raw = json.loads(config_path.read_text())
+    except FileNotFoundError:
+        return ModelFingerprint()
+    except Exception as e:
+        logger.debug(f"Failed to parse config.json at {config_path}: {e}")
+        return ModelFingerprint()
+
+    if not isinstance(raw, dict):
+        return ModelFingerprint()
+
+    data: dict[str, Any] = dict(raw)
+    text_config = data.get("text_config")
+    if isinstance(text_config, dict):
+        for key in ("architectures", "model_type", "tokenizer_class"):
+            if (val := text_config.get(key)) is not None:
+                data[key] = val
+
+    model_type = data.get("model_type")
+    if isinstance(model_type, str):
+        model_type = model_type.strip() or None
+    else:
+        model_type = None
+
+    tokenizer_class = data.get("tokenizer_class")
+    if isinstance(tokenizer_class, str):
+        tokenizer_class = tokenizer_class.strip() or None
+    else:
+        tokenizer_class = None
+
+    arch_raw = data.get("architectures")
+    architectures: tuple[str, ...] = ()
+    if isinstance(arch_raw, list):
+        architectures = tuple(a for a in arch_raw if isinstance(a, str))
+
+    return ModelFingerprint(
+        model_type=model_type,
+        architectures=architectures,
+        tokenizer_class=tokenizer_class,
+    )
+
+
+def is_kimi_tokenizer_repo(model_path: Path) -> bool:
+    """Detect Kimi-style repos by the presence of custom tokenizer code."""
+
+    return (model_path / "tokenization_kimi.py").exists()
+
+
+def is_gemma3(fingerprint: ModelFingerprint) -> bool:
+    model_type = (fingerprint.model_type or "").lower()
+    if model_type.startswith("gemma3"):
+        return True
+    return any("gemma3" in arch.lower() for arch in fingerprint.architectures)
+
+
+def is_glm(fingerprint: ModelFingerprint) -> bool:
+    model_type = (fingerprint.model_type or "").lower()
+    if model_type.startswith("glm"):
+        return True
+    # GLM model architectures commonly use Glm* or ChatGLM* naming.
+    return any(
+        arch.lower().startswith("glm") or "chatglm" in arch.lower()
+        for arch in fingerprint.architectures
+    )
+

--- a/src/exo/worker/engines/mlx/tokenizer_patches.py
+++ b/src/exo/worker/engines/mlx/tokenizer_patches.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from loguru import logger
+
+GLM_EOS_TOKENS: tuple[str, ...] = (
+    "<|endoftext|>",
+    "<|user|>",
+    "<|assistant|>",
+    "<|observation|>",
+)
+GEMMA_END_OF_TURN_TOKEN = "<end_of_turn>"
+
+
+def _get_underlying_tokenizer(tokenizer_wrapper: Any) -> Any:
+    # mlx_lm.TokenizerWrapper commonly exposes the HF tokenizer via `.tokenizer`
+    # or `._tokenizer`. Fall back to the wrapper itself.
+    for attr in ("tokenizer", "_tokenizer"):
+        tok = getattr(tokenizer_wrapper, attr, None)
+        if tok is not None:
+            return tok
+    return tokenizer_wrapper
+
+
+def try_resolve_token_id(tokenizer_wrapper: Any, token: str) -> int | None:
+    """Best-effort mapping from token string to token id.
+
+    Returns None when the token cannot be resolved.
+    """
+
+    tok = _get_underlying_tokenizer(tokenizer_wrapper)
+
+    # Prefer vocab lookups where available.
+    try:
+        vocab = tok.get_vocab() if hasattr(tok, "get_vocab") else None
+        if isinstance(vocab, dict):
+            tid = vocab.get(token)
+            if isinstance(tid, int):
+                return tid
+    except Exception:
+        pass
+
+    # Fall back to tokenizer method.
+    try:
+        if hasattr(tok, "convert_tokens_to_ids"):
+            tid = tok.convert_tokens_to_ids(token)
+            if isinstance(tid, int):
+                # Some tokenizers return unk_token_id for unknown tokens.
+                unk_id = getattr(tok, "unk_token_id", None)
+                if isinstance(unk_id, int) and tid == unk_id:
+                    return None
+                return tid
+    except Exception:
+        pass
+
+    return None
+
+
+def extend_eos_token_ids(tokenizer_wrapper: Any, extra_ids: Iterable[int]) -> None:
+    extras = [i for i in extra_ids if isinstance(i, int)]
+    if not extras:
+        return
+
+    current = getattr(tokenizer_wrapper, "eos_token_ids", None)
+    current_list: list[int] = []
+    if isinstance(current, (list, tuple)):
+        current_list = [i for i in current if isinstance(i, int)]
+
+    seen: set[int] = set()
+    merged: list[int] = []
+    for i in current_list + extras:
+        if i in seen:
+            continue
+        seen.add(i)
+        merged.append(i)
+
+    setattr(tokenizer_wrapper, "eos_token_ids", merged)
+    logger.debug(f"Patched eos_token_ids={merged}")
+
+
+def extend_eos_token_ids_by_token_strings(
+    tokenizer_wrapper: Any, token_strings: Iterable[str]
+) -> None:
+    token_ids: list[int] = []
+    for token in token_strings:
+        tid = try_resolve_token_id(tokenizer_wrapper, token)
+        if tid is not None:
+            token_ids.append(tid)
+
+    extend_eos_token_ids(tokenizer_wrapper, token_ids)
+

--- a/src/exo/worker/tests/unittests/test_mlx/test_model_fingerprint.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_model_fingerprint.py
@@ -1,0 +1,45 @@
+import json
+
+from exo.worker.engines.mlx.model_fingerprint import (
+    is_gemma3,
+    is_glm,
+    is_kimi_tokenizer_repo,
+    load_model_fingerprint,
+)
+
+
+def test_load_model_fingerprint_prefers_text_config(tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "ignored",
+                "architectures": ["Ignored"],
+                "text_config": {"model_type": "glm", "architectures": ["ChatGLMModel"]},
+            }
+        )
+    )
+
+    fp = load_model_fingerprint(tmp_path)
+    assert fp.model_type == "glm"
+    assert fp.architectures == ("ChatGLMModel",)
+    assert is_glm(fp)
+
+
+def test_is_gemma3_detects_model_type(tmp_path):
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "gemma3"}))
+    fp = load_model_fingerprint(tmp_path)
+    assert is_gemma3(fp)
+
+
+def test_is_gemma3_detects_architecture(tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps({"architectures": ["Gemma3ForCausalLM"]})
+    )
+    fp = load_model_fingerprint(tmp_path)
+    assert is_gemma3(fp)
+
+
+def test_is_kimi_tokenizer_repo_detects_custom_tokenizer_file(tmp_path):
+    (tmp_path / "tokenization_kimi.py").write_text("# test")
+    assert is_kimi_tokenizer_repo(tmp_path)
+


### PR DESCRIPTION
Fixes #1371

## Summary
- Add `config.json`-based model fingerprinting helpers to identify Kimi/GLM/Gemma3 families.
- Remove fragile model-id substring checks from MLX tokenizer loading; detect Kimi via repo structure.
- Patch GLM/Gemma3 EOS handling by resolving ids from special token strings (with safe fallbacks).

## Test plan
- `EXO_DASHBOARD_DIR=$PWD/dashboard ./.venv/bin/python -m pytest -q src/exo/worker/tests/unittests/test_mlx/test_model_fingerprint.py`
- `EXO_DASHBOARD_DIR=$PWD/dashboard ./.venv/bin/python -m pytest -q src/exo/worker/tests/unittests/test_plan/test_task_forwarding.py`