### PR TITLE
fix: log exceptions causing silent node shutdown

### DIFF
--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -270,9 +270,16 @@ def main():
         logger.info("FAST_SYNCH forced OFF")
 
     node = anyio.run(Node.create, args)
-    anyio.run(node.run)
-    logger.info("EXO Shutdown complete")
-    logger_cleanup()
+    try:
+        anyio.run(node.run)
+    except BaseException as exception:
+        logger.opt(exception=exception).critical(
+            "EXO terminated due to unhandled exception"
+        )
+        raise
+    finally:
+        logger.info("EXO Shutdown complete")
+        logger_cleanup()
 
 
 class Args(CamelCaseModel):


### PR DESCRIPTION
## Motivation

Nodes silently shut down mid-inference with no exception logged. The logs show a clean-looking shutdown cascade (unsubscribe all topics → stop worker → runner communication closed) but no error explaining *why*. This makes debugging cluster issues extremely difficult.

## Changes

**`src/exo/routing/router.py`** — Added `try/except Exception` around `_networking_recv()` and `_networking_recv_connection_messages()` loops. Logs the root cause at ERROR level via `logger.opt(exception=...).error(...)` before re-raising. Uses `Exception` (not `BaseException`) so clean SIGTERM cancellation is unaffected.

**`src/exo/main.py`** — Wrapped `anyio.run(node.run)` in `try/except/finally`:
- `except BaseException`: logs the fatal exception at CRITICAL level through loguru
- `finally`: ensures `logger.info("EXO Shutdown complete")` and `logger_cleanup()` always run, guaranteeing the async log queue is flushed before process exit

## Why It Works

The Router's recv loops (`_networking_recv`, `_networking_recv_connection_messages`) are infinite `while True` loops calling Rust bindings with **no exception handling**. When the Rust networking layer raises `ConnectionError` (e.g. channel closed), the exception cascades silently through anyio task groups: Router → Node → all components shut down. The exception was never logged because (1) no try-except anywhere in the cascade, and (2) `logger_cleanup()` was skipped when `anyio.run()` raised, so loguru's async queue was never flushed.

## Test Plan

### Manual Testing
- Run `uv run exo`, send SIGTERM → should see clean shutdown with "EXO Shutdown complete", no error/critical logs
- Next time the silent shutdown reproduces, logs should now show the actual exception with full traceback at ERROR level from the recv loop, plus CRITICAL level from main()

### Automated Testing
- All 222 existing tests pass (1 pre-existing failure in `test_python.py::test_sleep_on_multiple_items` unrelated to this change)
- `uv run basedpyright` — 0 errors
- `uv run ruff check` — all checks passed
- `nix fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)