### PR TITLE
fix: mini topology sidebar navigates home on click

### DIFF
--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -6050,12 +6050,11 @@
               </div>
 
               <div
-                class="relative aspect-square bg-exo-dark-gray rounded-lg overflow-hidden"
+                class="relative aspect-square bg-exo-dark-gray rounded-lg overflow-hidden pointer-events-none"
               >
                 <TopologyGraph
                   highlightedNodes={highlightedNodes()}
                   filteredNodes={nodeFilter}
-                  onNodeClick={togglePreviewNodeFilter}
                 />
 
                 {@render clusterWarningsCompact()}


### PR DESCRIPTION
## Motivation

Clicking on the mini topology view in the right sidebar during chat was selecting/filtering nodes instead of navigating back to the home view. The entire mini topology section is wrapped in a button that calls `handleGoHome()`, but individual node clicks were intercepting the event via `stopPropagation()`.

## Changes

- Removed `onNodeClick={togglePreviewNodeFilter}` from the mini sidebar's `TopologyGraph` component
- Added `pointer-events-none` to the topology graph container so all clicks pass through to the parent button

## Why It Works

`TopologyGraph` only registers click/hover handlers when `onNodeClick` is provided. Removing it disables node interaction entirely in the mini view. The `pointer-events-none` class ensures no SVG element can intercept clicks — they all bubble up to the parent `<button onclick={handleGoHome}>`, which resets the chat state and returns to the main topology view.

## Test Plan

### Manual Testing
<!-- Hardware: (e.g., MacBook Pro M1 Max 32GB, Mac Mini M2 16GB, connected via Thunderbolt 4) -->
<!-- What you did: -->
- Start exo and open the dashboard
- Start a chat to trigger the mini topology sidebar
- Click on the mini topology view → should navigate back to home
- Confirm nodes in the mini topology are not selectable or hoverable

### Automated Testing
- Dashboard builds successfully (`npm run build`)