### PR TITLE
Ciaran/minor download bugs

### DIFF
--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -297,8 +297,8 @@ class DownloadCoordinator:
             del self.download_status[model_id]
 
     async def _emit_existing_download_progress(self) -> None:
-        try:
-            while True:
+        while True:
+            try:
                 logger.debug(
                     "DownloadCoordinator: Fetching and emitting existing download progress..."
                 )
@@ -386,8 +386,8 @@ class DownloadCoordinator:
                 logger.debug(
                     "DownloadCoordinator: Done emitting existing download progress."
                 )
-                await anyio.sleep(60)
-        except Exception as e:
-            logger.error(
-                f"DownloadCoordinator: Error emitting existing download progress: {e}"
-            )
+            except Exception as e:
+                logger.error(
+                    f"DownloadCoordinator: Error emitting existing download progress: {e}"
+                )
+            await anyio.sleep(60)


### PR DESCRIPTION
## Motivation

Two minor bugs in the download coordinator: cancelling a download didn't reset its status to pending, and a single error in _emit_existing_download_progress would kill the loop permanently.

## Changes

- Cancel emits pending status: When a download is cancelled, emit a DownloadPending event so the UI/cluster state reflects that the model is no longer actively downloading.
- Resilient progress emission loop: Move the try/except inside the while loop so transient errors are logged but the periodic emission continues.

## Why It Works

- The cancel fix ensures the download status is consistent — without it, a cancelled download would still appear as in-progress.
- The loop fix prevents a single exception from permanently stopping the 60-second periodic progress broadcast.
