### PR TITLE
dashboard: make mobile welcome/chat layouts usable with slide-up control panels

### DIFF
--- a/dashboard/src/lib/components/HeaderNav.svelte
+++ b/dashboard/src/lib/components/HeaderNav.svelte
@@ -30,11 +30,11 @@
 </script>
 
 <header
-  class="relative z-20 flex items-center justify-center px-6 pt-8 pb-4 bg-exo-dark-gray"
+  class="relative z-20 flex items-center justify-center px-4 sm:px-6 pt-4 sm:pt-8 pb-3 sm:pb-4 bg-exo-dark-gray"
 >
   <!-- Left: Sidebar Toggle -->
   {#if showSidebarToggle}
-    <div class="absolute left-6 top-1/2 -translate-y-1/2">
+    <div class="hidden lg:block absolute left-6 top-1/2 -translate-y-1/2">
       <button
         onclick={handleToggleSidebar}
         class="p-2 rounded border border-exo-light-gray/30 hover:border-exo-yellow/50 hover:bg-exo-medium-gray/30 transition-colors cursor-pointer"
@@ -83,19 +83,19 @@
     <img
       src="/exo-logo.png"
       alt="EXO"
-      class="h-18 drop-shadow-[0_0_4px_rgba(255,215,0,0.3)]"
+      class="h-14 sm:h-18 drop-shadow-[0_0_4px_rgba(255,215,0,0.3)]"
     />
   </button>
 
   <!-- Right: Home + Downloads -->
   <nav
-    class="absolute right-6 top-1/2 -translate-y-1/2 flex items-center gap-4"
+    class="absolute right-4 sm:right-6 top-1/2 -translate-y-1/2 flex items-center gap-2 sm:gap-4"
     aria-label="Main navigation"
   >
     {#if showHome}
       <button
         onclick={handleHome}
-        class="text-sm text-white/70 hover:text-exo-yellow transition-colors tracking-wider uppercase flex items-center gap-2 cursor-pointer"
+        class="text-xs sm:text-sm text-white/70 hover:text-exo-yellow transition-colors tracking-wider uppercase flex items-center gap-1.5 sm:gap-2 cursor-pointer"
         title="Back to topology view"
       >
         <svg
@@ -111,12 +111,12 @@
             d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
           />
         </svg>
-        Home
+        <span class="hidden sm:inline">Home</span>
       </button>
     {/if}
     <a
       href="/#/downloads"
-      class="text-sm text-white/70 hover:text-exo-yellow transition-colors tracking-wider uppercase flex items-center gap-2 cursor-pointer"
+      class="text-xs sm:text-sm text-white/70 hover:text-exo-yellow transition-colors tracking-wider uppercase flex items-center gap-1.5 sm:gap-2 cursor-pointer"
       title="View downloads overview"
     >
       {#if downloadProgress}
@@ -168,7 +168,7 @@
           <path d="M5 21h14" />
         </svg>
       {/if}
-      Downloads
+      <span class="hidden sm:inline">Downloads</span>
     </a>
   </nav>
 </header>

--- a/dashboard/src/lib/components/HuggingFaceResultItem.svelte
+++ b/dashboard/src/lib/components/HuggingFaceResultItem.svelte
@@ -36,12 +36,8 @@
     return num.toString();
   }
 
-  // Show short name for mlx-community models, full ID for everything else
-  const modelName = $derived(
-    model.author === "mlx-community"
-      ? model.id.split("/").pop() || model.id
-      : model.id,
-  );
+  // Extract model name from full ID (e.g., "mlx-community/Llama-3.2-1B" -> "Llama-3.2-1B")
+  const modelName = $derived(model.id.split("/").pop() || model.id);
 </script>
 
 <div

--- a/dashboard/src/lib/components/MarkdownContent.svelte
+++ b/dashboard/src/lib/components/MarkdownContent.svelte
@@ -507,29 +507,9 @@
   });
 
   $effect(() => {
-    if (!containerRef || !browser) return;
-
-    function handleDelegatedClick(event: MouseEvent) {
-      const codeBtn = (event.target as HTMLElement).closest(
-        ".copy-code-btn",
-      ) as HTMLButtonElement | null;
-      if (codeBtn) {
-        handleCopyClick({ currentTarget: codeBtn } as unknown as Event);
-        return;
-      }
-      const mathBtn = (event.target as HTMLElement).closest(
-        ".copy-math-btn",
-      ) as HTMLButtonElement | null;
-      if (mathBtn) {
-        handleMathCopyClick({ currentTarget: mathBtn } as unknown as Event);
-        return;
-      }
+    if (containerRef && processedHtml) {
+      setupCopyButtons();
     }
-
-    containerRef.addEventListener("click", handleDelegatedClick);
-    return () => {
-      containerRef?.removeEventListener("click", handleDelegatedClick);
-    };
   });
 </script>
 

--- a/dashboard/src/lib/components/ModelPickerGroup.svelte
+++ b/dashboard/src/lib/components/ModelPickerGroup.svelte
@@ -32,7 +32,6 @@
     group: ModelGroup;
     isExpanded: boolean;
     isFavorite: boolean;
-    isHighlighted?: boolean;
     selectedModelId: string | null;
     canModelFit: (id: string) => boolean;
     getModelFitStatus: (id: string) => ModelFitStatus;
@@ -49,7 +48,6 @@
     group,
     isExpanded,
     isFavorite,
-    isHighlighted = false,
     selectedModelId,
     canModelFit,
     getModelFitStatus,
@@ -152,11 +150,10 @@
 </script>
 
 <div
-  data-model-ids={group.variants.map((v) => v.id).join(" ")}
   class="border-b border-white/5 last:border-b-0 {!anyVariantFits &&
   !anyVariantHasInstance
     ? 'opacity-50'
-    : ''} {isHighlighted ? 'model-just-added' : ''}"
+    : ''}"
 >
   <!-- Main row -->
   <div
@@ -647,21 +644,3 @@
     </div>
   {/if}
 </div>
-
-<style>
-  .model-just-added {
-    animation: highlightFade 4s ease-out forwards;
-  }
-
-  @keyframes highlightFade {
-    0%,
-    40% {
-      background-color: rgba(20, 83, 45, 0.25);
-      box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.4);
-    }
-    100% {
-      background-color: transparent;
-      box-shadow: none;
-    }
-  }
-</style>

--- a/dashboard/src/lib/components/ModelPickerModal.svelte
+++ b/dashboard/src/lib/components/ModelPickerModal.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { tick } from "svelte";
   import { fade, fly } from "svelte/transition";
   import { cubicOut } from "svelte/easing";
   import FamilySidebar from "./FamilySidebar.svelte";
@@ -8,7 +7,6 @@
   import HuggingFaceResultItem from "./HuggingFaceResultItem.svelte";
   import { getNodesWithModelDownloaded } from "$lib/utils/downloads";
   import { getRecentEntries } from "$lib/stores/recents.svelte";
-  import { addToast } from "$lib/stores/toast.svelte";
 
   interface ModelInfo {
     id: string;
@@ -193,13 +191,6 @@
   let hfSearchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   let manualModelId = $state("");
   let addModelError = $state<string | null>(null);
-  let justAddedModelId = $state<string | null>(null);
-  let justAddedTimer: ReturnType<typeof setTimeout> | null = null;
-
-  // Inline HuggingFace search in main search bar
-  let mainSearchHfResults = $state<HuggingFaceModel[]>([]);
-  let mainSearchHfLoading = $state(false);
-  let mainSearchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Reset transient state when modal opens, but preserve tab selection
   $effect(() => {
@@ -209,11 +200,6 @@
       showFilters = false;
       manualModelId = "";
       addModelError = null;
-      justAddedModelId = null;
-      if (justAddedTimer) {
-        clearTimeout(justAddedTimer);
-        justAddedTimer = null;
-      }
     }
   });
 
@@ -226,50 +212,6 @@
     ) {
       fetchTrendingModels();
     }
-  });
-
-  // Inline HuggingFace search when local search returns no results
-  $effect(() => {
-    const query = searchQuery.trim();
-    const noLocalResults = filteredGroups.length === 0;
-
-    if (mainSearchDebounceTimer) {
-      clearTimeout(mainSearchDebounceTimer);
-      mainSearchDebounceTimer = null;
-    }
-
-    if (
-      selectedFamily === "huggingface" ||
-      selectedFamily === "recents" ||
-      selectedFamily === "favorites" ||
-      query.length < 2 ||
-      !noLocalResults
-    ) {
-      mainSearchHfResults = [];
-      mainSearchHfLoading = false;
-      return;
-    }
-
-    mainSearchHfLoading = true;
-    mainSearchDebounceTimer = setTimeout(async () => {
-      try {
-        const response = await fetch(
-          `/models/search?query=${encodeURIComponent(query)}&limit=10`,
-        );
-        if (response.ok) {
-          const results: HuggingFaceModel[] = await response.json();
-          mainSearchHfResults = results.filter(
-            (r) => !existingModelIds.has(r.id),
-          );
-        } else {
-          mainSearchHfResults = [];
-        }
-      } catch {
-        mainSearchHfResults = [];
-      } finally {
-        mainSearchHfLoading = false;
-      }
-    }, 500);
   });
 
   async function fetchTrendingModels() {
@@ -332,24 +274,6 @@
     addModelError = null;
     try {
       await onAddModel(modelId);
-      // Success: show toast, switch to All Models, highlight the model
-      const shortName = modelId.split("/").pop() || modelId;
-      addToast({ type: "success", message: `Added ${shortName}` });
-      justAddedModelId = modelId;
-      selectedFamily = null;
-      searchQuery = "";
-      // Scroll to the newly added model after DOM update
-      await tick();
-      const el = document.querySelector(
-        `[data-model-ids~="${CSS.escape(modelId)}"]`,
-      );
-      el?.scrollIntoView({ behavior: "smooth", block: "center" });
-      // Clear highlight after 4 seconds
-      if (justAddedTimer) clearTimeout(justAddedTimer);
-      justAddedTimer = setTimeout(() => {
-        justAddedModelId = null;
-        justAddedTimer = null;
-      }, 4000);
     } catch (error) {
       addModelError =
         error instanceof Error ? error.message : "Failed to add model";
@@ -917,8 +841,6 @@
                 {group}
                 isExpanded={expandedGroups.has(group.id)}
                 isFavorite={favorites.has(group.id)}
-                isHighlighted={justAddedModelId !== null &&
-                  group.variants.some((v) => v.id === justAddedModelId)}
                 {selectedModelId}
                 {canModelFit}
                 {getModelFitStatus}
@@ -988,8 +910,6 @@
               {group}
               isExpanded={expandedGroups.has(group.id)}
               isFavorite={favorites.has(group.id)}
-              isHighlighted={justAddedModelId !== null &&
-                group.variants.some((v) => v.id === justAddedModelId)}
               {selectedModelId}
               {canModelFit}
               {getModelFitStatus}
@@ -1017,8 +937,6 @@
               {group}
               isExpanded={expandedGroups.has(group.id)}
               isFavorite={favorites.has(group.id)}
-              isHighlighted={justAddedModelId !== null &&
-                group.variants.some((v) => v.id === justAddedModelId)}
               {selectedModelId}
               {canModelFit}
               {getModelFitStatus}
@@ -1030,55 +948,6 @@
               {instanceStatuses}
             />
           {/each}
-          <!-- Inline HuggingFace search results (shown when no local results match) -->
-          {#if filteredGroups.length === 0 && searchQuery.trim().length >= 2 && selectedFamily !== "huggingface" && selectedFamily !== "recents" && selectedFamily !== "favorites"}
-            {#if mainSearchHfLoading}
-              <div
-                class="flex items-center gap-2 px-3 py-2 border-t border-orange-400/20 bg-orange-950/20"
-              >
-                <span
-                  class="w-4 h-4 border-2 border-orange-400 border-t-transparent rounded-full animate-spin"
-                ></span>
-                <span class="text-xs font-mono text-orange-400/60"
-                  >Searching HuggingFace...</span
-                >
-              </div>
-            {:else if mainSearchHfResults.length > 0}
-              <div
-                class="sticky top-0 z-10 flex items-center gap-2 px-3 py-2 bg-orange-950/30 border-y border-orange-400/20 backdrop-blur-sm"
-              >
-                <span
-                  class="text-xs font-mono text-orange-400 tracking-wider uppercase"
-                  >From HuggingFace</span
-                >
-              </div>
-              {#each mainSearchHfResults as model}
-                <HuggingFaceResultItem
-                  {model}
-                  isAdded={existingModelIds.has(model.id)}
-                  isAdding={addingModelId === model.id}
-                  onAdd={() => handleAddModel(model.id)}
-                  onSelect={() => handleSelectHfModel(model.id)}
-                  downloadedOnNodes={downloadsData
-                    ? getNodesWithModelDownloaded(downloadsData, model.id).map(
-                        getNodeName,
-                      )
-                    : []}
-                />
-              {/each}
-              <button
-                type="button"
-                class="w-full px-3 py-2 text-xs font-mono text-orange-400/60 hover:text-orange-400 hover:bg-orange-500/10 transition-colors text-center"
-                onclick={() => {
-                  hfSearchQuery = searchQuery;
-                  searchHuggingFace(searchQuery);
-                  selectedFamily = "huggingface";
-                }}
-              >
-                See all results on Hub
-              </button>
-            {/if}
-          {/if}
         {/if}
       </div>
     </div>

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -916,11 +916,27 @@
   // Slider dragging state
   let isDraggingSlider = $state(false);
   let sliderTrackElement: HTMLDivElement | null = $state(null);
+  let mobileControlsOpen = $state(false);
+  let mobileChatPanelOpen = $state(false);
 
   // Instances container ref for scrolling
   let instancesContainerRef: HTMLDivElement | null = $state(null);
   // Chat scroll container ref for precise scroll behavior
   let chatScrollRef: HTMLDivElement | null = $state(null);
+
+  $effect(() => {
+    // Keep the mobile sheet scoped to the welcome screen only.
+    if (chatStarted || topologyOnlyEnabled || showOnboardingOverlay) {
+      mobileControlsOpen = false;
+    }
+  });
+
+  $effect(() => {
+    // Keep the chat mobile panel scoped to chat mode when topology is minimized.
+    if (!chatStarted || !minimized || topologyOnlyEnabled || showOnboardingOverlay) {
+      mobileChatPanelOpen = false;
+    }
+  });
 
   // Instance hover state for highlighting nodes in topology
   let hoveredInstanceId = $state<string | null>(null);
@@ -4613,7 +4629,7 @@
     <!-- Left: Conversation History Sidebar (hidden in topology-only mode, welcome state, or when toggled off) -->
     {#if !topologyOnlyEnabled && sidebarVisible}
       <div
-        class="w-80 flex-shrink-0 border-r border-exo-yellow/10"
+        class="hidden lg:block w-80 flex-shrink-0 border-r border-exo-yellow/10"
         role="complementary"
         aria-label="Conversation history"
       >
@@ -4921,13 +4937,66 @@
               />
             </div>
           </div>
+
+          {#if !mobileControlsOpen}
+            <button
+              type="button"
+              class="fixed bottom-5 right-4 z-30 lg:hidden inline-flex items-center gap-2 px-3 py-2 rounded border border-exo-yellow/40 bg-exo-dark-gray/95 text-xs text-exo-yellow font-mono tracking-wider uppercase shadow-lg shadow-black/50 backdrop-blur-sm"
+              onclick={() => (mobileControlsOpen = true)}
+              aria-label="Open models and instances panel"
+            >
+              <svg
+                class="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.8"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M4 6h16M4 12h16M4 18h10"
+                />
+              </svg>
+              Models &amp; Instances
+            </button>
+          {/if}
         </div>
+
+        {#if mobileControlsOpen}
+          <button
+            type="button"
+            class="fixed inset-0 z-30 bg-black/65 lg:hidden"
+            onclick={() => (mobileControlsOpen = false)}
+            aria-label="Close models and instances panel"
+          ></button>
+        {/if}
 
         <!-- Right Sidebar: Instance Controls (wider on welcome page for better visibility) -->
         <aside
-          class="w-80 border-l border-exo-yellow/10 bg-exo-dark-gray flex flex-col flex-shrink-0"
+          class="bg-exo-dark-gray flex flex-col border-exo-yellow/10 fixed inset-x-0 bottom-0 z-40 h-[min(82vh,760px)] w-full border-t shadow-2xl shadow-black/70 transition-transform duration-300 ease-out lg:relative lg:inset-auto lg:bottom-auto lg:z-auto lg:h-auto lg:w-80 lg:flex-shrink-0 lg:border-l lg:border-t-0 lg:shadow-none {mobileControlsOpen
+            ? 'translate-y-0'
+            : 'translate-y-full lg:translate-y-0'}"
           aria-label="Instance controls"
         >
+          <div class="lg:hidden px-4 pt-2 pb-3 border-b border-exo-yellow/20">
+            <div class="w-10 h-1 rounded-full bg-exo-medium-gray/70 mx-auto mb-2"
+            ></div>
+            <div class="flex items-center justify-between gap-3">
+              <p class="text-xs text-exo-yellow font-mono uppercase tracking-[0.2em]">
+                Controls
+              </p>
+              <button
+                type="button"
+                class="px-2.5 py-1 rounded border border-exo-medium-gray/50 text-[11px] text-exo-light-gray font-mono uppercase tracking-wider"
+                onclick={() => (mobileControlsOpen = false)}
+                aria-label="Close controls panel"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+
           <!-- Running Instances Panel (only shown when instances exist) - Scrollable -->
           {#if instanceCount > 0}
             <div class="p-4 flex-shrink-0">
@@ -6022,13 +6091,66 @@
           {/if}
         </div>
 
+        {#if minimized && !mobileChatPanelOpen}
+          <button
+            type="button"
+            class="fixed bottom-24 right-4 z-30 lg:hidden inline-flex items-center gap-2 px-3 py-2 rounded border border-exo-yellow/40 bg-exo-dark-gray/95 text-xs text-exo-yellow font-mono tracking-wider uppercase shadow-lg shadow-black/50 backdrop-blur-sm"
+            onclick={() => (mobileChatPanelOpen = true)}
+            aria-label="Open topology and instances panel"
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="1.8"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M4 6h16M4 12h16M4 18h10"
+              />
+            </svg>
+            Topology &amp; Instances
+          </button>
+        {/if}
+
+        {#if minimized && mobileChatPanelOpen}
+          <button
+            type="button"
+            class="fixed inset-0 z-30 bg-black/65 lg:hidden"
+            onclick={() => (mobileChatPanelOpen = false)}
+            aria-label="Close topology and instances panel"
+          ></button>
+        {/if}
+
         <!-- Right: Mini-Map Sidebar -->
         {#if minimized}
           <aside
-            class="w-80 border-l border-exo-yellow/20 bg-exo-dark-gray flex flex-col flex-shrink-0 overflow-y-auto"
+            class="bg-exo-dark-gray flex flex-col border-exo-yellow/20 fixed inset-x-0 bottom-0 z-40 h-[min(82vh,760px)] w-full border-t shadow-2xl shadow-black/70 transition-transform duration-300 ease-out lg:relative lg:inset-auto lg:bottom-auto lg:z-auto lg:h-auto lg:w-80 lg:flex-shrink-0 lg:border-l lg:border-t-0 lg:shadow-none {mobileChatPanelOpen
+              ? 'translate-y-0'
+              : 'translate-y-full lg:translate-y-0'}"
             in:fly={{ x: 100, duration: 400, easing: cubicInOut }}
             aria-label="Cluster topology"
           >
+            <div class="lg:hidden px-4 pt-2 pb-3 border-b border-exo-yellow/20">
+              <div class="w-10 h-1 rounded-full bg-exo-medium-gray/70 mx-auto mb-2"
+              ></div>
+              <div class="flex items-center justify-between gap-3">
+                <p class="text-xs text-exo-yellow font-mono uppercase tracking-[0.2em]">
+                  Cluster
+                </p>
+                <button
+                  type="button"
+                  class="px-2.5 py-1 rounded border border-exo-medium-gray/50 text-[11px] text-exo-light-gray font-mono uppercase tracking-wider"
+                  onclick={() => (mobileChatPanelOpen = false)}
+                  aria-label="Close cluster panel"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+
             <!-- Topology Section - clickable to go back to main view -->
             <button
               class="p-4 border-b border-exo-medium-gray/30 w-full text-left cursor-pointer hover:bg-exo-medium-gray/10 transition-colors"


### PR DESCRIPTION
The dashboard main route was desktop-first and rendered fixed 320px side panels in flows that users hit on phones (welcome and chat). This change keeps topology visible on mobile and moves side controls into bottom sheets.

- Hide desktop side columns on small screens
- Add welcome-screen mobile controls panel
- Add chat-screen mobile cluster panel
- Make header mobile-safe
- Preserve desktop behavior at `lg` and above

## Motivation
Dashboard is completely useless on mobile.

Before:
<img width="238" height="446" alt="Screenshot 2026-03-07 at 5 56 36 PM" src="https://github.com/user-attachments/assets/24c34c1a-ca49-44ea-a614-59181e6dc965" />

After:
<img width="209" height="441" alt="Screenshot 2026-03-07 at 6 04 31 PM" src="https://github.com/user-attachments/assets/4e08b3ea-f84d-47fc-9bbb-1448aaed801d" />
<img width="229" height="445" alt="Screenshot 2026-03-07 at 5 57 29 PM" src="https://github.com/user-attachments/assets/30d331fd-0849-4c98-aa3b-507d0cb88b84" />


## Changes

- Hide desktop side columns on small screens
- Add welcome-screen mobile controls panel
- Add chat-screen mobile cluster panel
- Make header mobile-safe
- Preserve desktop behavior at `lg` and above

## Test Plan

### Manual Testing

Tested in Chrome and Safari on different viewport sizes



