### PR TITLE
fix: --no-downloads no longer blocks model loading

### DIFF
--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -94,6 +94,7 @@ class Node:
                 command_sender=router.sender(topics.COMMANDS),
                 download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
                 event_index_counter=event_index_counter,
+                no_downloads=args.no_downloads,
             )
         else:
             worker = None
@@ -225,6 +226,7 @@ class Node:
                         )
                         self._tg.start_soon(self.download_coordinator.run)
                     if self.worker:
+                        no_downloads = self.worker.no_downloads
                         self.worker.shutdown()
                         # TODO: add profiling etc to resource monitor
                         self.worker = Worker(
@@ -239,6 +241,7 @@ class Node:
                                 topics.DOWNLOAD_COMMANDS
                             ),
                             event_index_counter=self.event_index_counter,
+                            no_downloads=no_downloads,
                         )
                         self._tg.start_soon(self.worker.run)
                     if self.api:

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -65,6 +65,7 @@ class Worker:
         command_sender: Sender[ForwarderCommand],
         download_command_sender: Sender[ForwarderDownloadCommand],
         event_index_counter: Iterator[int],
+        no_downloads: bool = False,
     ):
         self.node_id: NodeId = node_id
         self.session_id: SessionId = session_id
@@ -74,6 +75,7 @@ class Worker:
         self.event_index_counter = event_index_counter
         self.command_sender = command_sender
         self.download_command_sender = download_command_sender
+        self.no_downloads = no_downloads
         self.event_buffer = OrderedBuffer[Event]()
         self.out_for_delivery: dict[EventId, ForwarderEvent] = {}
 
@@ -182,6 +184,7 @@ class Worker:
                 self.state.tasks,
                 self.input_chunk_buffer,
                 self.input_chunk_counts,
+                no_downloads=self.no_downloads,
             )
             if task is None:
                 continue

--- a/src/exo/worker/tests/unittests/test_plan/test_download_and_loading.py
+++ b/src/exo/worker/tests/unittests/test_plan/test_download_and_loading.py
@@ -157,6 +157,41 @@ def test_plan_does_not_request_download_when_shard_already_downloaded():
     assert not isinstance(result, plan_mod.DownloadModel)
 
 
+def test_plan_loads_model_with_no_downloads_flag():
+    """
+    When no_downloads=True, plan() should skip download checks and proceed
+    to load the model even with empty global_download_status.
+    """
+    shard = get_pipeline_shard_metadata(model_id=MODEL_A_ID, device_rank=0)
+    instance = get_mlx_ring_instance(
+        instance_id=INSTANCE_1_ID,
+        model_id=MODEL_A_ID,
+        node_to_runner={NODE_A: RUNNER_1_ID},
+        runner_to_shard={RUNNER_1_ID: shard},
+    )
+    bound_instance = BoundInstance(
+        instance=instance, bound_runner_id=RUNNER_1_ID, bound_node_id=NODE_A
+    )
+    runner = FakeRunnerSupervisor(bound_instance=bound_instance, status=RunnerIdle())
+
+    runners = {RUNNER_1_ID: runner}
+    instances = {INSTANCE_1_ID: instance}
+    all_runners = {RUNNER_1_ID: RunnerIdle()}
+
+    result = plan_mod.plan(
+        node_id=NODE_A,
+        runners=runners,  # type: ignore
+        global_download_status={},
+        instances=instances,
+        all_runners=all_runners,
+        tasks={},
+        no_downloads=True,
+    )
+
+    assert isinstance(result, LoadModel)
+    assert result.instance_id == INSTANCE_1_ID
+
+
 def test_plan_does_not_load_model_until_all_shards_downloaded_globally():
     """
     LoadModel should not be emitted while some shards are still missing from


### PR DESCRIPTION
## Summary
- When `--no-downloads` is passed, `plan()` now skips download checks so pre-staged models can be loaded without `DownloadCompleted` events
- Adds `no_downloads` flag through `Worker` → `plan()` → `_load_model()`, skipping `_model_needs_download()` and the download completeness check
- Preserves the flag across Worker recreation during master re-election

Fixes #1510

## Test plan
- [x] New test `test_plan_loads_model_with_no_downloads_flag` verifies `LoadModel` is returned with empty download status when `no_downloads=True`
- [x] All existing plan tests pass (no regression)
- [x] basedpyright passes with 0 errors
- [x] ruff check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)