### PR TITLE
fix: suppress closure errors in runnersupervisor and force spawn start method

### DIFF
--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -1,10 +1,9 @@
-import contextlib
 from collections import defaultdict
 from datetime import datetime, timezone
 from random import random
 
 import anyio
-from anyio import CancelScope, ClosedResourceError, fail_after
+from anyio import CancelScope, fail_after
 from loguru import logger
 
 from exo.download.download_utils import resolve_model_in_path
@@ -120,8 +119,7 @@ class Worker:
             self.command_sender.close()
             self.download_command_sender.close()
             for runner in self.runners.values():
-                with contextlib.suppress(ClosedResourceError):
-                    runner.shutdown()
+                runner.shutdown()
 
     async def _forward_info(self, recv: Receiver[GatheredInfo]):
         with recv as info_stream:
@@ -267,8 +265,7 @@ class Worker:
                             )
                         )
                     finally:
-                        with contextlib.suppress(ClosedResourceError):
-                            runner.shutdown()
+                        runner.shutdown()
                 case CancelTask(
                     cancelled_task_id=cancelled_task_id, runner_id=runner_id
                 ):

--- a/src/exo/worker/runner/runner_supervisor.py
+++ b/src/exo/worker/runner/runner_supervisor.py
@@ -106,13 +106,18 @@ class RunnerSupervisor:
     def shutdown(self):
         logger.info("Runner supervisor shutting down")
         self._tg.cancel_tasks()
-        self._ev_recv.close()
-        self._task_sender.close()
         if not self._cancel_watch_runner.cancel_called:
             self._cancel_watch_runner.cancel()
         with contextlib.suppress(ClosedResourceError):
+            self._ev_recv.close()
+        with contextlib.suppress(ClosedResourceError):
+            self._task_sender.close()
+        with contextlib.suppress(ClosedResourceError):
+            self._event_sender.close()
+        with contextlib.suppress(ClosedResourceError):
             self._cancel_sender.send(TaskId("CANCEL_CURRENT_TASK"))
-        self._cancel_sender.close()
+        with contextlib.suppress(ClosedResourceError):
+            self._cancel_sender.close()
         self.runner_process.join(5)
         if not self.runner_process.is_alive():
             logger.info("Runner process succesfully terminated")


### PR DESCRIPTION
Part 5 of meta-instance split. Independent bug fixes that were bundled in PR #1519, now extracted for easier review.