### PR TITLE
Replace model ID string matching with architecture-based checks in tokenizer loading

### DIFF
--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -165,6 +165,7 @@ def is_custom_card(model_id: ModelId) -> bool:
 class ConfigData(BaseModel):
     model_config = {"extra": "ignore"}  # Allow unknown fields
 
+    model_type: str | None = None
     architectures: list[str] | None = None
     hidden_size: Annotated[int, Field(ge=0)] | None = None
     layer_count: int = Field(
@@ -200,6 +201,7 @@ class ConfigData(BaseModel):
             return data
 
         for field in [
+            "model_type",
             "architectures",
             "hidden_size",
             "num_hidden_layers",

--- a/src/exo/worker/tests/unittests/test_mlx/test_tokenizers.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_tokenizers.py
@@ -24,6 +24,7 @@ from exo.worker.engines.mlx.utils_mlx import (
 
 # Files needed for tokenizer functionality
 TOKENIZER_FILE_PATTERNS = [
+    "config.json",
     "tokenizer.json",
     "tokenizer_config.json",
     "special_tokens_map.json",
@@ -338,6 +339,9 @@ async def test_kimi_tokenizer_specifically():
     # Verify EOS token is set
     assert eos_token_ids == [163586], "Kimi EOS token should be [163586]"
 
+    # Verify architecture-based detection gives same result
+    assert get_eos_token_ids_for_model(model_id, model_type="kimi") == [163586]
+
 
 # Test GLM tokenizer since it also has special handling
 @pytest.mark.asyncio
@@ -378,3 +382,10 @@ async def test_glm_tokenizer_specifically():
         151329,
         151338,
     ], "GLM EOS tokens should be correct"
+
+    # Verify architecture-based detection gives same result
+    assert get_eos_token_ids_for_model(model_id, model_type="glm4") == [
+        151336,
+        151329,
+        151338,
+    ]


### PR DESCRIPTION
## Summary
- Reads `model_type` from `config.json` instead of substring-matching on model IDs for architecture detection in tokenizer loading
- Adds `_read_model_type_from_config()` helper that handles both top-level and `text_config`-nested `model_type` fields
- Falls back to existing string matching when `config.json` is unavailable, ensuring backward compatibility
- Adds `model_type` field to `ConfigData` for broader use

Closes #1371

## Test plan
- [x] `basedpyright` passes with 0 errors
- [x] `ruff check` passes
- [x] `nix fmt` applied
- [x] `pytest` passes (187 passed, 1 skipped)
- [ ] Verify with a Kimi model that `model_type == "kimi"` is detected from config.json
- [ ] Verify with a GLM model that `model_type` starting with `"glm"` is detected
- [ ] Verify with a Gemma-3 model that `model_type == "gemma3"` is detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)