### PR TITLE
standardise logs

### DIFF
--- a/src/exo/shared/constants.py
+++ b/src/exo/shared/constants.py
@@ -43,7 +43,8 @@ DASHBOARD_DIR = (
 )
 
 # Log files (data/logs or cache)
-EXO_LOG = EXO_CACHE_HOME / "exo.log"
+EXO_LOG_DIR = EXO_CACHE_HOME / "exo_log"
+EXO_LOG = EXO_LOG_DIR / "exo.log"
 EXO_TEST_LOG = EXO_CACHE_HOME / "exo_test.log"
 
 # Identity (config)


### PR DESCRIPTION
## Motivation

Standardises exo.log and event_log

## Changes

- exo.log and exo.log.zst are now in a exo_log directory.
- event_log is now timestamped and not numbered. The timestamps can be sorted as they are YYYY-MM-DD-HH-MM

## Test Plan

### Manual Testing
Nothing crashes.