### PR TITLE
worker: add EXO_MODELS_PATH for pre-downloaded model directories

### DIFF
--- a/src/exo/shared/constants.py
+++ b/src/exo/shared/constants.py
@@ -33,6 +33,15 @@ EXO_MODELS_DIR = (
     if _EXO_MODELS_DIR_ENV is None
     else Path.home() / _EXO_MODELS_DIR_ENV
 )
+
+# Read-only search path for pre-downloaded models (colon-separated directories)
+_EXO_MODELS_PATH_ENV = os.environ.get("EXO_MODELS_PATH", None)
+EXO_MODELS_PATH: tuple[Path, ...] | None = (
+    tuple(Path(p).expanduser() for p in _EXO_MODELS_PATH_ENV.split(":") if p)
+    if _EXO_MODELS_PATH_ENV is not None
+    else None
+)
+
 _RESOURCES_DIR_ENV = os.environ.get("EXO_RESOURCES_DIR", None)
 RESOURCES_DIR = (
     find_resources() if _RESOURCES_DIR_ENV is None else Path.home() / _RESOURCES_DIR_ENV


### PR DESCRIPTION
Users with pre-existing model files (e.g. on shared NFS mounts or from prior downloads) had no way to point exo at those directories without going through the download coordinator. EXO_MODELS_DIR only moves the download target directory, it doesn't support read-only search paths.

Added EXO_MODELS_PATH environment variable as a colon-separated list of directories to search for models. When the worker's plan loop encounters a DownloadModel task, it checks these directories first and emits a synthetic DownloadCompleted event if found, bypassing the download coordinator entirely. The runner's build_model_path also checks these directories first so the correct path is used during model loading.

This keeps the existing event sourcing state machine unchanged — the DownloadCompleted event propagates naturally through the system, so _load_model and all downstream logic work without modification.

Test plan:
- `s1@s1s-Mac-Studio ~ % EXO_LIBP2P_NAMESPACE=jake EXO_MODELS_PATH="/Volumes/Definitely Leo's SSD" nix --extra-experimental-features 'nix-command flakes' run github:exo-explore/exo/f2babbc2f742357d97dc177619fec062ef545be4`
- Started mlx-community/Qwen3-Coder-Next-4bit - it's present on the disk and it worked.
- Renamed one safetensor of mlx-community/Qwen3-Coder-Next-4bit on the disk. It then started the download locally, as expected.