### PR TITLE
fix: retry downloads on transient errors instead of breaking

### DIFF
--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -381,7 +381,11 @@ async def download_file_with_retry(
             on_connection_lost()
             if attempt == n_attempts - 1:
                 raise e
-            break
+            logger.error(
+                f"Download error on attempt {attempt + 1}/{n_attempts} for {model_id=} {revision=} {path=} {target_dir=}"
+            )
+            logger.error(traceback.format_exc())
+            await asyncio.sleep(2.0**attempt)
     raise Exception(
         f"Failed to download file {model_id=} {revision=} {path=} {target_dir=}"
     )


### PR DESCRIPTION
## Summary
- The generic exception handler in `download_file_with_retry()` used `break` to exit the retry loop on the first transient failure, completely defeating the retry mechanism
- Now it logs the error and retries with exponential backoff, matching the existing rate-limit handler behavior

## The bug

```python
except Exception as e:
    on_connection_lost()
    if attempt == n_attempts - 1:
        raise e
    break  # <-- exits loop immediately, skipping remaining retries
```

On any non-auth, non-rate-limit exception (network timeout, connection reset, server error, etc.), the code called `break` which exited the retry loop after just one attempt. It then fell through to raise a generic "Failed to download" error, losing the original exception context.

## The fix

Replace `break` with the same logging + exponential backoff pattern used by the rate-limit handler. The function now actually retries all 3 attempts before giving up.

## Test plan
- [ ] Existing download tests pass (`uv run pytest src/exo/download/tests/ -v`)
- [ ] `uv run basedpyright` passes with 0 errors
- [ ] `uv run ruff check` passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)