### PR TITLE
fix: Instantiate KVPrefixCache to enable KV cache hits on multi-turn conversations

### DIFF
--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -204,6 +204,7 @@ class Runner:
                     )
                 )
 
+                self.generator.kv_prefix_cache = KVPrefixCache(self.generator.group)
                 self.generator = self.generator.build()
 
                 self.send_task_status(task.task_id, TaskStatus.Complete)


### PR DESCRIPTION
## Summary

The `KVPrefixCache` system is fully implemented but never activated. The `Builder.kv_prefix_cache` field defaults to `None` and is never assigned a `KVPrefixCache` instance, causing every conversational turn to recompute the entire prompt from scratch.

## Impact

| Scenario | Before Fix | After Fix |
|----------|-----------|-----------|
| Multi-turn conversation (50k+ context) | Full prefill from token 0 | Only new tokens prefilled |
| M3 Ultra (512GB) @ ~290 tok/s | Several minutes per turn | ~100ms for new tokens |
| Cache hit rate | 0% | >97% |

**Real-world:** On a 50k+ token conversation, turn 2 prefills all 50k+ tokens. Turn 3 prefills all 50k+ tokens again. This compounds with every message.

## Root Cause

`KVPrefixCache` is defined in `src/exo/worker/engines/mlx/cache.py` and correctly wired through:
- `generator/generate.py` — `mlx_generate()` accepts `kv_prefix_cache` param and uses it
- `runner/llm_inference/runner.py` — `Builder` dataclass has `kv_prefix_cache: KVPrefixCache | None = None`
- `runner/llm_inference/batch_generator.py` — passes it through

**However**, `KVPrefixCache()` is never constructed anywhere in non-test code:

```bash
$ grep -rn "KVPrefixCache(" src/exo/worker/ --include="*.py" | grep -v test
# (no results)
```

The `Builder` is created with only `model_id`, `event_sender`, and `cancel_receiver`. The `kv_prefix_cache` field stays `None` through the entire `Connect → LoadModel → Build` lifecycle.

## Fix

**File:** `src/exo/worker/runner/llm_inference/runner.py`

**Location:** Just before `self.generator.build()` is called (~line 207)

```python
# Add this line before self.generator.build():
self.generator.kv_prefix_cache = KVPrefixCache(self.generator.group)
self.generator = self.generator.build()
```

**Import:** Already exists on line 55:
```python
from exo.worker.engines.mlx.cache import KVPrefixCache
```

## Reproduction

1. Start exo with `-v` (verbose)
2. Load any model and start a multi-turn conversation
3. Observe prefill logs — every turn prefills from 0:
   ```
   Prefill progress: 4096/48112 tokens (676.1 tok/s)  # turn 2 — starts from 0
   ```
4. Apply the one-line fix above
5. Turn 2 now shows:
   ```
   KV cache hit: 47000/48112 tokens cached (97.7%)
   ```

## Testing Environment

- **exo:** v0.3.68 (built from source)
- **OS:** macOS 26
- **Hardware:** Apple M3 Ultra, 512GB
- **Python:** 3.13.12

## Why This Matters

For users running multi-turn agentic workflows (the primary use case for exo), this bug turns what should be a ~100ms incremental prefill into a multi-minute full recomputation. The fix unlocks the performance that the KVPrefixCache system was designed to provide.