### PR TITLE
bench: fix KeyError on DownloadCompleted total field

### DIFF
--- a/bench/harness.py
+++ b/bench/harness.py
@@ -371,7 +371,7 @@ def run_planning_phase(
                 unwrap_instance(p["DownloadCompleted"]["shardMetadata"])["modelCard"][
                     "modelId"
                 ],
-                p["DownloadCompleted"]["totalBytes"]["inBytes"],
+                p["DownloadCompleted"]["total"]["inBytes"],
             )
             for p in node_downloads
             if "DownloadCompleted" in p


### PR DESCRIPTION
The bench harness accessed the serialized DownloadCompleted field as "totalBytes", but the Python field is `total: Memory` which serializes to "total" (not snake_case, so the camelCase alias generator leaves it unchanged). This caused a KeyError when --danger-delete-downloads needed to free disk space by deleting existing models.

Changed the key from "totalBytes" to "total" to match the actual serialized JSON structure.

Test plan:
- CI
- Reproduced KeyError on unfixed code by filling disk on a test node to 14GB free and running exo-bench with a 16GB model (Meta-Llama-3.1-8B-Instruct-bf16) with --danger-delete-downloads
- Verified fixed code successfully deletes smaller models to free space and completes the benchmark run