### PR TITLE
More image dimensions

### DIFF
--- a/dashboard/src/lib/components/ImageParamsPanel.svelte
+++ b/dashboard/src/lib/components/ImageParamsPanel.svelte
@@ -64,6 +64,8 @@
     "1024x1024",
     "1024x768",
     "768x1024",
+    "1024x1365",
+    "1365x1024",
   ];
 
   const qualityOptions: ImageGenerationParams["quality"][] = [

--- a/dashboard/src/lib/stores/app.svelte.ts
+++ b/dashboard/src/lib/stores/app.svelte.ts
@@ -286,7 +286,14 @@ const IMAGE_PARAMS_STORAGE_KEY = "exo-image-generation-params";
 // Image generation params interface matching backend API
 export interface ImageGenerationParams {
   // Basic params
-  size: "512x512" | "768x768" | "1024x1024" | "1024x768" | "768x1024";
+  size:
+    | "512x512"
+    | "768x768"
+    | "1024x1024"
+    | "1024x768"
+    | "768x1024"
+    | "1024x1365"
+    | "1365x1024";
   quality: "low" | "medium" | "high";
   outputFormat: "png" | "jpeg";
   numImages: number;


### PR DESCRIPTION
## Motivation

More dimensions for image generation

## Changes

  - dashboard/src/lib/components/ImageParamsPanel.svelte: Added "1024x1365" and "1365x1024" to the sizeOptions array
  - dashboard/src/lib/stores/app.svelte.ts: Extended the size type in ImageGenerationParams interface to include the two new dimension options
