### PR TITLE
fix: replace flaky internet checks with explicit offline mode

### DIFF
--- a/app/EXO/EXO/ExoProcessController.swift
+++ b/app/EXO/EXO/ExoProcessController.swift
@@ -5,6 +5,7 @@ import Foundation
 private let customNamespaceKey = "EXOCustomNamespace"
 private let hfTokenKey = "EXOHFToken"
 private let enableImageModelsKey = "EXOEnableImageModels"
+private let offlineModeKey = "EXOOfflineMode"
 private let onboardingCompletedKey = "EXOOnboardingCompleted"
 
 @MainActor
@@ -58,6 +59,14 @@ final class ExoProcessController: ObservableObject {
     {
         didSet {
             UserDefaults.standard.set(enableImageModels, forKey: enableImageModelsKey)
+        }
+    }
+    @Published var offlineMode: Bool = {
+        return UserDefaults.standard.bool(forKey: offlineModeKey)
+    }()
+    {
+        didSet {
+            UserDefaults.standard.set(offlineMode, forKey: offlineModeKey)
         }
     }
 
@@ -266,6 +275,9 @@ final class ExoProcessController: ObservableObject {
         }
         if enableImageModels {
             environment["EXO_ENABLE_IMAGE_MODELS"] = "true"
+        }
+        if offlineMode {
+            environment["EXO_OFFLINE"] = "true"
         }
 
         var paths: [String] = []

--- a/app/EXO/EXO/Views/SettingsView.swift
+++ b/app/EXO/EXO/Views/SettingsView.swift
@@ -13,6 +13,7 @@ struct SettingsView: View {
     @State private var pendingNamespace: String = ""
     @State private var pendingHFToken: String = ""
     @State private var pendingEnableImageModels = false
+    @State private var pendingOfflineMode = false
     @State private var needsRestart = false
     @State private var bugReportInFlight = false
     @State private var bugReportMessage: String?
@@ -42,6 +43,7 @@ struct SettingsView: View {
             pendingNamespace = controller.customNamespace
             pendingHFToken = controller.hfToken
             pendingEnableImageModels = controller.enableImageModels
+            pendingOfflineMode = controller.offlineMode
             needsRestart = false
         }
     }
@@ -68,6 +70,13 @@ struct SettingsView: View {
                         .frame(width: 200)
                 }
                 Text("Required for gated models. Get yours at huggingface.co/settings/tokens")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Section {
+                Toggle("Offline Mode", isOn: $pendingOfflineMode)
+                Text("Skip internet checks and use only locally available models.")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -445,6 +454,7 @@ struct SettingsView: View {
 
     private var hasGeneralChanges: Bool {
         pendingNamespace != controller.customNamespace || pendingHFToken != controller.hfToken
+            || pendingOfflineMode != controller.offlineMode
     }
 
     private var hasModelChanges: Bool {
@@ -454,6 +464,7 @@ struct SettingsView: View {
     private func applyGeneralSettings() {
         controller.customNamespace = pendingNamespace
         controller.hfToken = pendingHFToken
+        controller.offlineMode = pendingOfflineMode
         restartIfRunning()
     }
 

--- a/src/exo/download/shard_downloader.py
+++ b/src/exo/download/shard_downloader.py
@@ -16,11 +16,6 @@ from exo.shared.types.worker.shards import (
 
 # TODO: the PipelineShardMetadata getting reinstantiated is a bit messy. Should this be a classmethod?
 class ShardDownloader(ABC):
-    internet_connection: bool = False
-
-    def set_internet_connection(self, value: bool) -> None:
-        self.internet_connection = value
-
     @abstractmethod
     async def ensure_shard(
         self, shard: ShardMetadata, config_only: bool = False

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -60,7 +60,7 @@ class Node:
             download_coordinator = DownloadCoordinator(
                 node_id,
                 session_id,
-                exo_shard_downloader(),
+                exo_shard_downloader(offline=args.offline),
                 download_command_receiver=router.receiver(topics.DOWNLOAD_COMMANDS),
                 local_event_sender=router.sender(topics.LOCAL_EVENTS),
                 offline=args.offline,
@@ -211,7 +211,7 @@ class Node:
                         self.download_coordinator = DownloadCoordinator(
                             self.node_id,
                             result.session_id,
-                            exo_shard_downloader(),
+                            exo_shard_downloader(offline=self.offline),
                             download_command_receiver=self.router.receiver(
                                 topics.DOWNLOAD_COMMANDS
                             ),
@@ -283,7 +283,7 @@ class Args(CamelCaseModel):
     tb_only: bool = False
     no_worker: bool = False
     no_downloads: bool = False
-    offline: bool = False
+    offline: bool = os.getenv("EXO_OFFLINE", "false").lower() == "true"
     fast_synch: bool | None = None  # None = auto, True = force on, False = force off
 
     @classmethod
@@ -334,6 +334,7 @@ class Args(CamelCaseModel):
         parser.add_argument(
             "--offline",
             action="store_true",
+            default=os.getenv("EXO_OFFLINE", "false").lower() == "true",
             help="Run in offline/air-gapped mode: skip internet checks, use only pre-staged local models",
         )
         fast_synch_group = parser.add_mutually_exclusive_group()

--- a/src/exo/shared/constants.py
+++ b/src/exo/shared/constants.py
@@ -78,4 +78,6 @@ EXO_ENABLE_IMAGE_MODELS = (
     os.getenv("EXO_ENABLE_IMAGE_MODELS", "false").lower() == "true"
 )
 
+EXO_OFFLINE = os.getenv("EXO_OFFLINE", "false").lower() == "true"
+
 EXO_TRACING_ENABLED = os.getenv("EXO_TRACING_ENABLED", "false").lower() == "true"


### PR DESCRIPTION
## Motivation

The socket-based internet connectivity probes (connecting to 1.1.1.1/8.8.8.8/1.0.0.1 every 10 seconds) are flaky — they produce false negatives on some networks/ISPs, causing downloads to silently fail or get stuck. Instead of dynamically detecting connectivity, this replaces it with an explicit offline mode that the user opts into.

## Changes

- **Removed internet check infrastructure**: Deleted `_test_internet_connection()` (socket probes) and `_check_internet_connection()` (10s polling loop) from `DownloadCoordinator`
- **Renamed `internet_connection` → `offline`** on `ShardDownloader` base class and all subclasses (`SingletonShardDownloader`, `CachedShardDownloader`, `ResumableShardDownloader`)
- **Removed `on_connection_lost` callbacks** from download calls — no longer needed without dynamic connectivity detection
- **Added `EXO_OFFLINE` env var support** in `constants.py` and `Args` default in `main.py`
- **Added Offline Mode toggle** to macOS app Settings → General tab, which sets `EXO_OFFLINE=true` in the process environment and restarts

## Why It Works

The download behavior (`skip_internet` conditionals in `download_utils.py`) is unchanged — we just changed what drives it. Instead of a flaky socket probe setting `internet_connection=True/False`, the user explicitly sets offline mode via:
1. `--offline` CLI flag
2. `EXO_OFFLINE=true` environment variable
3. macOS app Settings → General → Offline Mode toggle

This is more reliable and predictable. Users on flaky networks no longer get intermittent download failures.

## Test Plan

### Manual Testing
- `uv run exo --offline` starts without internet checks, rejects downloads for unavailable models
- `EXO_OFFLINE=true uv run exo` behaves identically
- macOS app Settings toggle persists across restarts and passes env var to the exo process

### Automated Testing
- All existing tests pass (222 passed), including 8 offline-mode specific tests
- `uv run basedpyright` — 0 errors
- `uv run ruff check` — all checks passed
- `nix fmt` — 0 files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)