### PR TITLE
Ciaran/re download bug

### DIFF
--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -19,9 +19,7 @@ def exo_shard_downloader(
     max_parallel_downloads: int = 8, offline: bool = False
 ) -> ShardDownloader:
     return SingletonShardDownloader(
-        CachedShardDownloader(
-            ResumableShardDownloader(max_parallel_downloads, offline=offline)
-        )
+        ResumableShardDownloader(max_parallel_downloads, offline=offline)
     )
 
 
@@ -72,39 +70,6 @@ class SingletonShardDownloader(ShardDownloader):
         finally:
             if shard in self.active_downloads and self.active_downloads[shard].done():
                 del self.active_downloads[shard]
-
-    async def get_shard_download_status(
-        self,
-    ) -> AsyncIterator[tuple[Path, RepoDownloadProgress]]:
-        async for path, status in self.shard_downloader.get_shard_download_status():
-            yield path, status
-
-    async def get_shard_download_status_for_shard(
-        self, shard: ShardMetadata
-    ) -> RepoDownloadProgress:
-        return await self.shard_downloader.get_shard_download_status_for_shard(shard)
-
-
-class CachedShardDownloader(ShardDownloader):
-    def __init__(self, shard_downloader: ShardDownloader):
-        self.shard_downloader = shard_downloader
-        self.cache: dict[tuple[str, ShardMetadata], Path] = {}
-
-    def on_progress(
-        self,
-        callback: Callable[[ShardMetadata, RepoDownloadProgress], Awaitable[None]],
-    ) -> None:
-        self.shard_downloader.on_progress(callback)
-
-    async def ensure_shard(
-        self, shard: ShardMetadata, config_only: bool = False
-    ) -> Path:
-        if (shard.model_card.model_id, shard) in self.cache:
-            return self.cache[(shard.model_card.model_id, shard)]
-
-        target_dir = await self.shard_downloader.ensure_shard(shard, config_only)
-        self.cache[(shard.model_card.model_id, shard)] = target_dir
-        return target_dir
 
     async def get_shard_download_status(
         self,

--- a/src/exo/download/tests/test_re_download.py
+++ b/src/exo/download/tests/test_re_download.py
@@ -1,6 +1,7 @@
 """Tests that re-downloading a previously deleted model completes successfully."""
 
 import asyncio
+import contextlib
 from collections.abc import AsyncIterator, Awaitable
 from datetime import timedelta
 from pathlib import Path
@@ -9,7 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 from exo.download.coordinator import DownloadCoordinator
 from exo.download.download_utils import RepoDownloadProgress
-from exo.download.impl_shard_downloader import CachedShardDownloader, SingletonShardDownloader
+from exo.download.impl_shard_downloader import SingletonShardDownloader
 from exo.download.shard_downloader import ShardDownloader
 from exo.shared.models.model_cards import ModelCard, ModelId, ModelTask
 from exo.shared.types.commands import (
@@ -62,7 +63,9 @@ class FakeShardDownloader(ShardDownloader):
         self._progress_callbacks.append(callback)
 
     async def ensure_shard(
-        self, shard: ShardMetadata, config_only: bool = False  # noqa: ARG002
+        self,
+        shard: ShardMetadata,
+        config_only: bool = False,  # noqa: ARG002
     ) -> Path:
         # Simulate a completed download by firing the progress callback
         progress = RepoDownloadProgress(
@@ -86,18 +89,26 @@ class FakeShardDownloader(ShardDownloader):
         self,
     ) -> AsyncIterator[tuple[Path, RepoDownloadProgress]]:
         if False:  # noqa: SIM108  # empty async generator
-            yield (Path(), RepoDownloadProgress(  # pyright: ignore[reportUnreachable]
-                repo_id="", repo_revision="", shard=_make_shard(),
-                completed_files=0, total_files=0, downloaded=Memory.from_bytes(0),
-                downloaded_this_session=Memory.from_bytes(0), total=Memory.from_bytes(0),
-                overall_speed=0, overall_eta=timedelta(seconds=0), status="not_started",
-            ))
-
-    def invalidate(self, model_id: ModelId) -> None:
-        pass
+            yield (
+                Path(),
+                RepoDownloadProgress(  # pyright: ignore[reportUnreachable]
+                    repo_id="",
+                    repo_revision="",
+                    shard=_make_shard(),
+                    completed_files=0,
+                    total_files=0,
+                    downloaded=Memory.from_bytes(0),
+                    downloaded_this_session=Memory.from_bytes(0),
+                    total=Memory.from_bytes(0),
+                    overall_speed=0,
+                    overall_eta=timedelta(seconds=0),
+                    status="not_started",
+                ),
+            )
 
     async def get_shard_download_status_for_shard(
-        self, shard: ShardMetadata,
+        self,
+        shard: ShardMetadata,
     ) -> RepoDownloadProgress:
         return RepoDownloadProgress(
             repo_id=str(shard.model_card.model_id),
@@ -122,9 +133,8 @@ async def test_re_download_after_delete_completes() -> None:
     cmd_send, cmd_recv = channel[ForwarderDownloadCommand]()
     event_send, event_recv = channel[Event]()
 
-    # Wrap in CachedShardDownloader + SingletonShardDownloader to match production
     fake_downloader = FakeShardDownloader()
-    wrapped_downloader = SingletonShardDownloader(CachedShardDownloader(fake_downloader))
+    wrapped_downloader = SingletonShardDownloader(fake_downloader)
     coordinator = DownloadCoordinator(
         node_id=NODE_ID,
         shard_downloader=wrapped_downloader,
@@ -178,10 +188,8 @@ async def test_re_download_after_delete_completes() -> None:
         finally:
             coordinator.shutdown()
             coordinator_task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await coordinator_task
-            except asyncio.CancelledError:
-                pass
 
 
 async def _wait_for_download_completed(


### PR DESCRIPTION
## Motivation

After deleting a model and re-downloading it, the CachedShardDownloader returns the stale cached path, so ensure_shard short-circuits and no download actually happens.

## Changes

- Added invalidate(model_id) method to the ShardDownloader ABC and all implementations
- CachedShardDownloader.invalidate evicts cache entries matching the model ID and delegates down
- DownloadCoordinator.delete_model calls invalidate after cancelling active downloads, before deleting files
- Added end-to-end test that downloads, deletes, and re-downloads a model through the coordinator

## Why It Works

The cache is cleared when a model is deleted, so the next ensure_shard call performs a fresh download instead of returning the stale path.

## Test Plan

## Automated Testing

New test_re_download_after_delete_completes exercises the full download → delete → re-download flow through DownloadCoordinator with CachedShardDownloader + SingletonShardDownloader wrappers matching production.

