### PR TITLE
Batch inference requests (MLX)

### DIFF
--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -1,3 +1,4 @@
+import os
 import time
 from copy import deepcopy
 from typing import Callable, Generator, cast, get_args
@@ -55,7 +56,7 @@ _DEFAULT_PREFILL_BATCH_SIZE = 8
 
 def _env_int(name: str, default: int) -> int:
     try:
-        return int((__import__("os").environ.get(name) or "").strip() or default)
+        return int((os.environ.get(name) or "").strip() or default)
     except Exception:
         return default
 

--- a/src/exo/worker/runner/runner.py
+++ b/src/exo/worker/runner/runner.py
@@ -162,7 +162,11 @@ def main(
     def _is_batchable_text_task(task_params: TextGenerationTaskParams) -> bool:
         model_name = str(task_params.model).lower()
         needs_single_path_processing = (
-            "gpt-oss" in model_name or "gpt_oss" in model_name or tool_parser is not None
+            "kimi" in model_name
+            or "glm" in model_name
+            or "gpt-oss" in model_name
+            or "gpt_oss" in model_name
+            or tool_parser is not None
         )
         return (
             not task_params.stream


### PR DESCRIPTION
Fixes #1020
Refs #1019

Bounty: $200

What changed:
- Add MLX batch generation helper (uses mlx-lm BatchGenerator)
- Runner now opportunistically batches compatible non-stream chat requests that arrive close together, then multiplexes per-token chunks back to each request

Batching rules (safe subset):
- stream=false
- no tools / tool calling
- no logprobs
- no stop sequences
- enable_thinking=false
- identical temperature/top_p/top_k/seed/model across the batch

Tuning:
- EXO_BATCH_MAX_SIZE (default: 4)
- EXO_BATCH_MAX_WAIT_S (default: 0.005)
- EXO_BATCH_COMPLETION_SIZE (default: 8)
- EXO_BATCH_PREFILL_SIZE (default: 8)

Verification:
- python -m py_compile src/exo/worker/runner/runner.py src/exo/worker/engines/mlx/generator/generate.py
