### PR TITLE
Add backpressure guard for chat text generations

### DIFF
--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -2,6 +2,7 @@ import base64
 import contextlib
 import hashlib
 import json
+import os
 import random
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
@@ -864,6 +865,25 @@ class API:
             "TODO: we should send a notification to the user to download the model"
         )
 
+    def _enforce_text_generation_backpressure(self) -> None:
+        """Protect workers from overload by limiting concurrent text streams.
+
+        Sub-agent workloads can issue many concurrent requests (for example, parallel
+        tool-calling clients). A bounded number of in-flight streams prevents runaway
+        queue growth and OOM cascades on smaller clusters.
+        """
+        max_in_flight = int(os.getenv("EXO_MAX_IN_FLIGHT_TEXT_GENERATIONS", "2"))
+        in_flight = len(self._text_generation_queues)
+        if in_flight >= max_in_flight:
+            raise HTTPException(
+                status_code=HTTPStatus.TOO_MANY_REQUESTS,
+                detail=(
+                    "Server is busy processing other generations. "
+                    f"in_flight={in_flight}, limit={max_in_flight}. "
+                    "Retry shortly or reduce client-side parallelism."
+                ),
+            )
+
     async def _send_text_generation_with_images(
         self, task_params: TextGenerationTaskParams
     ) -> TextGeneration:
@@ -917,6 +937,7 @@ class API:
         self, payload: ChatCompletionRequest
     ) -> ChatCompletionResponse | StreamingResponse:
         """OpenAI Chat Completions API - adapter."""
+        self._enforce_text_generation_backpressure()
         task_params = await chat_request_to_text_generation(payload)
         validated_model = await self._validate_model_has_instance(task_params.model)
         task_params = task_params.model_copy(update={"model": validated_model})
@@ -950,6 +971,7 @@ class API:
     async def bench_chat_completions(
         self, payload: BenchChatCompletionRequest
     ) -> BenchChatCompletionResponse | StreamingResponse:
+        self._enforce_text_generation_backpressure()
         task_params = await chat_request_to_text_generation(payload)
         validated_model = await self._validate_model_has_instance(
             ModelId(task_params.model)

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -2,7 +2,6 @@ import base64
 import contextlib
 import hashlib
 import json
-import os
 import random
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
@@ -247,6 +246,7 @@ class API:
         download_command_sender: Sender[ForwarderDownloadCommand],
         # This lets us pause the API if an election is running
         election_receiver: Receiver[ElectionMessage],
+        max_in_flight_text_generations: int = 2,
     ) -> None:
         self.state = State()
         self._event_log = DiskEventLog(_API_EVENT_LOG_DIR)
@@ -259,6 +259,7 @@ class API:
         self.last_completed_election: int = 0
         self.port = port
         self._sent_image_hashes: set[str] = set()
+        self.max_in_flight_text_generations = max_in_flight_text_generations
 
         self.paused: bool = False
         self.paused_ev: anyio.Event = anyio.Event()
@@ -872,7 +873,7 @@ class API:
         tool-calling clients). A bounded number of in-flight streams prevents runaway
         queue growth and OOM cascades on smaller clusters.
         """
-        max_in_flight = int(os.getenv("EXO_MAX_IN_FLIGHT_TEXT_GENERATIONS", "2"))
+        max_in_flight = self.max_in_flight_text_generations
         in_flight = len(self._text_generation_queues)
         if in_flight >= max_in_flight:
             raise HTTPException(

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -97,6 +97,7 @@ class Node:
                 command_sender=router.sender(topics.COMMANDS),
                 download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
                 election_receiver=router.receiver(topics.ELECTION_MESSAGES),
+                max_in_flight_text_generations=args.max_in_flight_text_generations,
             )
         else:
             api = None
@@ -382,6 +383,7 @@ class Args(FrozenModel):
     force_master: bool = False
     spawn_api: bool = False
     api_port: PositiveInt = 52415
+    max_in_flight_text_generations: PositiveInt = 2
     tb_only: bool = False
     no_worker: bool = False
     no_downloads: bool = False
@@ -429,6 +431,13 @@ class Args(FrozenModel):
             type=int,
             dest="api_port",
             default=52415,
+        )
+        parser.add_argument(
+            "--max-in-flight-text-generations",
+            type=int,
+            dest="max_in_flight_text_generations",
+            default=2,
+            help="Maximum concurrent in-flight text generation streams before API returns 429",
         )
         parser.add_argument(
             "--no-worker",

--- a/src/exo/master/tests/test_text_generation_backpressure.py
+++ b/src/exo/master/tests/test_text_generation_backpressure.py
@@ -1,0 +1,32 @@
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from exo.shared.types.common import CommandId
+
+
+def _make_api_with_inflight(n: int):
+    from exo.api.main import API
+
+    api = object.__new__(API)
+    api._text_generation_queues = {
+        CommandId(f"cmd-{i}"): object() for i in range(n)
+    }  # pyright: ignore[reportPrivateUsage]
+    return api
+
+
+def test_backpressure_allows_when_below_limit() -> None:
+    api = _make_api_with_inflight(1)
+    with patch.dict("os.environ", {"EXO_MAX_IN_FLIGHT_TEXT_GENERATIONS": "2"}):
+        api._enforce_text_generation_backpressure()  # pyright: ignore[reportPrivateUsage]
+
+
+def test_backpressure_rejects_when_at_limit() -> None:
+    api = _make_api_with_inflight(2)
+    with patch.dict("os.environ", {"EXO_MAX_IN_FLIGHT_TEXT_GENERATIONS": "2"}):
+        with pytest.raises(HTTPException) as exc:
+            api._enforce_text_generation_backpressure()  # pyright: ignore[reportPrivateUsage]
+
+    assert exc.value.status_code == 429
+    assert "Server is busy processing other generations" in str(exc.value.detail)

--- a/src/exo/master/tests/test_text_generation_backpressure.py
+++ b/src/exo/master/tests/test_text_generation_backpressure.py
@@ -1,15 +1,14 @@
-from unittest.mock import patch
-
 import pytest
 from fastapi import HTTPException
 
 from exo.shared.types.common import CommandId
 
 
-def _make_api_with_inflight(n: int):
+def _make_api_with_inflight(n: int, *, limit: int = 2):
     from exo.api.main import API
 
     api = object.__new__(API)
+    api.max_in_flight_text_generations = limit
     api._text_generation_queues = {
         CommandId(f"cmd-{i}"): object() for i in range(n)
     }  # pyright: ignore[reportPrivateUsage]
@@ -17,16 +16,14 @@ def _make_api_with_inflight(n: int):
 
 
 def test_backpressure_allows_when_below_limit() -> None:
-    api = _make_api_with_inflight(1)
-    with patch.dict("os.environ", {"EXO_MAX_IN_FLIGHT_TEXT_GENERATIONS": "2"}):
-        api._enforce_text_generation_backpressure()  # pyright: ignore[reportPrivateUsage]
+    api = _make_api_with_inflight(1, limit=2)
+    api._enforce_text_generation_backpressure()  # pyright: ignore[reportPrivateUsage]
 
 
 def test_backpressure_rejects_when_at_limit() -> None:
-    api = _make_api_with_inflight(2)
-    with patch.dict("os.environ", {"EXO_MAX_IN_FLIGHT_TEXT_GENERATIONS": "2"}):
-        with pytest.raises(HTTPException) as exc:
-            api._enforce_text_generation_backpressure()  # pyright: ignore[reportPrivateUsage]
+    api = _make_api_with_inflight(2, limit=2)
+    with pytest.raises(HTTPException) as exc:
+        api._enforce_text_generation_backpressure()  # pyright: ignore[reportPrivateUsage]
 
     assert exc.value.status_code == 429
     assert "Server is busy processing other generations" in str(exc.value.detail)


### PR DESCRIPTION
## Summary
Add backpressure protection for chat text generations in the master API.

## Problem
When too many text generations are already in flight, new requests can overload the master process and degrade responsiveness.

## Root cause
There was no explicit in-flight guard for text generation requests at the API entry point.

## Fix
- Add a configurable backpressure guard for in-flight text generation requests.
- Return HTTP 429 when the in-flight count is at or above the configured limit.
- Add focused tests for both allow and reject behavior.

## Validation
- uv run pytest src/exo/master/tests/test_text_generation_backpressure.py src/exo/master/tests/test_cancel_command.py

Closes #1664.
