### PR TITLE
feat: graduate image generation to non-experimental (default on)

### DIFF
--- a/app/EXO/EXO/ContentView.swift
+++ b/app/EXO/EXO/ContentView.swift
@@ -26,8 +26,6 @@ struct ContentView: View {
     @State private var uninstallInProgress = false
     @State private var pendingNamespace: String = ""
     @State private var pendingHFToken: String = ""
-    @State private var pendingEnableImageModels = false
-
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             statusSection
@@ -326,28 +324,6 @@ struct ContentView: View {
                             .font(.caption2)
                             .disabled(pendingHFToken == controller.hfToken)
                         }
-                    }
-                    Divider()
-                    HStack {
-                        Toggle(
-                            "Enable Image Models (experimental)", isOn: $pendingEnableImageModels
-                        )
-                        .toggleStyle(.switch)
-                        .font(.caption2)
-                        .onAppear {
-                            pendingEnableImageModels = controller.enableImageModels
-                        }
-
-                        Spacer()
-
-                        Button("Save & Restart") {
-                            controller.enableImageModels = pendingEnableImageModels
-                            if controller.status == .running || controller.status == .starting {
-                                controller.restart()
-                            }
-                        }
-                        .font(.caption2)
-                        .disabled(pendingEnableImageModels == controller.enableImageModels)
                     }
                     HoverButton(title: "Check for Updates", small: true) {
                         updater.checkForUpdates()

--- a/app/EXO/EXO/ExoProcessController.swift
+++ b/app/EXO/EXO/ExoProcessController.swift
@@ -4,8 +4,6 @@ import Foundation
 
 private let customNamespaceKey = "EXOCustomNamespace"
 private let hfTokenKey = "EXOHFToken"
-private let enableImageModelsKey = "EXOEnableImageModels"
-
 @MainActor
 final class ExoProcessController: ObservableObject {
     enum Status: Equatable {
@@ -49,14 +47,6 @@ final class ExoProcessController: ObservableObject {
     {
         didSet {
             UserDefaults.standard.set(hfToken, forKey: hfTokenKey)
-        }
-    }
-    @Published var enableImageModels: Bool = {
-        return UserDefaults.standard.bool(forKey: enableImageModelsKey)
-    }()
-    {
-        didSet {
-            UserDefaults.standard.set(enableImageModels, forKey: enableImageModelsKey)
         }
     }
 
@@ -246,10 +236,6 @@ final class ExoProcessController: ObservableObject {
         if !hfToken.isEmpty {
             environment["HF_TOKEN"] = hfToken
         }
-        if enableImageModels {
-            environment["EXO_ENABLE_IMAGE_MODELS"] = "true"
-        }
-
         var paths: [String] = []
         if let existing = environment["PATH"], !existing.isEmpty {
             paths = existing.split(separator: ":").map(String.init)

--- a/src/exo/shared/constants.py
+++ b/src/exo/shared/constants.py
@@ -65,8 +65,4 @@ EXO_EVENT_LOG_DIR = EXO_DATA_HOME / "event_log"
 EXO_IMAGE_CACHE_DIR = EXO_CACHE_HOME / "images"
 EXO_TRACING_CACHE_DIR = EXO_CACHE_HOME / "traces"
 
-EXO_ENABLE_IMAGE_MODELS = (
-    os.getenv("EXO_ENABLE_IMAGE_MODELS", "false").lower() == "true"
-)
-
 EXO_TRACING_ENABLED = os.getenv("EXO_TRACING_ENABLED", "false").lower() == "true"

--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -20,7 +20,6 @@ from tomlkit.exceptions import TOMLKitError
 
 from exo.shared.constants import (
     EXO_CUSTOM_MODEL_CARDS_DIR,
-    EXO_ENABLE_IMAGE_MODELS,
     RESOURCES_DIR,
 )
 from exo.shared.types.common import ModelId
@@ -50,16 +49,10 @@ async def _refresh_card_cache():
                 pass
 
 
-def _is_image_card(card: "ModelCard") -> bool:
-    return any(t in (ModelTask.TextToImage, ModelTask.ImageToImage) for t in card.tasks)
-
-
 async def get_model_cards() -> list["ModelCard"]:
     if len(_card_cache) == 0:
         await _refresh_card_cache()
-    if EXO_ENABLE_IMAGE_MODELS:
-        return list(_card_cache.values())
-    return [c for c in _card_cache.values() if not _is_image_card(c)]
+    return list(_card_cache.values())
 
 
 class ModelTask(str, Enum):


### PR DESCRIPTION
## Summary
- Remove the `EXO_ENABLE_IMAGE_MODELS` experimental flag — image models (FLUX, Qwen-Image) are now always available
- Remove the macOS app "Enable Image Models (experimental)" toggle from Advanced settings
- Remove env var plumbing from `ExoProcessController.swift`
- Simplify `get_model_cards()` to always return all models (65 text + 18 image = 83 total)

**NOTE: Merge after 1.0.68 release — this will ship in 1.0.69.**

## Test plan
- [x] `uv run basedpyright` — 0 new errors (pre-existing Keypair issue only)
- [x] `uv run ruff check` — all checks passed
- [x] `uv run pytest` — 216 passed (1 pre-existing failure unrelated)
- [x] `nix fmt` — no changes needed
- [x] Verified `get_model_cards()` returns all 18 image models without any env var set

🤖 Generated with [Claude Code](https://claude.com/claude-code)