### PR TITLE
fix: replace panicking assertions in mDNS discovery with graceful handling

### DIFF
--- a/rust/networking/src/discovery.rs
+++ b/rust/networking/src/discovery.rs
@@ -145,23 +145,21 @@ impl Behaviour {
                 continue;
             };
 
-            // multiaddress should never already be present - else something has gone wrong
-            let is_new_addr = mas.insert(ma);
-            assert!(is_new_addr, "cannot discover a discovered peer");
+            // duplicate discovery is benign — mDNS can re-fire for the same peer+addr
+            // under rapid reconnect scenarios; just skip it
+            mas.insert(ma);
         }
     }
 
     fn handle_mdns_expired(&mut self, peers: Vec<(PeerId, Multiaddr)>) {
         for (p, ma) in peers {
-            // at this point, we *must* have the peer
-            let mas = self
-                .mdns_discovered
-                .get_mut(&p)
-                .expect("nonexistent peer cannot expire");
+            // peer may already have been removed (e.g. rapid expire/discover cycle)
+            let Some(mas) = self.mdns_discovered.get_mut(&p) else {
+                continue;
+            };
 
-            // at this point, we *must* have the multiaddress
-            let was_present = mas.remove(&ma);
-            assert!(was_present, "nonexistent multiaddress cannot expire");
+            // address may already have been removed — skip if so
+            mas.remove(&ma);
 
             // if empty, remove the peer-id entirely
             if mas.is_empty() {
@@ -313,11 +311,8 @@ impl NetworkBehaviour for Behaviour {
                 }
             }
 
-            // since we are running TCP/IP transport layer, we are assuming that
-            // no address changes can occur, hence encountering one is a fatal error
-            FromSwarm::AddressChange(a) => {
-                unreachable!("unhandlable: address change encountered: {:?}", a)
-            }
+            // address changes are unexpected with TCP but not worth crashing over
+            FromSwarm::AddressChange(_) => {}
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

- Replace `assert!()` and `.expect()` in `handle_mdns_discovered()` / `handle_mdns_expired()` with graceful no-op handling
- Replace `unreachable!()` on `AddressChange` swarm events with empty handler
- Prevents SIGABRT (double-panic / panic-in-cleanup) that kills the secondary node in multi-node clusters

## Problem

On a 2-node M3 Ultra cluster running tensor-sharded models under sustained inference load, the secondary node (Epimetheus) crashes repeatedly with `SIGABRT`. All 8 crashes today have an identical signature:

```
exo_pyo3_bindings::networking::PyNetworkingHandle::py_new
core::panicking::panic_in_cleanup
signal: SIGABRT (Abort trap: 6)
```

**Root cause:** mDNS can fire duplicate discover events (same peer + same multiaddr) or expire events for peers/addresses already removed during rapid reconnect cycles. The current code uses `assert!()` and `.expect()` which panic on these benign conditions. Because `py_new` runs inside a tokio task via PyO3, the panic triggers cleanup that itself panics → double-panic → unconditional `abort()`.

## Changes

**`rust/networking/src/discovery.rs`:**

1. `handle_mdns_discovered` (line 150): Remove `assert!(is_new_addr, "cannot discover a discovered peer")` — duplicate insert into `BTreeSet` is idempotent and harmless
2. `handle_mdns_expired` (lines 157-164): Replace `.expect("nonexistent peer cannot expire")` + `assert!(was_present)` with `let Some(...) else { continue }` + bare `.remove()` — skip missing peers/addresses gracefully
3. `on_swarm_event` (line 319): Replace `unreachable!("address change encountered")` with `{}` — don't crash on unexpected but harmless events

## Reproduction

- 2x M3 Ultra 512GB (Atlas + Epimetheus) connected via Thunderbolt 5
- Tensor-sharded MiniMax-M2.5-8bit with sustained inference traffic
- Place/remove instances or restart one node while the other is serving
- Secondary node crashes within minutes

Crash reports: `~/Library/Logs/DiagnosticReports/exo-2026-03-10-*.ips` (8 identical reports in one day)

## Test plan

- [ ] Verify `cargo check -p networking` passes
- [ ] Run 2-node cluster with repeated instance place/remove cycles
- [ ] Confirm no more SIGABRT crashes on secondary node under sustained load

🤖 Generated with [Claude Code](https://claude.com/claude-code)