### PR TITLE
dashboard: allow typing in chat input while response is generating

### DIFF
--- a/dashboard/src/lib/components/ChatForm.svelte
+++ b/dashboard/src/lib/components/ChatForm.svelte
@@ -599,9 +599,8 @@
             : isImageModel()
               ? "Describe the image you want to generate..."
               : placeholder}
-        disabled={loading}
         rows={1}
-        class="flex-1 resize-none bg-transparent text-foreground placeholder:text-exo-light-gray/60 placeholder:text-sm placeholder:tracking-[0.15em] placeholder:leading-7 focus:outline-none focus:ring-0 focus:border-none disabled:opacity-50 text-sm leading-7 font-mono"
+        class="flex-1 resize-none bg-transparent text-foreground placeholder:text-exo-light-gray/60 placeholder:text-sm placeholder:tracking-[0.15em] placeholder:leading-7 focus:outline-none focus:ring-0 focus:border-none text-sm leading-7 font-mono"
         style="min-height: 28px; max-height: 150px;"
       ></textarea>
 


### PR DESCRIPTION
The chat textarea was fully disabled during response generation, preventing users from drafting their next message while waiting.

Removed the `disabled={loading}` attribute from the textarea element. Submission is still blocked during generation by the early return in `handleSubmit()` and the submit button's own disabled state.

Test plan:
- Ran on one machine. While a model was writing a really long poem, I typed my next response. I couldn't submit it with Enter and the button still said "Processing" greyed out. I could send the message after generation finished.