### PR TITLE
fix: update fa_idx/ssm_idx for Qwen3.5 after pipeline layer slicing

### DIFF
--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -38,6 +38,7 @@ from mlx_lm.models.qwen3_next import Qwen3NextDecoderLayer, Qwen3NextSparseMoeBl
 from mlx_lm.models.step3p5 import Model as Step35Model
 from mlx_lm.models.step3p5 import Step3p5MLP as Step35MLP
 from mlx_lm.models.step3p5 import Step3p5Model as Step35InnerModel
+from mlx_lm.models.qwen3_5 import Qwen3_5TextModel
 
 from exo.shared.logging import logger
 from exo.shared.types.worker.shards import PipelineShardMetadata
@@ -190,10 +191,13 @@ class PipelineLastLayer(CustomMlxLayer):
             if cache is not None:
                 # CacheList (used by MLA models like DeepSeekV32, GLM MoE DSA)
                 # doesn't have .keys directly; access via first sub-cache.
+                # ArraysCache (used by hybrid SSM/attention models like Qwen3.5)
+                # has no .keys attribute at all — guard before accessing.
                 _cache = cache[0] if hasattr(cache, "caches") else cache  # type: ignore
-                _cache.keys = mx.depends(_cache.keys, output)  # type: ignore
+                if hasattr(_cache, "keys"):
+                    _cache.keys = mx.depends(_cache.keys, output)  # type: ignore
             mx.eval(output)
-            if cache is not None:
+            if cache is not None and hasattr(_cache, "keys"):  # type: ignore
                 mx.eval(_cache.keys)  # type: ignore
 
         if not self.is_prefill:
@@ -318,6 +322,21 @@ def pipeline_auto_parallel(
         inner_model_instance._swa_idx = 0 if not sliding_layers else sliding_layers[0]
         inner_model_instance._full_idx = 0 if not full_layers else full_layers[0]
 
+    if isinstance(inner_model_instance, Qwen3_5TextModel):
+        # fa_idx and ssm_idx are global layer indices set during __init__.
+        # After pipeline layer slicing they must point to the first full-attention
+        # and first linear (SSM) layer in the local slice, respectively.
+        # If the local slice contains no full-attention layers (all SSM), fa_idx
+        # defaults to 0 so that create_attention_mask receives a valid cache entry.
+        full_attn_layers = [
+            i for i, layer in enumerate(layers) if not getattr(layer, "is_linear", True)
+        ]
+        linear_layers = [
+            i for i, layer in enumerate(layers) if getattr(layer, "is_linear", False)
+        ]
+        inner_model_instance.fa_idx = full_attn_layers[0] if full_attn_layers else 0
+        inner_model_instance.ssm_idx = linear_layers[0] if linear_layers else 0
+
     _set_layers(model, layers)
 
     assert isinstance(layers, list), (
@@ -347,7 +366,8 @@ def patch_pipeline_model[T](model: T, group: mx.distributed.Group) -> T:
         if cache is not None:
             last = cache[-1]  # type: ignore
             dep_cache = last[0] if hasattr(last, "caches") else last  # type: ignore
-            dep_cache.keys = mx.depends(dep_cache.keys, logits)  # type: ignore
+            if hasattr(dep_cache, "keys"):
+                dep_cache.keys = mx.depends(dep_cache.keys, logits)  # type: ignore
 
         return logits
 


### PR DESCRIPTION
## Motivation

When running a Qwen3.5 model (e.g. `mlx-community/Qwen3.5-122B-A10B-8bit`) across 2 nodes in pipeline mode, inference crashes with one of two errors depending on which node receives which layer slice:

- `TypeError: ArraysCache.make_mask() got an unexpected keyword argument 'return_array'`
- `AttributeError: 'ArraysCache' object has no attribute 'keys'`

Fixes #1646

## Root Cause

Qwen3.5 is a hybrid SSM/attention model. Its layers alternate between linear attention layers (GatedDeltaNet, using `ArraysCache`) and full-attention layers (using `KVCache`) every `full_attention_interval` (default: 4) layers.

`Qwen3_5TextModel.__init__` sets `fa_idx = full_attention_interval - 1` and `ssm_idx = 0` as **global** layer indices. When Exo splits the model across nodes, each node only receives a slice of the layers and a corresponding local cache list. However, `fa_idx` and `ssm_idx` were never updated to reflect the local slice.

On a node whose slice starts mid-model (e.g. layers 48–95), `cache[fa_idx]` (e.g. `cache[3]`) lands on an `ArraysCache` entry instead of the expected `KVCache`. This causes:

1. `create_attention_mask` to call `ArraysCache.make_mask` with kwargs it does not accept
2. The pipeline sync code to access `.keys` which `ArraysCache` does not have

## Changes

1. **`pipeline_auto_parallel`**: After slicing layers for each node, update `fa_idx` and `ssm_idx` on `Qwen3_5TextModel` to point to the first full-attention and first linear (SSM) layer in the local slice respectively. This follows the same pattern already used for `GptOssMoeModel` (`swa_idx`/`ga_idx`) and `Step35InnerModel` (`_swa_idx`/`_full_idx`).

2. **`PipelineLastLayer.__call__`** and **`patch_pipeline_model`**: Guard `.keys` access with `hasattr(_cache, "keys")` to be safe against cache types that do not have this attribute (such as `ArraysCache`). This is a defensive fix that prevents similar crashes for other future hybrid SSM/attention models.

## Manual Testing

Verified with `mlx-community/Qwen3.5-122B-A10B-8bit` split across 2x Mac Studio M4 Max 128GB nodes in pipeline mode. Both nodes complete warmup and inference successfully after this fix.

## Additional
The Qwen3.5-122B actually worked for me on v1.0.68 when I first tried but it no longer does. I'm not really sure why it worked initially, but this is what I think could've happened (I'm not really sure, need someone to verify):

The first time I ran it on v1.0.68, my two nodes happened to have a memory ratio that produced a 24/24 split (or any split divisible by 4). With a 24/24 split:

- Node 0: layers 0–23, cache[3] = KVCache (layer 3 is full attention)
- Node 1: layers 24–47, cache[3] = KVCache (layer 27 is full attention)

Both nodes worked perfectly by coincidence.

But when I ran it again later — even on the same v1.0.68 code — the available RAM on my nodes was slightly different (maybe a browser was open, or macOS allocated memory differently, or Spotlight was indexing). This caused a split like 23/25 instead of 24/24:

- Node 0: layers 0–22 → cache[3] = KVCache (layer 3) — still works
- Node 1: layers 23–47 → cache[3] = ArraysCache (layer 26) — crashes

This is exactly what my traceback shows: cache[0] = KVCache (the slice starts at layer 23, which is full attention), but cache[3] = ArraysCache (layer 26, which is linear).