### PR TITLE
fix: show partial download progress on initial dashboard load

### DIFF
--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -1567,7 +1567,8 @@
             downloadedBytes: pendingDownloaded,
             speed: 0,
             etaMs: 0,
-            percentage: pendingTotal > 0 ? (pendingDownloaded / pendingTotal) * 100 : 0,
+            percentage:
+              pendingTotal > 0 ? (pendingDownloaded / pendingTotal) * 100 : 0,
             completedFiles: 0,
             totalFiles: 0,
             files: [],
@@ -1762,7 +1763,8 @@
               downloadedBytes: pendingDownloaded,
               speed: 0,
               etaMs: 0,
-              percentage: pendingTotal > 0 ? (pendingDownloaded / pendingTotal) * 100 : 0,
+              percentage:
+                pendingTotal > 0 ? (pendingDownloaded / pendingTotal) * 100 : 0,
               completedFiles: 0,
               totalFiles: 0,
               files: [],


### PR DESCRIPTION
## Summary

- Dashboard now shows partial download progress for models that were partially downloaded in a previous session, instead of showing 0%
- Both `getModelDownloadStatus()` and `getInstanceDownloadStatus()` now handle `DownloadPending` entries that carry non-zero `downloaded`/`total` bytes

Fixes #1042

## Root cause

When exo restarts with partially downloaded models, the `DownloadCoordinator` emits `DownloadPending` events (because `downloaded_this_session` is 0, even though real bytes exist on disk). The main page dashboard only checked for `DownloadOngoing` entries, so these partially downloaded models showed as 0%.

The dedicated `/downloads` page already handled this correctly — it renders `DownloadPending` entries with a progress bar when `downloaded > 0`. This fix brings the same behavior to the main page.

## Changes

For both `getModelDownloadStatus()` and `getInstanceDownloadStatus()` in `+page.svelte`:
- Accept `DownloadPending` in addition to `DownloadOngoing`
- For `DownloadPending` entries with `downloaded > 0` or `total > 0`, synthesize a `DownloadProgress` object from the top-level fields (with `speed: 0` and `etaMs: 0` since no active download is in progress)
- Skip `DownloadPending` entries where both `downloaded` and `total` are 0 (truly pending, not yet started)

## Test plan

- [ ] Partially download a model, quit exo, relaunch — dashboard should show partial progress instead of 0%
- [ ] Fully downloaded models still show as complete
- [ ] Active downloads still show real-time progress with speed/ETA
- [ ] Models never downloaded show as not started (not falsely showing progress)
- [ ] Dashboard builds without errors (`cd dashboard && npm run build`)