### PR TITLE
feat: suppress EOS tokens during tool call generation

### DIFF
--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -30,6 +30,7 @@ from exo.worker.engines.mlx.cache import (
 )
 from exo.worker.engines.mlx.constants import DEFAULT_TOP_LOGPROBS, MAX_TOKENS
 from exo.worker.engines.mlx.generator.generate import (
+    ToolCallEosSuppressor,
     ban_token_ids,
     eos_ids_from_tokenizer,
     extract_top_logprobs,
@@ -59,6 +60,7 @@ class _EngineTask:
     cache_snapshots: list[CacheSnapshot] | None
     detokenizer: StreamingDetokenizer
     on_generation_token: Callable[[], None] | None = None
+    eos_suppressor: ToolCallEosSuppressor | None = None
     generated_text_parts: list[str] = field(default_factory=list)
     potential_stop_sequence_text: str = ""
     completion_tokens: int = 0
@@ -180,9 +182,13 @@ class ExoBatchGenerator:
                 repetition_context_size=task_params.repetition_context_size,
             )
         )
+        eos_ids = eos_ids_from_tokenizer(self.tokenizer)
+        eos_suppressor: ToolCallEosSuppressor | None = None
+        if self.tokenizer.tool_call_start is not None:
+            eos_suppressor = ToolCallEosSuppressor(eos_ids)
+            logits_processors = [eos_suppressor] + logits_processors
         if is_bench:
             # Only sample length eos tokens
-            eos_ids = eos_ids_from_tokenizer(self.tokenizer)
             logits_processors = [ban_token_ids(eos_ids)] + logits_processors
 
         max_tokens = task_params.max_output_tokens or MAX_TOKENS
@@ -208,6 +214,7 @@ class ExoBatchGenerator:
             cache_snapshots=cache_snapshots or None,
             detokenizer=self.tokenizer.detokenizer,
             on_generation_token=on_generation_token,
+            eos_suppressor=eos_suppressor,
             generation_start_time=time.perf_counter(),
         )
 
@@ -248,6 +255,12 @@ class ExoBatchGenerator:
                 state.in_thinking = False
             if state.in_thinking:
                 state.reasoning_tokens += 1
+
+            if state.eos_suppressor is not None:
+                if self.tokenizer.tool_call_start is not None and text == self.tokenizer.tool_call_start:
+                    state.eos_suppressor.in_tool_call = True
+                elif self.tokenizer.tool_call_end is not None and text == self.tokenizer.tool_call_end:
+                    state.eos_suppressor.in_tool_call = False
 
             finish_reason: FinishReason | None = cast(
                 FinishReason | None, response.finish_reason

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -386,6 +386,24 @@ def ban_token_ids(token_ids: list[int]) -> Callable[[mx.array, mx.array], mx.arr
     return proc
 
 
+class ToolCallEosSuppressor:
+    """Suppresses EOS tokens while inside a tool call section.
+
+    State is toggled externally by the generation loop when it detects
+    tool_call_start / tool_call_end tokens in the decoded output.
+    """
+
+    def __init__(self, eos_ids: list[int]) -> None:
+        self.eos_ids = [int(t) for t in eos_ids]
+        self.in_tool_call = False
+
+    def __call__(self, _history: mx.array, logits: mx.array) -> mx.array:
+        if self.in_tool_call:
+            for tid in self.eos_ids:
+                logits[..., tid] = -1e9
+        return logits
+
+
 def eos_ids_from_tokenizer(tokenizer: TokenizerWrapper) -> list[int]:
     eos: list[int] | None = getattr(tokenizer, "eos_token_ids", None)
     if eos is None:
@@ -498,9 +516,13 @@ def mlx_generate(
             repetition_context_size=task.repetition_context_size,
         )
     )
+    eos_ids = eos_ids_from_tokenizer(tokenizer)
+    eos_suppressor: ToolCallEosSuppressor | None = None
+    if tokenizer.tool_call_start is not None:
+        eos_suppressor = ToolCallEosSuppressor(eos_ids)
+        logits_processors = [eos_suppressor] + logits_processors
     if is_bench:
         # Only sample length eos tokens
-        eos_ids = eos_ids_from_tokenizer(tokenizer)
         logits_processors = [ban_token_ids(eos_ids)] + logits_processors
 
     sampler = make_sampler(
@@ -571,6 +593,12 @@ def mlx_generate(
             in_thinking = False
         if in_thinking:
             reasoning_tokens += 1
+
+        if eos_suppressor is not None:
+            if tokenizer.tool_call_start is not None and out.text == tokenizer.tool_call_start:
+                eos_suppressor.in_tool_call = True
+            elif tokenizer.tool_call_end is not None and out.text == tokenizer.tool_call_end:
+                eos_suppressor.in_tool_call = False
 
         # Check for stop sequences
         text = out.text


### PR DESCRIPTION
## Summary

- Prevents models from emitting EOS mid-tool-call, which causes partial tool call tokens to be dumped as raw text to the client
- Adds a stateful logits processor (`ToolCallEosSuppressor`) that masks EOS token logits to `-1e9` while inside a `<|tool_calls_section_begin|>` ... `<|tool_calls_section_end|>` block
- Wired into both `mlx_generate` (single request) and `ExoBatchGenerator` (batch), following the same pattern as existing thinking state tracking

## Problem

When a thinking model (e.g. Kimi K2.5) generates a tool call with a very long argument (such as writing a large file), the model can choose to emit EOS before the closing `<|tool_calls_section_end|>` token. When this happens, the tool call parser in `model_output_parsers.py` hits the `finish_reason is not None` check at line 369 and falls back to yielding the partial tool call as raw text:

```
tool call parsing interrupted, yield partial tool call as text
```

The client then receives raw special tokens (`<|tool_calls_section_begin|><|tool_call_begin|>functions.write:87<|tool_call_argument_begin|>...`) instead of a properly parsed tool call response.

## Approach

Inspired by [vLLM's guided decoding](https://docs.vllm.ai/en/latest/features/tool_calling/) which uses logit masking to enforce structured outputs. Our implementation is simpler — just a boolean flag and EOS masking, no full grammar engine needed:

1. `ToolCallEosSuppressor` — a logits processor that sets all EOS token logits to `-1e9` when `in_tool_call` is `True`
2. The generation loop toggles `in_tool_call` when it decodes `tool_call_start` / `tool_call_end` tokens (same text-matching approach as existing `in_thinking` tracking)
3. Only activated for models that have `tool_call_start` set on the tokenizer (currently Kimi models)

## Test plan

- [ ] Test with Kimi K2.5 generating a very long tool call argument (e.g. writing a large markdown file via a `write` tool)
- [ ] Verify normal tool calls still parse correctly
- [ ] Verify non-tool-call generation (pure text, thinking) is unaffected
- [ ] Verify models without `tool_call_start` (non-Kimi) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)