### PR TITLE
Ciaran/gpt oss tool call finish reason

### DIFF
--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -117,7 +117,7 @@ def parse_gpt_oss(
             if delta:
                 tool_arg_parts.append(delta)
             if response.finish_reason is not None:
-                yield response.model_copy(update={"text": ""})
+                yield response.model_copy(update={"text": "".join(tool_arg_parts)})
                 tool_arg_parts = []
             continue
 

--- a/src/exo/worker/tests/unittests/test_runner/test_parse_gpt_oss.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_parse_gpt_oss.py
@@ -234,11 +234,11 @@ class TestParseGptOssMaxTokensTruncation:
         ]
         assert "length" in finish_reasons
 
-    def test_truncated_tool_call_emits_empty_text(self):
+    def test_truncated_tool_call_emits_partial_args(self):
         results = _collect(TRUNCATED_TOOL_CALL_TOKENS, last_finish_reason="length")
         gen_responses = [r for r in results if isinstance(r, GenerationResponse)]
         last = [r for r in gen_responses if r.finish_reason is not None][-1]
-        assert last.text == ""
+        assert len(last.text) > 0
 
     def test_truncated_plain_text_still_works(self):
         results = _collect(PLAIN_TEXT_TOKENS, last_finish_reason="length")


### PR DESCRIPTION
## Motivation

When gpt-oss truncates a response mid-tool-call (e.g. hitting max tokens), the finish_reason was swallowed because the parser was in tool-accumulation mode and never yielded it back to the caller. This caused the API to hang or fail to signal completion.

## Changes

In parse_gpt_oss, when accumulating tool call arguments and a finish_reason arrives, yield the response (with empty text) so the finish reason propagates

## Why It Works

The parser now checks for finish_reason on every chunk while inside a tool call. When the model stops generating (truncation), the finish signal is forwarded immediately rather than being silently consumed.

## Test Plan

### Automated Testing

Added tests covering truncated tool calls (finish_reason="length") and plain text truncation