### PR TITLE
dashboard: show macOS version in debug mode

### DIFF
--- a/dashboard/src/lib/components/TopologyGraph.svelte
+++ b/dashboard/src/lib/components/TopologyGraph.svelte
@@ -1192,7 +1192,9 @@
             .attr("fill", "rgba(179,179,179,0.7)")
             .attr("font-size", debugFontSize)
             .attr("font-family", "SF Mono, Monaco, monospace")
-            .text(`macOS ${identity.osVersion}${identity.osBuildVersion ? ` (${identity.osBuildVersion})` : ""}`);
+            .text(
+              `macOS ${identity.osVersion}${identity.osBuildVersion ? ` (${identity.osBuildVersion})` : ""}`,
+            );
         }
       }
     });


### PR DESCRIPTION
## Motivation

When debugging cluster issues, it's useful to see which macOS version each node is running — especially since version mismatches can cause compatibility problems. The OS version data is already collected by the identity gatherer but wasn't shown in the topology graph.

## Changes

- Added OS version label (e.g. "macOS 15.2") to each node in the topology graph when debug mode is enabled
- Renders below the existing TB and RDMA debug labels using the same styling conventions
- Sources data from the existing `nodeIdentities` store (no backend changes needed)

## Why It Works

The `nodeIdentities` store already contains `osVersion` for each node. We simply read it in the `TopologyGraph` component and append a text label in the debug section, following the exact same pattern as the TB and RDMA labels.

## Test Plan

### Manual Testing
<!-- Hardware: MacBook Pro -->
- Enable debug mode in the dashboard
- Verify OS version label appears below TB/RDMA labels on each node
- Verify label disappears when debug mode is disabled

### Automated Testing
- Dashboard build passes (`npm run build`)