### PR TITLE
fix: sync model selectors between sidebar and chat input

### DIFF
--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -889,6 +889,7 @@
       availableModels.some((m) => m.id === defaults.modelId)
     ) {
       selectPreviewModel(defaults.modelId);
+      setSelectedChatModel(defaults.modelId);
     }
   }
 
@@ -1324,6 +1325,7 @@
 
   function handleModelPickerSelect(modelId: string) {
     selectPreviewModel(modelId);
+    setSelectedChatModel(modelId);
     saveLaunchDefaults();
     isModelPickerOpen = false;
   }
@@ -2284,7 +2286,8 @@
     selectedChatCategory = null;
     pendingAutoMessage = null;
     userForcedIdle = true;
-    setSelectedChatModel("");
+    // Restore chat model from the sidebar preview selection so both selectors stay in sync
+    setSelectedChatModel(selectedModelId ?? "");
     clearChat();
   }
 
@@ -2993,6 +2996,7 @@
   // Handle model selection from the picker when opened from chat context
   function handleChatPickerSelect(modelId: string) {
     setSelectedChatModel(modelId);
+    selectPreviewModel(modelId);
     userForcedIdle = false;
     isModelPickerOpen = false;
   }
@@ -3012,6 +3016,7 @@
 
     // Model is selected and running — send directly
     if (model && hasRunningInstance(model)) {
+      chatLaunchState = "ready";
       sendMessage(content, files, null);
       return;
     }


### PR DESCRIPTION
## Motivation

The "Load Model" dropdown in the right sidebar and the model selector above the chat input were operating on independent state (`selectedPreviewModelId` vs `selectedChatModel`). This caused several UX issues:
- Selecting a model in one selector didn't update the other
- After going home from a chat, the chat selector showed "SELECT MODEL" while the sidebar still showed the model
- On page refresh, only the sidebar restored the saved model
- Sending a chat message with a running model briefly showed the recommended models view instead of starting the chat

## Changes

- **`handleModelPickerSelect`**: Also sets `selectedChatModel` when a model is picked from the sidebar dropdown
- **`handleChatPickerSelect`**: Also sets `selectedPreviewModelId` when a model is picked from the chat selector
- **`handleGoHome`**: Restores `selectedChatModel` from the sidebar's `selectedModelId` instead of clearing it
- **`applyLaunchDefaults`**: Syncs `selectedChatModel` when restoring saved defaults on page load
- **`handleChatSend`**: Sets `chatLaunchState = "ready"` before calling `sendMessage` when the model is already running, ensuring the chat view renders correctly on view transition

## Why It Works

The two selectors were backed by different store properties that were never kept in sync. By updating both properties in every selection path (sidebar pick, chat pick, go-home, page restore), they always reflect the same model. The `chatLaunchState = "ready"` fix mirrors what `launchModelForChat` already does (line 2649) and prevents the chat state from being "idle" when transitioning from the welcome view to the chat view.

## Test Plan

### Manual Testing
<!-- Hardware: MacBook Pro M4 Max 48GB -->
- Select a model from sidebar "Load Model" dropdown → chat input selector updates to match
- Select a model from chat input selector → sidebar dropdown updates to match
- Launch a model, chat with it, click "Go Home" → both selectors show the same model
- Refresh the page → both selectors show the previously selected model
- With a running model, type and send a message from the welcome view → chat starts directly without flashing the recommended models view

### Automated Testing
No new automated tests — this is a UI state synchronization fix in the Svelte dashboard with no backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)