### PR TITLE
Fix instance type mismatch in /instance/previews endpoint

### DIFF
--- a/src/exo/master/api.py
+++ b/src/exo/master/api.py
@@ -168,7 +168,12 @@ from exo.shared.types.openai_responses import (
 )
 from exo.shared.types.state import State
 from exo.shared.types.worker.downloads import DownloadCompleted
-from exo.shared.types.worker.instances import Instance, InstanceId, InstanceMeta
+from exo.shared.types.worker.instances import (
+    Instance,
+    InstanceId,
+    InstanceMeta,
+    MlxJacclInstance,
+)
 from exo.shared.types.worker.shards import Sharding
 from exo.utils.banner import print_startup_banner
 from exo.utils.channels import Receiver, Sender, channel
@@ -513,6 +518,14 @@ class API:
             shard_assignments = instance.shard_assignments
             placement_node_ids = list(shard_assignments.node_to_runner.keys())
 
+            # Derive instance_meta from the actual instance type, since
+            # place_instance() may override it (e.g., single-node → MlxRing)
+            actual_instance_meta = (
+                InstanceMeta.MlxJaccl
+                if isinstance(instance, MlxJacclInstance)
+                else InstanceMeta.MlxRing
+            )
+
             memory_delta_by_node: dict[str, int] = {}
             if placement_node_ids:
                 total_bytes = model_card.storage_size.in_bytes
@@ -525,14 +538,14 @@ class API:
             if (
                 model_card.model_id,
                 sharding,
-                instance_meta,
+                actual_instance_meta,
                 len(placement_node_ids),
             ) not in seen:
                 previews.append(
                     PlacementPreview(
                         model_id=model_card.model_id,
                         sharding=sharding,
-                        instance_meta=instance_meta,
+                        instance_meta=actual_instance_meta,
                         instance=instance,
                         memory_delta_by_node=memory_delta_by_node or None,
                         error=None,
@@ -542,7 +555,7 @@ class API:
                 (
                     model_card.model_id,
                     sharding,
-                    instance_meta,
+                    actual_instance_meta,
                     len(placement_node_ids),
                 )
             )


### PR DESCRIPTION
## Summary
- Fixes `instance_meta` in preview responses not matching the actual `instance` type
- `place_instance()` overrides single-node placements to `MlxRing`, but the preview was still reporting the originally requested type (e.g., `MlxJaccl`)
- Now derives `instance_meta` from the actual instance object returned (`MlxJacclInstance` vs `MlxRingInstance`) so the response is always consistent

Closes #1426

## Test plan
- [x] `basedpyright` passes with 0 errors
- [x] `ruff check` passes
- [x] `nix fmt` clean (0 changed)
- [x] `pytest` passes (260 passed, 1 skipped)
- [ ] On a single-node setup, call `GET /instance/previews?model_id=<model>` and verify that when `instance_meta` is `MlxRing`, the `instance` key wraps as `MlxRingInstance` (not `MlxJacclInstance`, and vice versa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)