### PR TITLE
fix: `KVPrefixCache` Regression

### DIFF
--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -216,6 +216,8 @@ class Runner:
                         tok.tool_parser,  # pyright: ignore[reportAny]
                     )
 
+                self.generator.kv_prefix_cache = KVPrefixCache(self.generator.group)
+
                 self.generator = self.generator.build()
 
                 self.send_task_status(task.task_id, TaskStatus.Complete)


### PR DESCRIPTION
## Motivation

PR #1632 accidentally removed the `KVPrefixCache` initialization that was added in #1262. 

The `Builder` dataclass declares `kv_prefix_cache: KVPrefixCache | None = None` but never sets it to a real `KVPrefixCache(group)` before calling `build()`. This means every request creates a fresh KV cache from scratch, completely negating the prefill speedup from #1262.

## Changes

One line added in `runner.py:` initialize `self.generator.kv_prefix_cache = KVPrefixCache(self.generator.group)` after model loading completes and before `self.generator.build()` is called. This restores the behavior from before the #1632 refactor.

## Why It Works

The old runner code (pre #1632) created `kv_prefix_cache = KVPrefixCache(group)` in the model load path and passed it through to `mlx_generate()`. The batching refactor moved setup into a `Builder` dataclass but forgot to initialize this field. 

By setting it after model/tokenizer/group are all loaded (right before `build()`), the `SequentialGenerator` receives a live prefix cache and reuses tokenized prefixes across requests, exactly as #1262 implemented.

## Test Plan

### Manual Testing

**Hardware:** Mac Studio M3 Ultra 96GB + Mac Mini M4 Pro 24GB: connected via Thunderbolt 5 (RDMA)

Tested via the OpenAI `/v1/chat/completions` API from a client app sending streaming requests with tools enabled.

- First request: Confirmed using default KV cache & KV cache added: 1983 tokens (cache populated)
- Second request (same conversation): Confirmed KV cache hit: 481/1982 tokens cached (24.3%) (partial prefix reuse from system prompt overlap)
- After several messages in the same conversation: cache hit ratio climbed to 99% as conversation continued
- Prefill dropped from ~6s to ~0.4s once the cache was warm


### Automated Testing

Full test suite passes: 238 passed, 1 skipped, 0 failures. Existing `test_kv_prefix_cache.py` tests cover the `KVPrefixCache` behavior.