### PR TITLE
add lazy task group

### DIFF
--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, field
 from typing import Self
 
 import anyio
-from anyio.abc import TaskGroup
 from loguru import logger
 from pydantic import PositiveInt
 
@@ -23,6 +22,7 @@ from exo.shared.logging import logger_cleanup, logger_setup
 from exo.shared.types.common import NodeId, SessionId
 from exo.utils.channels import Receiver, channel
 from exo.utils.pydantic_ext import CamelCaseModel
+from exo.utils.task_group import TaskGroup
 from exo.worker.main import Worker
 
 
@@ -38,7 +38,7 @@ class Node:
 
     node_id: NodeId
     offline: bool
-    _tg: TaskGroup = field(init=False, default_factory=anyio.create_task_group)
+    _tg: TaskGroup = field(init=False, default_factory=TaskGroup)
 
     @classmethod
     async def create(cls, args: "Args") -> Self:
@@ -149,11 +149,11 @@ class Node:
 
     def shutdown(self):
         # if this is our second call to shutdown, just sys.exit
-        if self._tg.cancel_scope.cancel_called:
+        if self._tg.cancel_called():
             import sys
 
             sys.exit(1)
-        self._tg.cancel_scope.cancel()
+        self._tg.cancel_tasks()
 
     async def _elect_loop(self):
         with self.election_result_receiver as results:

--- a/src/exo/routing/router.py
+++ b/src/exo/routing/router.py
@@ -8,11 +8,9 @@ from typing import cast
 from anyio import (
     BrokenResourceError,
     ClosedResourceError,
-    create_task_group,
     move_on_after,
     sleep_forever,
 )
-from anyio.abc import TaskGroup
 from exo_pyo3_bindings import (
     AllQueuesFullError,
     Keypair,
@@ -25,6 +23,7 @@ from loguru import logger
 from exo.shared.constants import EXO_NODE_ID_KEYPAIR
 from exo.utils.channels import Receiver, Sender, channel
 from exo.utils.pydantic_ext import CamelCaseModel
+from exo.utils.task_group import TaskGroup
 
 from .connection_message import ConnectionMessage
 from .topics import CONNECTION_MESSAGES, PublishPolicy, TypedTopic
@@ -111,10 +110,9 @@ class Router:
         self._net: NetworkingHandle = handle
         self._tmp_networking_sender: Sender[tuple[str, bytes]] | None = send
         self._id_count = count()
-        self._tg: TaskGroup | None = None
+        self._tg: TaskGroup = TaskGroup()
 
     async def register_topic[T: CamelCaseModel](self, topic: TypedTopic[T]):
-        assert self._tg is None, "Attempted to register topic after setup time"
         send = self._tmp_networking_sender
         if send:
             self._tmp_networking_sender = None
@@ -148,8 +146,7 @@ class Router:
     async def run(self):
         logger.debug("Starting Router")
         try:
-            async with create_task_group() as tg:
-                self._tg = tg
+            async with self._tg as tg:
                 for topic in self.topic_routers:
                     router = self.topic_routers[topic]
                     tg.start_soon(router.run)
@@ -165,9 +162,7 @@ class Router:
 
     async def shutdown(self):
         logger.debug("Shutting down Router")
-        if not self._tg:
-            return
-        self._tg.cancel_scope.cancel()
+        self._tg.cancel_tasks()
 
     async def _networking_subscribe(self, topic: str):
         await self._net.gossipsub_subscribe(topic)

--- a/src/exo/utils/task_group.py
+++ b/src/exo/utils/task_group.py
@@ -1,0 +1,65 @@
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from types import TracebackType
+from typing import Any, Unpack
+
+from anyio import create_task_group
+from anyio.abc import TaskGroup as TaskGroupABC
+
+
+@dataclass
+class TaskGroup:
+    _tg: TaskGroupABC | None = field(default=None, init=False)
+    _queued: list[tuple[Any, Any, Any]] | None = field(default_factory=list, init=False)
+
+    def is_running(self) -> bool:
+        return self._tg is not None
+
+    def cancel_tasks(self):
+        assert self._tg
+        self._tg.cancel_scope.cancel()
+
+    def cancel_called(self) -> bool:
+        assert self._tg
+        return self._tg.cancel_scope.cancel_called
+
+    def start_soon[*T](
+        self,
+        func: Callable[[Unpack[T]], Awaitable[Any]],
+        *args: Unpack[T],
+        name: object = None,
+    ) -> None:
+        assert self._tg is not None
+        assert self._queued is None
+        self._tg.start_soon(func, *args, name=name)
+
+    def queue[*T](
+        self,
+        func: Callable[[Unpack[T]], Awaitable[Any]],
+        *args: Unpack[T],
+        name: object = None,
+    ) -> None:
+        assert self._tg is None
+        assert self._queued is not None
+        self._queued.append((func, args, name))
+
+    async def __aenter__(self) -> TaskGroupABC:
+        assert self._tg is None
+        assert self._queued is not None
+        self._tg = create_task_group()
+        r = await self._tg.__aenter__()
+        for func, args, name in self._queued:  # pyright: ignore[reportAny]
+            self._tg.start_soon(func, *args, name=name)  # pyright: ignore[reportAny]
+        self._queued = None
+        return r
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool:
+        """Exit the task group context waiting for all tasks to finish."""
+        assert self._tg is not None, "aenter sets self.lazy, so it exists when we aexit"
+        assert self._queued is None
+        return await self._tg.__aexit__(exc_type, exc_val, exc_tb)

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -3,8 +3,7 @@ from datetime import datetime, timezone
 from random import random
 
 import anyio
-from anyio import CancelScope, create_task_group, fail_after
-from anyio.abc import TaskGroup
+from anyio import CancelScope, fail_after
 from loguru import logger
 
 from exo.download.download_utils import resolve_model_in_path
@@ -51,6 +50,7 @@ from exo.utils.event_buffer import OrderedBuffer
 from exo.utils.info_gatherer.info_gatherer import GatheredInfo, InfoGatherer
 from exo.utils.info_gatherer.net_profile import check_reachable
 from exo.utils.keyed_backoff import KeyedBackoff
+from exo.utils.task_group import TaskGroup
 from exo.worker.plan import plan
 from exo.worker.runner.runner_supervisor import RunnerSupervisor
 
@@ -80,7 +80,7 @@ class Worker:
 
         self.state: State = State()
         self.runners: dict[RunnerId, RunnerSupervisor] = {}
-        self._tg: TaskGroup = create_task_group()
+        self._tg: TaskGroup = TaskGroup()
 
         self._nack_cancel_scope: CancelScope | None = None
         self._nack_attempts: int = 0
@@ -317,7 +317,7 @@ class Worker:
                     await self._start_runner_task(task)
 
     def shutdown(self):
-        self._tg.cancel_scope.cancel()
+        self._tg.cancel_tasks()
 
     async def _start_runner_task(self, task: Task):
         if (instance := self.state.instances.get(task.instance_id)) is not None:


### PR DESCRIPTION
in a few places we instantiate task groups early, in others we have an optional task group.

this standardizes these patterns into a lazy task group, which queues tasks until it is entered, at which point it enters its inner task group and starts all its queued tasks. it should be noted that no queued tasks will be started until the group itself is started.