### PR TITLE
Handle MessageTooLarge error in router to prevent node crash

### DIFF
--- a/src/exo/routing/router.py
+++ b/src/exo/routing/router.py
@@ -211,6 +211,14 @@ class Router:
                     pass
                 except AllQueuesFullError:
                     logger.warning(f"All peer queues full, dropping message on {topic}")
+                except RuntimeError as e:
+                    if "MessageTooLarge" in str(e):
+                        logger.error(
+                            f"Message too large for gossipsub on topic {topic} "
+                            f"({len(data)} bytes), dropping message"
+                        )
+                    else:
+                        raise
 
 
 def get_node_id_keypair(


### PR DESCRIPTION
## Summary
- When a message exceeds gossipsub's 1 MiB limit, `_networking_publish` threw an unhandled `RuntimeError("MessageTooLarge")` which propagated through the TaskGroup and crashed the entire node
- Now catches this error, logs the message size, and drops the oversized message gracefully instead of crashing
- A proper `MessageTooLargeError` exception class in the Rust bindings (similar to existing `AllQueuesFullError`) would be a better long-term fix

Fixes #1296

## Test plan
- [ ] Verify node no longer crashes when a large payload (1M+ chars) is sent via the API
- [ ] Verify normal-sized messages continue to route correctly
- [ ] Verify the error is logged with the topic and payload size

🤖 Generated with [Claude Code](https://claude.com/claude-code)