### PR TITLE
feat: expose max_concurrent_requests in /state endpoint

### DIFF
--- a/src/exo/shared/apply.py
+++ b/src/exo/shared/apply.py
@@ -306,6 +306,7 @@ def apply_node_gathered_info(event: NodeGatheredInfo, state: State) -> State:
                     "chip_id": info.chip,
                     "os_version": info.os_version,
                     "os_build_version": info.os_build_version,
+                    "max_concurrent_requests": info.max_concurrent_requests,
                 }
             )
             update["node_identities"] = {

--- a/src/exo/shared/types/profiling.py
+++ b/src/exo/shared/types/profiling.py
@@ -5,6 +5,7 @@ from typing import Literal, Self
 
 import psutil
 
+from exo.shared.constants import EXO_MAX_CONCURRENT_REQUESTS
 from exo.shared.types.memory import Memory
 from exo.shared.types.thunderbolt import ThunderboltIdentifier
 from exo.utils.pydantic_ext import CamelCaseModel
@@ -83,6 +84,7 @@ class NodeIdentity(CamelCaseModel):
     friendly_name: str = "Unknown"
     os_version: str = "Unknown"
     os_build_version: str = "Unknown"
+    max_concurrent_requests: int = EXO_MAX_CONCURRENT_REQUESTS
 
 
 class NodeNetworkInfo(CamelCaseModel):

--- a/src/exo/utils/info_gatherer/info_gatherer.py
+++ b/src/exo/utils/info_gatherer/info_gatherer.py
@@ -14,7 +14,11 @@ from anyio.streams.text import TextReceiveStream
 from loguru import logger
 from pydantic import ValidationError
 
-from exo.shared.constants import EXO_CONFIG_FILE, EXO_MODELS_DIR
+from exo.shared.constants import (
+    EXO_CONFIG_FILE,
+    EXO_MAX_CONCURRENT_REQUESTS,
+    EXO_MODELS_DIR,
+)
 from exo.shared.types.memory import Memory
 from exo.shared.types.profiling import (
     DiskUsage,
@@ -186,6 +190,7 @@ class StaticNodeInformation(TaggedModel):
     chip: str
     os_version: str
     os_build_version: str
+    max_concurrent_requests: int
 
     @classmethod
     async def gather(cls) -> Self:
@@ -195,6 +200,7 @@ class StaticNodeInformation(TaggedModel):
             chip=chip,
             os_version=get_os_version(),
             os_build_version=await get_os_build_version(),
+            max_concurrent_requests=EXO_MAX_CONCURRENT_REQUESTS,
         )
 
 


### PR DESCRIPTION
## Summary

Exposes the `EXO_MAX_CONCURRENT_REQUESTS` concurrency limit per-node in the `/state` endpoint, making it visible to dashboards and orchestrators without needing to check environment variables directly.

### Changes

- **`NodeIdentity`** (`profiling.py`): Added `max_concurrent_requests: int` field (defaults to `EXO_MAX_CONCURRENT_REQUESTS`)
- **`StaticNodeInformation`** (`info_gatherer.py`): Added `max_concurrent_requests: int` field, populated in `gather()`
- **`apply.py`**: Propagates `max_concurrent_requests` from `StaticNodeInformation` into `NodeIdentity` during state updates

### Motivation

The `/state` endpoint already exposes per-node runtime info (memory, disk, system, network, thunderbolt) but not the concurrency limit. This follows the existing per-node pattern and makes the configured value accessible without SSH or env var inspection.

### Verification

- `uv run basedpyright` — 0 errors
- `uv run ruff check` — 0 errors
- `uv run pytest` — 249 passed