### PR TITLE
fix: make cancel_command idempotent to prevent duplicate TaskCancelled events

### DIFF
--- a/src/exo/master/api.py
+++ b/src/exo/master/api.py
@@ -571,9 +571,9 @@ class API:
 
     async def cancel_command(self, command_id: CommandId) -> CancelCommandResponse:
         """Cancel an active command by closing its stream and notifying workers."""
-        sender = self._text_generation_queues.get(
-            command_id
-        ) or self._image_generation_queues.get(command_id)
+        sender = self._text_generation_queues.pop(
+            command_id, None
+        ) or self._image_generation_queues.pop(command_id, None)
         if sender is None:
             raise HTTPException(
                 status_code=404,


### PR DESCRIPTION
## Problem

`POST /v1/cancel/{command_id}` uses `.get()` to look up the stream sender but never removes it from `_text_generation_queues`. If a client calls cancel more than once (e.g., retries or concurrent cancel paths), each call finds the same closed sender still in the dict and emits another `TaskCancelled` event — flooding all worker nodes with redundant `CancelTask` plans.

## Fix

Change `.get()` to `.pop()` in `cancel_command` so the sender is atomically removed on the first cancel. Subsequent calls find no sender and return 404 ("Command not found or already completed"), which is the correct idempotent behavior for a cancel endpoint.

The `_token_chunk_stream` `finally` block already has a guarded `del` for normal completion cleanup — the `pop` in `cancel_command` runs before the `finally`, which then safely no-ops on the already-missing key.

## Testing

- Single cancel: returns 200, stream stopped as before
- Double cancel (same `command_id`): second call returns 404
- Cancel after stream ends naturally: returns 404 (sender already removed by stream cleanup)