### PR TITLE
Dont save to app directory

### DIFF
--- a/app/EXO/EXO/ExoProcessController.swift
+++ b/app/EXO/EXO/ExoProcessController.swift
@@ -267,7 +267,6 @@ final class ExoProcessController: ObservableObject {
         let custom = customNamespace.trimmingCharacters(in: .whitespaces)
         return custom.isEmpty ? base : custom
     }
-
 }
 
 struct RuntimeError: LocalizedError {


### PR DESCRIPTION
## Motivation

App keeps losing Local Network permissions.

## Changes

Don't save stuff to the app directory anymore. Instead, save to .exo.

## Why It Works

<!-- Explain why your approach solves the problem -->

## Test Plan

### Manual Testing
Before:
<img width="1512" height="106" alt="image" src="https://github.com/user-attachments/assets/544ef57e-b626-484d-941f-2472969aa208" />

After:
<img width="433" height="53" alt="Screenshot 2026-02-10 at 17 43 06" src="https://github.com/user-attachments/assets/3de2856b-cdf6-4b35-aa8f-50440686344f" />


### Automated Testing
<!-- Describe changes to automated tests, or how existing tests cover this change -->
<!-- - -->
