### PR TITLE
Support trace deletion in dashboard

### DIFF
--- a/dashboard/src/lib/stores/app.svelte.ts
+++ b/dashboard/src/lib/stores/app.svelte.ts
@@ -3159,6 +3159,23 @@ class AppStore {
   }
 
   /**
+   * Delete traces by task IDs
+   */
+  async deleteTraces(
+    taskIds: string[],
+  ): Promise<{ deleted: string[]; notFound: string[] }> {
+    const response = await fetch("/v1/traces/delete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ taskIds }),
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to delete traces: ${response.status}`);
+    }
+    return await response.json();
+  }
+
+  /**
    * Get the URL for the raw trace file (for Perfetto)
    */
   getTraceRawUrl(taskId: string): string {
@@ -3301,3 +3318,5 @@ export const fetchTraceStats = (taskId: string) =>
   appStore.fetchTraceStats(taskId);
 export const getTraceRawUrl = (taskId: string) =>
   appStore.getTraceRawUrl(taskId);
+export const deleteTraces = (taskIds: string[]) =>
+  appStore.deleteTraces(taskIds);

--- a/src/exo/shared/types/api.py
+++ b/src/exo/shared/types/api.py
@@ -437,3 +437,12 @@ class TraceListItem(CamelCaseModel):
 
 class TraceListResponse(CamelCaseModel):
     traces: list[TraceListItem]
+
+
+class DeleteTracesRequest(CamelCaseModel):
+    task_ids: list[str]
+
+
+class DeleteTracesResponse(CamelCaseModel):
+    deleted: list[str]
+    not_found: list[str]


### PR DESCRIPTION
## Motivation

Enable using the dashboard to delete traces

## Changes

  - Backend (src/exo/master/api.py): Added POST /v1/traces/delete endpoint that deletes trace files by task ID, with path traversal protection
  - API types (src/exo/shared/types/api.py): Added DeleteTracesRequest and DeleteTracesResponse models
  - Dashboard store (app.svelte.ts): Added deleteTraces() method
  - Traces page (+page.svelte): Added multi-select UI (click to select, select all/deselect all) with a bulk delete button and confirmation dialog

## Why It Works

  - Uses existing _get_trace_path helper (now hardened against path traversal) to resolve and delete trace files
  - Dashboard selection state is reactive via Svelte 5 runes; deleted traces refresh the list automatically

## Test Plan

### Manual Testing

  - Select individual traces, select all, delete with confirmation dialog
  - Verify traces are removed from disk and list refreshes

