### PR TITLE
nix: override apple-sdk to 26.2 and enable MLX_BUILD_CPU

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,9 @@
           _module.args.pkgs = import inputs.nixpkgs {
             inherit system;
             config.allowUnfreePredicate = pkg: (pkg.pname or "") == "metal-toolchain";
+            overlays = [
+              (import ./nix/apple-sdk-overlay.nix)
+            ];
           };
           treefmt = {
             projectRootFile = "flake.nix";

--- a/nix/apple-sdk-overlay.nix
+++ b/nix/apple-sdk-overlay.nix
@@ -1,0 +1,18 @@
+# Overlay that builds apple-sdk with a custom versions.json (for SDK 26.2).
+# The upstream nixpkgs package reads versions.json at eval time via a relative
+# path, so we can't override it through callPackage args. Instead, we copy
+# the upstream source and patch the one file.
+final: _prev:
+let
+  upstreamSrc = final.path + "/pkgs/by-name/ap/apple-sdk";
+  patchedSrc = final.runCommandLocal "apple-sdk-src-patched" { } ''
+    cp -r ${upstreamSrc} $out
+    chmod -R u+w $out
+    cp ${./apple-sdk/metadata/versions.json} $out/metadata/versions.json
+  '';
+in
+{
+  apple-sdk_26 = final.callPackage (patchedSrc + "/package.nix") {
+    darwinSdkMajorVersion = "26";
+  };
+}

--- a/nix/apple-sdk/metadata/versions.json
+++ b/nix/apple-sdk/metadata/versions.json
@@ -1,0 +1,26 @@
+{
+  "14": {
+    "urls": [
+      "https://swcdn.apple.com/content/downloads/14/48/052-59890-A_I0F5YGAY0Y/p9n40hio7892gou31o1v031ng6fnm9sb3c/CLTools_macOSNMOS_SDK.pkg",
+      "https://web.archive.org/web/20250211001355/https://swcdn.apple.com/content/downloads/14/48/052-59890-A_I0F5YGAY0Y/p9n40hio7892gou31o1v031ng6fnm9sb3c/CLTools_macOSNMOS_SDK.pkg"
+    ],
+    "version": "14.4",
+    "hash": "sha256-QozDiwY0Czc0g45vPD7G4v4Ra+3DujCJbSads3fJjjM="
+  },
+  "15": {
+    "urls": [
+      "https://swcdn.apple.com/content/downloads/52/01/082-41241-A_0747ZN8FHV/dectd075r63pppkkzsb75qk61s0lfee22j/CLTools_macOSNMOS_SDK.pkg",
+      "https://web.archive.org/web/20250530132510/https://swcdn.apple.com/content/downloads/52/01/082-41241-A_0747ZN8FHV/dectd075r63pppkkzsb75qk61s0lfee22j/CLTools_macOSNMOS_SDK.pkg"
+    ],
+    "version": "15.5",
+    "hash": "sha256-HBiSJuw1XBUK5R/8Sj65c3rftSEvQl/O9ZZVp/g1Amo="
+  },
+  "26": {
+    "urls": [
+      "https://swcdn.apple.com/content/downloads/60/22/089-71960-A_W8BL1RUJJ6/5zkyplomhk1cm7z6xja2ktgapnhhti6wwd/CLTools_macOSNMOS_SDK.pkg",
+      "https://web.archive.org/web/20250915230423/https://swcdn.apple.com/content/downloads/60/22/089-71960-A_W8BL1RUJJ6/5zkyplomhk1cm7z6xja2ktgapnhhti6wwd/CLTools_macOSNMOS_SDK.pkg"
+    ],
+    "version": "26.2",
+    "hash": "sha256-hXRlMieVv0smna5uiWRwq87IWOaPWtAjAldbi+wQXcw="
+  }
+}

--- a/nix/mlx.nix
+++ b/nix/mlx.nix
@@ -85,6 +85,7 @@ let
         (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_JSON" "${nlohmann_json.src}")
         (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_NANOBIND" "${nanobind}")
         (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
+        (lib.cmakeBool "MLX_BUILD_CPU" true)
         (lib.cmakeBool "MLX_BUILD_METAL" true)
         (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_METAL_CPP" "${metal_cpp}")
         (lib.cmakeOptionType "string" "CMAKE_OSX_DEPLOYMENT_TARGET" "${apple-sdk_26.version}")


### PR DESCRIPTION
The pinned nixpkgs provides apple-sdk 26.0, but building MLX requires SDK 26.2. The upstream package reads versions.json via a relative path at eval time, so it can't be overridden through callPackage args.

Added a thin overlay that copies the upstream apple-sdk source and patches only metadata/versions.json to point at SDK 26.2. Also enabled MLX_BUILD_CPU in the MLX nix build.

This avoids vendoring the entire apple-sdk package (~2200 lines) while still getting the SDK version we need.

Test plan:
- CI
- Built and ran on two machines connected with Thunderbolt 5 - Kimi K2.5 starts in Tensor+RDMA and seems sensible.