### PR TITLE
Ensure coordinator is rank 0

### DIFF
--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -143,7 +143,7 @@ def place_instance(
 
     match command.instance_meta:
         case InstanceMeta.MlxJaccl:
-
+            # TODO(evan): shard assignments should contain information about ranks, this is ugly
             def get_device_rank(node_id: NodeId) -> int:
                 runner_id = shard_assignments.node_to_runner[node_id]
                 shard_metadata = shard_assignments.runner_to_shard.get(runner_id)


### PR DESCRIPTION
## Motivation

Coordinator can be a random rank. Let's just fix this to rank 0 as that's what we typically assume.

## Test Plan

### Manual Testing
Works as normal on 2 nodes.


Let's wait for a little more testing to merge this.
