### PR TITLE
Prevent image editing without image input

### DIFF
--- a/dashboard/src/lib/components/ChatForm.svelte
+++ b/dashboard/src/lib/components/ChatForm.svelte
@@ -265,6 +265,7 @@
 
   function handleSubmit() {
     if ((!message.trim() && uploadedFiles.length === 0) || loading) return;
+    if (isEditOnlyWithoutImage) return;
 
     const content = message.trim();
     const files = [...uploadedFiles];
@@ -289,7 +290,11 @@
       if (imageFile.preview) {
         editImage(content, imageFile.preview);
       }
-    } else if (isImageModel() && content) {
+    } else if (
+      currentModel &&
+      modelSupportsTextToImage(currentModel) &&
+      content
+    ) {
       // Use image generation for text-to-image models
       generateImage(content);
     } else {


### PR DESCRIPTION
## Motivation

Models that only support image editing (ImageToImage but not TextToImage) would silently attempt text-to-image generation when a user submitted a text prompt without an attached image

## Changes

  - Added an early return guard in handleSubmit() that prevents submission when the selected model only supports image editing and no image is attached (isEditOnlyWithoutImage)
  - Fixed the text-to-image generation branch to use the more specific modelSupportsTextToImage() check instead of the broad isImageModel(), ensuring only models with TextToImage capability trigger generation from text alone
  - The existing isEditOnlyWithoutImage derived state (which was already used for UI hints like placeholder text and button disabling) now also blocks the actual submit path

## Why It Works

The text-to-image fallback now correctly checks modelSupportsTextToImage() directly, so edit-only models no longer fall through to the generation path


## Test Plan

### Manual Testing

  - Select an edit-only image model (e.g., one with only ImageToImage capability)
  - Verify the send button is disabled and placeholder reads "Attach an image to edit..." when no image is attached
  - Attach an image and verify the form becomes submittable
  - Select a text-to-image model and verify text-only prompts still trigger generation normally
  - Ensure pressing `enter` doesn't bypass check