### PR TITLE
feat(api): add agent-friendly cluster management endpoints

### DIFF
--- a/src/exo/master/api.py
+++ b/src/exo/master/api.py
@@ -169,8 +169,35 @@ from exo.shared.types.openai_responses import (
     ResponsesResponse,
 )
 from exo.shared.types.state import State
-from exo.shared.types.worker.downloads import DownloadCompleted
+from exo.shared.types.cluster import (
+    ClusterDownloadSummary,
+    ClusterHealthResponse,
+    ClusterModelSummary,
+    ClusterModelsResponse,
+    ClusterNodeSummary,
+    ClusterNodesResponse,
+    ClusterOverviewResponse,
+    ClusterTaskSummary,
+    LoadModelRequest,
+    LoadModelResponse,
+    ModelStatusResponse,
+    SwapModelRequest,
+    SwapModelResponse,
+    UnloadModelResponse,
+)
+from exo.shared.types.worker.downloads import (
+    DownloadCompleted,
+    DownloadFailed,
+    DownloadOngoing,
+    DownloadPending,
+)
 from exo.shared.types.worker.instances import Instance, InstanceId, InstanceMeta
+from exo.shared.types.worker.runners import (
+    RunnerFailed,
+    RunnerLoading,
+    RunnerReady,
+    RunnerRunning,
+)
 from exo.shared.types.worker.shards import Sharding
 from exo.utils.banner import print_startup_banner
 from exo.utils.channels import Receiver, Sender, channel
@@ -351,6 +378,21 @@ class API:
         self.app.get("/v1/traces/{task_id}/raw")(self.get_trace_raw)
         self.app.get("/onboarding")(self.get_onboarding)
         self.app.post("/onboarding")(self.complete_onboarding)
+
+        # Cluster management API — agent-friendly endpoints
+        self.app.get("/v1/cluster")(self.cluster_overview)
+        self.app.get("/v1/cluster/health")(self.cluster_health)
+        self.app.get("/v1/cluster/nodes")(self.cluster_nodes)
+        self.app.get("/v1/cluster/nodes/{node_id}")(self.cluster_node_detail)
+        self.app.get("/v1/cluster/models")(self.cluster_models)
+        self.app.post("/v1/cluster/models/load")(self.cluster_load_model)
+        self.app.delete("/v1/cluster/models/{model_id:path}")(
+            self.cluster_unload_model
+        )
+        self.app.post("/v1/cluster/models/swap")(self.cluster_swap_model)
+        self.app.get("/v1/cluster/models/{model_id:path}/status")(
+            self.cluster_model_status
+        )
 
     async def place_instance(self, payload: PlaceInstanceParams):
         command = PlaceInstance(
@@ -1525,6 +1567,592 @@ class API:
     async def ollama_version(self) -> dict[str, str]:
         """Returns version information for Ollama API compatibility."""
         return {"version": "exo v1.0"}
+
+    # ------------------------------------------------------------------
+    # Cluster management API — agent-friendly endpoints
+    # ------------------------------------------------------------------
+
+    def _build_node_summary(self, node_id: NodeId) -> ClusterNodeSummary:
+        """Build a flat, agent-friendly summary for a single node."""
+        identity = self.state.node_identities.get(node_id)
+        memory = self.state.node_memory.get(node_id)
+        disk = self.state.node_disk.get(node_id)
+        system = self.state.node_system.get(node_id)
+        network = self.state.node_network.get(node_id)
+        tb = self.state.node_thunderbolt.get(node_id)
+        rdma = self.state.node_rdma_ctl.get(node_id)
+        last_seen = self.state.last_seen.get(node_id)
+
+        # Determine status from last_seen
+        status: str = "unknown"
+        seconds_since: float | None = None
+        if last_seen is not None:
+            from datetime import datetime, timezone
+
+            now = datetime.now(timezone.utc)
+            delta = (now - last_seen).total_seconds()
+            seconds_since = round(delta, 1)
+            status = "online" if delta < 30 else "stale"
+
+        # Collect loaded models for this node
+        loaded_models: list[str] = []
+        for instance in self.state.instances.values():
+            if node_id in instance.shard_assignments.node_to_runner:
+                model_name = instance.shard_assignments.model_id.short()
+                if model_name not in loaded_models:
+                    loaded_models.append(model_name)
+
+        # IP addresses and connection types
+        ip_addresses: list[str] = []
+        connection_types: list[str] = []
+        if network:
+            for iface in network.interfaces:
+                ip_addresses.append(iface.ip_address)
+                if iface.interface_type not in connection_types:
+                    connection_types.append(iface.interface_type)
+
+        ram_total = round(memory.ram_total.in_gb, 1) if memory else 0.0
+        ram_avail = round(memory.ram_available.in_gb, 1) if memory else 0.0
+        ram_used = round(ram_total - ram_avail, 1)
+        ram_pct = round((ram_used / ram_total) * 100, 1) if ram_total > 0 else 0.0
+
+        return ClusterNodeSummary(
+            node_id=str(node_id),
+            friendly_name=identity.friendly_name if identity else "Unknown",
+            chip=identity.chip_id if identity else "Unknown",
+            os_version=identity.os_version if identity else "Unknown",
+            ram_total_gb=ram_total,
+            ram_available_gb=ram_avail,
+            ram_used_gb=ram_used,
+            ram_used_percent=ram_pct,
+            disk_total_gb=round(disk.total.in_gb, 1) if disk else 0.0,
+            disk_available_gb=round(disk.available.in_gb, 1) if disk else 0.0,
+            gpu_usage_percent=round(system.gpu_usage, 1) if system else 0.0,
+            cpu_p_usage_percent=round(system.pcpu_usage, 1) if system else 0.0,
+            cpu_e_usage_percent=round(system.ecpu_usage, 1) if system else 0.0,
+            temperature_c=round(system.temp, 1) if system else 0.0,
+            power_watts=round(system.sys_power, 1) if system else 0.0,
+            ip_addresses=ip_addresses,
+            connection_types=connection_types,
+            has_thunderbolt=bool(tb and len(tb.interfaces) > 0),
+            rdma_enabled=bool(rdma and rdma.enabled),
+            loaded_models=loaded_models,
+            status=status,
+            seconds_since_seen=seconds_since,
+        )
+
+    def _build_model_summary(
+        self, instance_id: InstanceId, instance: Instance
+    ) -> ClusterModelSummary:
+        """Build a flat summary for a loaded model instance."""
+        assignments = instance.shard_assignments
+        model_id = str(assignments.model_id)
+        model_name = assignments.model_id.short()
+        nodes = list(str(n) for n in assignments.node_to_runner.keys())
+
+        # Friendly names for nodes
+        node_names = []
+        for nid in assignments.node_to_runner.keys():
+            identity = self.state.node_identities.get(nid)
+            node_names.append(identity.friendly_name if identity else str(nid)[:8])
+
+        # Determine instance type and sharding from the instance class
+        from exo.shared.types.worker.instances import MlxJacclInstance, MlxRingInstance
+
+        if isinstance(instance, MlxRingInstance):
+            instance_type = "MlxRing"
+        elif isinstance(instance, MlxJacclInstance):
+            instance_type = "MlxJaccl"
+        else:
+            instance_type = "unknown"
+
+        # Determine sharding from shard metadata
+        sharding = "unknown"
+        for shard_meta in assignments.runner_to_shard.values():
+            sharding = type(shard_meta).__name__.replace("ShardMetadata", "").lower()
+            break
+
+        # Runner statuses for each node
+        runner_statuses: dict[str, str] = {}
+        ready = True
+        overall_status = "unknown"
+        for nid, runner_id in assignments.node_to_runner.items():
+            runner_status = self.state.runners.get(runner_id)
+            if runner_status is None:
+                runner_statuses[str(nid)] = "unknown"
+                ready = False
+            else:
+                status_name = type(runner_status).__name__.replace("Runner", "").lower()
+                runner_statuses[str(nid)] = status_name
+                if isinstance(runner_status, RunnerFailed):
+                    ready = False
+                    overall_status = "failed"
+                elif isinstance(runner_status, RunnerLoading):
+                    ready = False
+                    overall_status = "loading"
+                elif isinstance(runner_status, RunnerRunning):
+                    overall_status = "running"
+                elif isinstance(runner_status, RunnerReady) and overall_status not in (
+                    "running",
+                    "failed",
+                    "loading",
+                ):
+                    overall_status = "ready"
+
+        if overall_status == "unknown" and ready:
+            overall_status = "ready"
+
+        # Get storage size from any shard's model card
+        storage_gb = 0.0
+        for shard_meta in assignments.runner_to_shard.values():
+            storage_gb = round(shard_meta.model_card.storage_size.in_gb, 1)
+            break
+
+        return ClusterModelSummary(
+            instance_id=str(instance_id),
+            model_id=model_id,
+            model_name=model_name,
+            sharding=sharding,
+            instance_type=instance_type,
+            nodes=nodes,
+            node_names=node_names,
+            storage_size_gb=storage_gb,
+            runner_statuses=runner_statuses,
+            ready=ready,
+            status=overall_status,
+        )
+
+    def _build_download_summaries(self) -> list[ClusterDownloadSummary]:
+        """Build flat download summaries from state."""
+        summaries: list[ClusterDownloadSummary] = []
+        for node_id, downloads in self.state.downloads.items():
+            identity = self.state.node_identities.get(node_id)
+            node_name = identity.friendly_name if identity else str(node_id)[:8]
+            for dl in downloads:
+                model_id = str(dl.shard_metadata.model_card.model_id)
+                if isinstance(dl, DownloadCompleted):
+                    summaries.append(
+                        ClusterDownloadSummary(
+                            node_id=str(node_id),
+                            node_name=node_name,
+                            model_id=model_id,
+                            status="completed",
+                            downloaded_gb=round(dl.total.in_gb, 1),
+                            total_gb=round(dl.total.in_gb, 1),
+                            progress_percent=100.0,
+                        )
+                    )
+                elif isinstance(dl, DownloadOngoing):
+                    prog = dl.download_progress
+                    total_gb = prog.total.in_gb
+                    dl_gb = prog.downloaded.in_gb
+                    pct = round((dl_gb / total_gb) * 100, 1) if total_gb > 0 else 0.0
+                    summaries.append(
+                        ClusterDownloadSummary(
+                            node_id=str(node_id),
+                            node_name=node_name,
+                            model_id=model_id,
+                            status="downloading",
+                            downloaded_gb=round(dl_gb, 1),
+                            total_gb=round(total_gb, 1),
+                            progress_percent=pct,
+                            speed_mb_s=round(prog.speed / (1024 * 1024), 1),
+                            eta_seconds=round(prog.eta_ms / 1000, 1)
+                            if prog.eta_ms > 0
+                            else None,
+                        )
+                    )
+                elif isinstance(dl, DownloadPending):
+                    summaries.append(
+                        ClusterDownloadSummary(
+                            node_id=str(node_id),
+                            node_name=node_name,
+                            model_id=model_id,
+                            status="pending",
+                            total_gb=round(dl.total.in_gb, 1),
+                        )
+                    )
+                elif isinstance(dl, DownloadFailed):
+                    summaries.append(
+                        ClusterDownloadSummary(
+                            node_id=str(node_id),
+                            node_name=node_name,
+                            model_id=model_id,
+                            status="failed",
+                            error=dl.error_message,
+                        )
+                    )
+        return summaries
+
+    def _build_task_summaries(self) -> list[ClusterTaskSummary]:
+        """Build flat task summaries from state."""
+        from exo.shared.types.tasks import (
+            ImageEdits as ImageEditsTask,
+            ImageGeneration as ImageGenTask,
+            TextGeneration as TextGenTask,
+        )
+
+        summaries: list[ClusterTaskSummary] = []
+        for task_id, task in self.state.tasks.items():
+            task_type = type(task).__name__
+            # Map to friendly names
+            if isinstance(task, TextGenTask):
+                task_type = "text_generation"
+            elif isinstance(task, ImageGenTask):
+                task_type = "image_generation"
+            elif isinstance(task, ImageEditsTask):
+                task_type = "image_edit"
+
+            model_id = ""
+            for inst in self.state.instances.values():
+                if inst.shard_assignments.model_id and task.instance_id == getattr(
+                    inst, "instance_id", None
+                ):
+                    model_id = str(inst.shard_assignments.model_id)
+                    break
+
+            summaries.append(
+                ClusterTaskSummary(
+                    task_id=str(task_id),
+                    task_type=task_type,
+                    status=task.task_status.value.lower(),
+                    model_id=model_id,
+                    instance_id=str(task.instance_id),
+                )
+            )
+        return summaries
+
+    async def cluster_health(self) -> ClusterHealthResponse:
+        """Quick health check — is the cluster alive and how many nodes?"""
+        nodes = list(self.state.topology.list_nodes())
+        return ClusterHealthResponse(
+            healthy=len(nodes) > 0,
+            node_count=len(nodes),
+            master_node_id=str(self.node_id),
+        )
+
+    async def cluster_overview(self) -> ClusterOverviewResponse:
+        """One call to understand the entire cluster.
+
+        Returns nodes, loaded models, active tasks, and downloads in a flat,
+        agent-friendly format.  Designed so a single GET gives full situational
+        awareness.
+        """
+        nodes = [
+            self._build_node_summary(nid)
+            for nid in self.state.topology.list_nodes()
+        ]
+        models = [
+            self._build_model_summary(iid, inst)
+            for iid, inst in self.state.instances.items()
+        ]
+        tasks = self._build_task_summaries()
+        downloads = self._build_download_summaries()
+
+        total_ram = sum(n.ram_total_gb for n in nodes)
+        avail_ram = sum(n.ram_available_gb for n in nodes)
+        used_ram = round(total_ram - avail_ram, 1)
+        pct = round((used_ram / total_ram) * 100, 1) if total_ram > 0 else 0.0
+
+        active_downloads = [d for d in downloads if d.status in ("pending", "downloading")]
+
+        return ClusterOverviewResponse(
+            node_count=len(nodes),
+            total_ram_gb=round(total_ram, 1),
+            available_ram_gb=round(avail_ram, 1),
+            used_ram_gb=used_ram,
+            ram_used_percent=pct,
+            loaded_model_count=len(models),
+            active_task_count=len([t for t in tasks if t.status in ("pending", "running")]),
+            active_download_count=len(active_downloads),
+            nodes=nodes,
+            models=models,
+            tasks=tasks,
+            downloads=downloads,
+            master_node_id=str(self.node_id),
+        )
+
+    async def cluster_nodes(self) -> ClusterNodesResponse:
+        """List all nodes with agent-friendly summaries."""
+        nodes = [
+            self._build_node_summary(nid)
+            for nid in self.state.topology.list_nodes()
+        ]
+        return ClusterNodesResponse(node_count=len(nodes), nodes=nodes)
+
+    async def cluster_node_detail(self, node_id: str) -> ClusterNodeSummary:
+        """Get detailed info for a single node."""
+        nid = NodeId(node_id)
+        all_nodes = list(self.state.topology.list_nodes())
+        if nid not in all_nodes:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Node '{node_id}' not found. "
+                f"Available nodes: {[str(n) for n in all_nodes]}",
+            )
+        return self._build_node_summary(nid)
+
+    async def cluster_models(self) -> ClusterModelsResponse:
+        """All loaded models and active downloads."""
+        loaded = [
+            self._build_model_summary(iid, inst)
+            for iid, inst in self.state.instances.items()
+        ]
+        downloading = [
+            d
+            for d in self._build_download_summaries()
+            if d.status in ("pending", "downloading")
+        ]
+        return ClusterModelsResponse(loaded=loaded, downloading=downloading)
+
+    async def cluster_load_model(self, payload: LoadModelRequest) -> LoadModelResponse:
+        """Load a model by name — the cluster auto-places it.
+
+        This is the agent-friendly wrapper around ``place_instance``.  Just
+        provide a model ID (e.g. ``mlx-community/Qwen3-30B-A3B-4bit``) and
+        optional preferences; the cluster handles sharding and placement.
+        """
+        model_card = await ModelCard.load(ModelId(payload.model_id))
+        required_memory = model_card.storage_size
+        available_memory = self._calculate_total_available_memory()
+
+        if required_memory > available_memory:
+            # Build a helpful error that suggests what to unload
+            loaded_models = []
+            for inst in self.state.instances.values():
+                for shard in inst.shard_assignments.runner_to_shard.values():
+                    loaded_models.append(
+                        f"{shard.model_card.model_id.short()} "
+                        f"({shard.model_card.storage_size.in_gb:.1f}GB)"
+                    )
+                    break
+
+            hint = ""
+            if loaded_models:
+                hint = (
+                    f" Currently loaded: {', '.join(loaded_models)}. "
+                    "Unload a model to free memory."
+                )
+
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Insufficient memory to load {model_card.model_id.short()}. "
+                    f"Need {required_memory.in_gb:.1f}GB, "
+                    f"have {available_memory.in_gb:.1f}GB available.{hint}"
+                ),
+            )
+
+        # Map user-friendly sharding preference to enum
+        if payload.preferred_sharding == "tensor":
+            sharding = Sharding.Tensor
+        elif payload.preferred_sharding == "pipeline":
+            sharding = Sharding.Pipeline
+        else:
+            # "auto" — prefer tensor if supported, fall back to pipeline
+            sharding = (
+                Sharding.Tensor if model_card.supports_tensor else Sharding.Pipeline
+            )
+
+        command = PlaceInstance(
+            model_card=model_card,
+            sharding=sharding,
+            instance_meta=InstanceMeta.MlxRing,
+            min_nodes=payload.min_nodes,
+        )
+        await self._send(command)
+
+        return LoadModelResponse(
+            message=f"Loading {model_card.model_id.short()} across the cluster.",
+            command_id=str(command.command_id),
+            model_id=str(model_card.model_id),
+            estimated_memory_gb=round(model_card.storage_size.in_gb, 1),
+        )
+
+    async def cluster_unload_model(self, model_id: str) -> UnloadModelResponse:
+        """Unload a model by model ID (not instance ID).
+
+        Finds the instance matching the given model ID and deletes it.
+        If multiple instances of the same model exist, unloads the first one.
+        """
+        target_instance_id: InstanceId | None = None
+        target_model_id: str = ""
+        freed_gb: float = 0.0
+
+        for iid, instance in self.state.instances.items():
+            inst_model = str(instance.shard_assignments.model_id)
+            # Match on full ID or short name
+            if inst_model == model_id or instance.shard_assignments.model_id.short() == model_id:
+                target_instance_id = iid
+                target_model_id = inst_model
+                for shard in instance.shard_assignments.runner_to_shard.values():
+                    freed_gb = round(shard.model_card.storage_size.in_gb, 1)
+                    break
+                break
+
+        if target_instance_id is None:
+            # Build helpful error with what IS loaded
+            loaded = [
+                f"{inst.shard_assignments.model_id.short()} (id: {inst.shard_assignments.model_id})"
+                for inst in self.state.instances.values()
+            ]
+            hint = f" Loaded models: {', '.join(loaded)}" if loaded else " No models are currently loaded."
+            raise HTTPException(
+                status_code=404,
+                detail=f"No loaded model matching '{model_id}'.{hint}",
+            )
+
+        command = DeleteInstance(instance_id=target_instance_id)
+        await self._send(command)
+
+        return UnloadModelResponse(
+            message=f"Unloading {ModelId(target_model_id).short()}.",
+            command_id=str(command.command_id),
+            model_id=target_model_id,
+            instance_id=str(target_instance_id),
+            freed_memory_gb=freed_gb,
+        )
+
+    async def cluster_model_status(self, model_id: str) -> ModelStatusResponse:
+        """Poll the status of a model by name.
+
+        Returns whether it's loaded, loading, downloading, or not present.
+        Designed for polling loops: call this after ``load`` or ``swap`` until
+        ``ready`` is ``true``.
+        """
+        # Check loaded instances
+        for iid, instance in self.state.instances.items():
+            inst_model = str(instance.shard_assignments.model_id)
+            if inst_model == model_id or instance.shard_assignments.model_id.short() == model_id:
+                summary = self._build_model_summary(iid, instance)
+                progress = None
+                if summary.status == "loading":
+                    # Try to get layer loading progress
+                    for runner_id in instance.shard_assignments.node_to_runner.values():
+                        rs = self.state.runners.get(runner_id)
+                        if isinstance(rs, RunnerLoading) and rs.total_layers > 0:
+                            pct = round((rs.layers_loaded / rs.total_layers) * 100)
+                            progress = f"Loading layers: {rs.layers_loaded}/{rs.total_layers} ({pct}%)"
+                            break
+
+                return ModelStatusResponse(
+                    model_id=inst_model,
+                    found=True,
+                    status=summary.status,
+                    ready=summary.ready,
+                    progress=progress,
+                    nodes=summary.node_names,
+                    instance_id=str(iid),
+                )
+
+        # Check downloads
+        for node_id, downloads in self.state.downloads.items():
+            for dl in downloads:
+                dl_model = str(dl.shard_metadata.model_card.model_id)
+                if dl_model == model_id or dl.shard_metadata.model_card.model_id.short() == model_id:
+                    if isinstance(dl, DownloadOngoing):
+                        prog = dl.download_progress
+                        pct = round((prog.downloaded.in_gb / prog.total.in_gb) * 100) if prog.total.in_gb > 0 else 0
+                        return ModelStatusResponse(
+                            model_id=dl_model,
+                            found=True,
+                            status="downloading",
+                            progress=f"Downloading: {prog.downloaded.in_gb:.1f}/{prog.total.in_gb:.1f}GB ({pct}%)",
+                        )
+                    elif isinstance(dl, DownloadPending):
+                        return ModelStatusResponse(
+                            model_id=dl_model,
+                            found=True,
+                            status="downloading",
+                            progress="Download pending...",
+                        )
+
+        return ModelStatusResponse(model_id=model_id, found=False, status="not_loaded")
+
+    async def cluster_swap_model(self, payload: SwapModelRequest) -> SwapModelResponse:
+        """Swap one model for another in a single call.
+
+        Unloads the old model then loads the new one.  Ideal for scheduled
+        model rotation (e.g. large model overnight, small model during the day).
+        """
+        # Step 1: Find and unload the old model
+        target_instance_id: InstanceId | None = None
+        freed_gb: float = 0.0
+        unloaded_model_name = payload.unload_model_id
+
+        for iid, instance in self.state.instances.items():
+            inst_model = str(instance.shard_assignments.model_id)
+            if inst_model == payload.unload_model_id or instance.shard_assignments.model_id.short() == payload.unload_model_id:
+                target_instance_id = iid
+                unloaded_model_name = inst_model
+                for shard in instance.shard_assignments.runner_to_shard.values():
+                    freed_gb = round(shard.model_card.storage_size.in_gb, 1)
+                    break
+                break
+
+        if target_instance_id is None:
+            loaded = [
+                inst.shard_assignments.model_id.short()
+                for inst in self.state.instances.values()
+            ]
+            hint = f" Loaded: {', '.join(loaded)}" if loaded else " No models loaded."
+            raise HTTPException(
+                status_code=404,
+                detail=f"Cannot swap: model '{payload.unload_model_id}' not found.{hint}",
+            )
+
+        # Step 2: Validate the new model can be loaded (with memory freed by unload)
+        model_card = await ModelCard.load(ModelId(payload.load_model_id))
+        available_after_unload = self._calculate_total_available_memory() + Memory.from_gb(freed_gb)
+
+        if model_card.storage_size > available_after_unload:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Even after unloading {ModelId(unloaded_model_name).short()} "
+                    f"(freeing {freed_gb:.1f}GB), not enough memory for "
+                    f"{model_card.model_id.short()} "
+                    f"(needs {model_card.storage_size.in_gb:.1f}GB, "
+                    f"would have {available_after_unload.in_gb:.1f}GB)."
+                ),
+            )
+
+        # Step 3: Send unload command
+        unload_cmd = DeleteInstance(instance_id=target_instance_id)
+        await self._send(unload_cmd)
+
+        # Step 4: Send load command
+        if payload.preferred_sharding == "tensor":
+            sharding = Sharding.Tensor
+        elif payload.preferred_sharding == "pipeline":
+            sharding = Sharding.Pipeline
+        else:
+            sharding = (
+                Sharding.Tensor if model_card.supports_tensor else Sharding.Pipeline
+            )
+
+        load_cmd = PlaceInstance(
+            model_card=model_card,
+            sharding=sharding,
+            instance_meta=InstanceMeta.MlxRing,
+            min_nodes=payload.min_nodes,
+        )
+        await self._send(load_cmd)
+
+        return SwapModelResponse(
+            message=(
+                f"Swapping {ModelId(unloaded_model_name).short()} → "
+                f"{model_card.model_id.short()}. "
+                f"Poll GET /v1/cluster/models/{model_card.model_id}/status "
+                f"until ready=true."
+            ),
+            unload_command_id=str(unload_cmd.command_id),
+            load_command_id=str(load_cmd.command_id),
+            unloaded_model=unloaded_model_name,
+            loaded_model=str(model_card.model_id),
+            freed_memory_gb=freed_gb,
+            estimated_load_memory_gb=round(model_card.storage_size.in_gb, 1),
+        )
 
     def _calculate_total_available_memory(self) -> Memory:
         """Calculate total available memory across all nodes in bytes."""

--- a/src/exo/master/tests/test_cluster_api.py
+++ b/src/exo/master/tests/test_cluster_api.py
@@ -1,0 +1,389 @@
+# pyright: reportUnusedFunction=false, reportAny=false
+"""Tests for the /v1/cluster/* agent-friendly management endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock
+
+import anyio
+import pytest
+from fastapi.testclient import TestClient
+
+from exo.master.api import API
+from exo.shared.models.model_cards import ModelCard, ModelId
+from exo.shared.topology import Topology
+from exo.shared.types.common import NodeId
+from exo.shared.types.memory import Memory
+from exo.shared.types.profiling import (
+    DiskUsage,
+    MemoryUsage,
+    NetworkInterfaceInfo,
+    NodeIdentity,
+    NodeNetworkInfo,
+    SystemPerformanceProfile,
+)
+from exo.shared.types.state import State
+from exo.shared.types.worker.instances import InstanceId, MlxRingInstance
+from exo.shared.types.worker.runners import (
+    RunnerId,
+    RunnerLoading,
+    RunnerReady,
+    ShardAssignments,
+)
+from exo.shared.types.worker.shards import PipelineShardMetadata
+
+
+def _make_api_with_state(state: State) -> tuple[API, TestClient]:
+    """Create a minimal API instance with injected state for testing."""
+    api = object.__new__(API)
+    api.state = state
+    api.node_id = NodeId("master-node-1")
+    api.paused = False
+    api.paused_ev = None  # type: ignore[assignment]
+    api.command_sender = AsyncMock()
+
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    api.app = app
+    api._setup_exception_handlers()
+
+    # Register cluster routes
+    app.get("/v1/cluster")(api.cluster_overview)
+    app.get("/v1/cluster/health")(api.cluster_health)
+    app.get("/v1/cluster/nodes")(api.cluster_nodes)
+    app.get("/v1/cluster/nodes/{node_id}")(api.cluster_node_detail)
+    app.get("/v1/cluster/models")(api.cluster_models)
+    app.get("/v1/cluster/models/{model_id:path}/status")(api.cluster_model_status)
+
+    client = TestClient(app)
+    return api, client
+
+
+def _two_node_state() -> State:
+    """Build a realistic 2-node cluster state for testing."""
+    topology = Topology()
+    node_a = NodeId("node-atlas")
+    node_b = NodeId("node-epimetheus")
+    topology.add_node(node_a)
+    topology.add_node(node_b)
+
+    now = datetime.now(timezone.utc)
+
+    model_card = ModelCard(
+        model_id=ModelId("mlx-community/Qwen3-30B-A3B-4bit"),
+        storage_size=Memory.from_gb(20),
+        n_layers=48,
+        hidden_size=4096,
+        supports_tensor=True,
+        tasks=[],
+    )
+
+    runner_a = RunnerId("runner-a")
+    runner_b = RunnerId("runner-b")
+    instance_id = InstanceId("inst-1")
+    instance = MlxRingInstance(
+        instance_id=instance_id,
+        shard_assignments=ShardAssignments(
+            model_id=ModelId("mlx-community/Qwen3-30B-A3B-4bit"),
+            runner_to_shard={
+                runner_a: PipelineShardMetadata(
+                    model_card=model_card,
+                    device_rank=0,
+                    world_size=2,
+                    start_layer=0,
+                    end_layer=24,
+                    n_layers=48,
+                ),
+                runner_b: PipelineShardMetadata(
+                    model_card=model_card,
+                    device_rank=1,
+                    world_size=2,
+                    start_layer=24,
+                    end_layer=48,
+                    n_layers=48,
+                ),
+            },
+            node_to_runner={
+                node_a: runner_a,
+                node_b: runner_b,
+            },
+        ),
+        hosts_by_node={node_a: [], node_b: []},
+        ephemeral_port=5000,
+    )
+
+    return State(
+        topology=topology,
+        instances={instance_id: instance},
+        runners={
+            runner_a: RunnerReady(),
+            runner_b: RunnerReady(),
+        },
+        node_identities={
+            node_a: NodeIdentity(
+                friendly_name="Atlas",
+                chip_id="Apple M3 Ultra",
+                os_version="macOS 26.2",
+            ),
+            node_b: NodeIdentity(
+                friendly_name="Epimetheus",
+                chip_id="Apple M3 Ultra",
+                os_version="macOS 26.2",
+            ),
+        },
+        node_memory={
+            node_a: MemoryUsage.from_bytes(
+                ram_total=512 * 1024**3,
+                ram_available=340 * 1024**3,
+                swap_total=0,
+                swap_available=0,
+            ),
+            node_b: MemoryUsage.from_bytes(
+                ram_total=512 * 1024**3,
+                ram_available=350 * 1024**3,
+                swap_total=0,
+                swap_available=0,
+            ),
+        },
+        node_disk={
+            node_a: DiskUsage(
+                total=Memory.from_gb(1000),
+                available=Memory.from_gb(600),
+            ),
+            node_b: DiskUsage(
+                total=Memory.from_gb(1000),
+                available=Memory.from_gb(700),
+            ),
+        },
+        node_system={
+            node_a: SystemPerformanceProfile(
+                gpu_usage=45.0, temp=62.0, sys_power=85.0
+            ),
+            node_b: SystemPerformanceProfile(
+                gpu_usage=40.0, temp=58.0, sys_power=80.0
+            ),
+        },
+        node_network={
+            node_a: NodeNetworkInfo(
+                interfaces=[
+                    NetworkInterfaceInfo(
+                        name="en0",
+                        ip_address="192.168.1.10",
+                        interface_type="ethernet",
+                    )
+                ]
+            ),
+            node_b: NodeNetworkInfo(
+                interfaces=[
+                    NetworkInterfaceInfo(
+                        name="en0",
+                        ip_address="192.168.1.11",
+                        interface_type="ethernet",
+                    )
+                ]
+            ),
+        },
+        last_seen={
+            node_a: now,
+            node_b: now,
+        },
+    )
+
+
+class TestClusterHealth:
+    def test_healthy_cluster(self) -> None:
+        state = _two_node_state()
+        _, client = _make_api_with_state(state)
+
+        resp = client.get("/v1/cluster/health")
+        assert resp.status_code == 200
+        data: dict[str, Any] = resp.json()
+
+        assert data["healthy"] is True
+        assert data["node_count"] == 2
+        assert data["master_node_id"] == "master-node-1"
+        assert "timestamp" in data
+
+    def test_empty_cluster(self) -> None:
+        _, client = _make_api_with_state(State())
+
+        resp = client.get("/v1/cluster/health")
+        data: dict[str, Any] = resp.json()
+
+        assert data["healthy"] is False
+        assert data["node_count"] == 0
+
+
+class TestClusterOverview:
+    def test_overview_structure(self) -> None:
+        state = _two_node_state()
+        _, client = _make_api_with_state(state)
+
+        resp = client.get("/v1/cluster")
+        assert resp.status_code == 200
+        data: dict[str, Any] = resp.json()
+
+        # Top-level summary
+        assert data["node_count"] == 2
+        assert data["total_ram_gb"] == 1024.0
+        assert data["loaded_model_count"] == 1
+        assert data["master_node_id"] == "master-node-1"
+
+        # Nodes
+        assert len(data["nodes"]) == 2
+        atlas = next(n for n in data["nodes"] if n["friendly_name"] == "Atlas")
+        assert atlas["chip"] == "Apple M3 Ultra"
+        assert atlas["ram_total_gb"] == 512.0
+        assert atlas["status"] == "online"
+        assert "Qwen3-30B-A3B-4bit" in atlas["loaded_models"]
+
+        # Models
+        assert len(data["models"]) == 1
+        model = data["models"][0]
+        assert model["model_name"] == "Qwen3-30B-A3B-4bit"
+        assert model["ready"] is True
+        assert len(model["nodes"]) == 2
+        assert model["storage_size_gb"] == 20.0
+
+    def test_overview_memory_math(self) -> None:
+        state = _two_node_state()
+        _, client = _make_api_with_state(state)
+
+        data: dict[str, Any] = client.get("/v1/cluster").json()
+
+        # 340 + 350 = 690 available, 1024 - 690 = 334 used
+        assert data["available_ram_gb"] == 690.0
+        assert data["used_ram_gb"] == 334.0
+        assert data["ram_used_percent"] == pytest.approx(32.6, abs=0.1)
+
+
+class TestClusterNodes:
+    def test_list_nodes(self) -> None:
+        state = _two_node_state()
+        _, client = _make_api_with_state(state)
+
+        resp = client.get("/v1/cluster/nodes")
+        assert resp.status_code == 200
+        data: dict[str, Any] = resp.json()
+
+        assert data["node_count"] == 2
+        assert len(data["nodes"]) == 2
+
+    def test_node_detail(self) -> None:
+        state = _two_node_state()
+        _, client = _make_api_with_state(state)
+
+        resp = client.get("/v1/cluster/nodes/node-atlas")
+        assert resp.status_code == 200
+        data: dict[str, Any] = resp.json()
+
+        assert data["friendly_name"] == "Atlas"
+        assert data["ram_total_gb"] == 512.0
+        assert data["gpu_usage_percent"] == 45.0
+        assert "192.168.1.10" in data["ip_addresses"]
+
+    def test_node_not_found(self) -> None:
+        state = _two_node_state()
+        _, client = _make_api_with_state(state)
+
+        resp = client.get("/v1/cluster/nodes/nonexistent")
+        assert resp.status_code == 404
+        data: dict[str, Any] = resp.json()
+        # Error should list available nodes
+        assert "node-atlas" in data["error"]["message"] or "Available nodes" in data["error"]["message"]
+
+
+class TestClusterModels:
+    def test_list_loaded_models(self) -> None:
+        state = _two_node_state()
+        _, client = _make_api_with_state(state)
+
+        resp = client.get("/v1/cluster/models")
+        assert resp.status_code == 200
+        data: dict[str, Any] = resp.json()
+
+        assert len(data["loaded"]) == 1
+        model = data["loaded"][0]
+        assert model["model_id"] == "mlx-community/Qwen3-30B-A3B-4bit"
+        assert model["model_name"] == "Qwen3-30B-A3B-4bit"
+        assert model["sharding"] == "pipeline"
+        assert model["instance_type"] == "MlxRing"
+        assert model["ready"] is True
+        assert "Atlas" in model["node_names"]
+        assert "Epimetheus" in model["node_names"]
+
+    def test_empty_cluster_models(self) -> None:
+        _, client = _make_api_with_state(State())
+
+        data: dict[str, Any] = client.get("/v1/cluster/models").json()
+        assert len(data["loaded"]) == 0
+        assert len(data["downloading"]) == 0
+
+
+class TestClusterModelStatus:
+    def test_loaded_model_status(self) -> None:
+        state = _two_node_state()
+        _, client = _make_api_with_state(state)
+
+        # By full model ID
+        resp = client.get("/v1/cluster/models/mlx-community/Qwen3-30B-A3B-4bit/status")
+        assert resp.status_code == 200
+        data: dict[str, Any] = resp.json()
+
+        assert data["found"] is True
+        assert data["ready"] is True
+        assert data["status"] == "ready"
+        assert data["model_id"] == "mlx-community/Qwen3-30B-A3B-4bit"
+        assert "Atlas" in data["nodes"]
+        assert data["instance_id"] is not None
+
+    def test_loaded_model_status_by_short_name(self) -> None:
+        state = _two_node_state()
+        _, client = _make_api_with_state(state)
+
+        resp = client.get("/v1/cluster/models/Qwen3-30B-A3B-4bit/status")
+        assert resp.status_code == 200
+        data: dict[str, Any] = resp.json()
+
+        assert data["found"] is True
+        assert data["ready"] is True
+
+    def test_not_loaded_model_status(self) -> None:
+        state = _two_node_state()
+        _, client = _make_api_with_state(state)
+
+        resp = client.get("/v1/cluster/models/nonexistent-model/status")
+        assert resp.status_code == 200  # Not a 404 — this is a status check
+        data: dict[str, Any] = resp.json()
+
+        assert data["found"] is False
+        assert data["ready"] is False
+        assert data["status"] == "not_loaded"
+
+    def test_loading_model_shows_progress(self) -> None:
+        """When a runner is in Loading state, status should show layer progress."""
+        state = _two_node_state()
+        # Replace one runner with a Loading state
+        runner_a = list(state.runners.keys())[0]
+        state = state.model_copy(
+            update={
+                "runners": {
+                    **state.runners,
+                    runner_a: RunnerLoading(layers_loaded=12, total_layers=48),
+                }
+            }
+        )
+        _, client = _make_api_with_state(state)
+
+        data: dict[str, Any] = client.get(
+            "/v1/cluster/models/Qwen3-30B-A3B-4bit/status"
+        ).json()
+
+        assert data["found"] is True
+        assert data["ready"] is False
+        assert data["status"] == "loading"
+        assert "12/48" in data["progress"]
+        assert "25%" in data["progress"]

--- a/src/exo/shared/types/cluster.py
+++ b/src/exo/shared/types/cluster.py
@@ -1,0 +1,251 @@
+"""Agent-friendly cluster management response types.
+
+These types power the ``/v1/cluster/*`` endpoints, designed for programmatic
+cluster management by AI agents, CLI tools, and automation scripts.  Every
+response is flat, self-describing, and includes units in field names so
+consumers never have to guess.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from exo.shared.types.common import CommandId, NodeId
+from exo.shared.types.worker.instances import InstanceId
+
+
+# ---------------------------------------------------------------------------
+# Node summary
+# ---------------------------------------------------------------------------
+
+class ClusterNodeSummary(BaseModel):
+    """One node in the cluster, with everything an agent needs at a glance."""
+
+    node_id: str
+    friendly_name: str = "Unknown"
+    chip: str = "Unknown"
+    os_version: str = "Unknown"
+
+    # Memory (GB, rounded to 1 decimal)
+    ram_total_gb: float = 0.0
+    ram_available_gb: float = 0.0
+    ram_used_gb: float = 0.0
+    ram_used_percent: float = 0.0
+
+    # Disk
+    disk_total_gb: float = 0.0
+    disk_available_gb: float = 0.0
+
+    # Performance
+    gpu_usage_percent: float = 0.0
+    cpu_p_usage_percent: float = 0.0
+    cpu_e_usage_percent: float = 0.0
+    temperature_c: float = 0.0
+    power_watts: float = 0.0
+
+    # Network
+    ip_addresses: list[str] = Field(default_factory=list)
+    connection_types: list[str] = Field(default_factory=list)
+
+    # Thunderbolt / RDMA
+    has_thunderbolt: bool = False
+    rdma_enabled: bool = False
+
+    # What's loaded on this node
+    loaded_models: list[str] = Field(default_factory=list)
+
+    # Status
+    status: Literal["online", "stale", "unknown"] = "unknown"
+    seconds_since_seen: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Loaded model summary
+# ---------------------------------------------------------------------------
+
+class ClusterModelSummary(BaseModel):
+    """A model instance currently loaded on the cluster."""
+
+    instance_id: str
+    model_id: str
+    model_name: str  # Short name (e.g. "Qwen3-30B-A3B")
+    sharding: str  # "pipeline" or "tensor"
+    instance_type: str  # "MlxRing" or "MlxJaccl"
+    nodes: list[str]  # Node IDs hosting this model
+    node_names: list[str]  # Friendly names of nodes
+    storage_size_gb: float = 0.0
+
+    # Runner status per node
+    runner_statuses: dict[str, str] = Field(default_factory=dict)
+
+    # Overall readiness
+    ready: bool = False
+    status: str = "unknown"  # "loading", "ready", "running", "failed", etc.
+
+
+# ---------------------------------------------------------------------------
+# Active task summary
+# ---------------------------------------------------------------------------
+
+class ClusterTaskSummary(BaseModel):
+    """An in-flight task on the cluster."""
+
+    task_id: str
+    task_type: str  # "text_generation", "image_generation", etc.
+    status: str  # "pending", "running", "complete", "failed"
+    model_id: str = ""
+    instance_id: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Download summary
+# ---------------------------------------------------------------------------
+
+class ClusterDownloadSummary(BaseModel):
+    """A model download in progress or completed."""
+
+    node_id: str
+    node_name: str
+    model_id: str
+    status: Literal["pending", "downloading", "completed", "failed"]
+    downloaded_gb: float = 0.0
+    total_gb: float = 0.0
+    progress_percent: float = 0.0
+    speed_mb_s: float = 0.0
+    eta_seconds: float | None = None
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Cluster overview (the "one call" response)
+# ---------------------------------------------------------------------------
+
+class ClusterHealthResponse(BaseModel):
+    """Quick health check — is the cluster alive?"""
+
+    healthy: bool
+    node_count: int
+    master_node_id: str
+    uptime_seconds: float | None = None
+    timestamp: float = Field(default_factory=time.time)
+
+
+class ClusterOverviewResponse(BaseModel):
+    """Everything an agent needs in one call.
+
+    Designed so that a single ``GET /v1/cluster`` gives full situational
+    awareness without parsing raw state or cross-referencing endpoints.
+    """
+
+    # Top-level summary
+    node_count: int = 0
+    total_ram_gb: float = 0.0
+    available_ram_gb: float = 0.0
+    used_ram_gb: float = 0.0
+    ram_used_percent: float = 0.0
+    loaded_model_count: int = 0
+    active_task_count: int = 0
+    active_download_count: int = 0
+
+    # Details
+    nodes: list[ClusterNodeSummary] = Field(default_factory=list)
+    models: list[ClusterModelSummary] = Field(default_factory=list)
+    tasks: list[ClusterTaskSummary] = Field(default_factory=list)
+    downloads: list[ClusterDownloadSummary] = Field(default_factory=list)
+
+    # Metadata
+    master_node_id: str = ""
+    timestamp: float = Field(default_factory=time.time)
+
+
+# ---------------------------------------------------------------------------
+# Action requests (simplified agent-friendly versions)
+# ---------------------------------------------------------------------------
+
+class LoadModelRequest(BaseModel):
+    """Load a model by name — the cluster figures out placement."""
+
+    model_id: str
+    min_nodes: int = 1
+    preferred_sharding: Literal["pipeline", "tensor", "auto"] = "auto"
+
+
+class LoadModelResponse(BaseModel):
+    """Response after requesting a model load."""
+
+    message: str
+    command_id: str
+    model_id: str
+    instance_id: str | None = None
+    placement: dict[str, str] = Field(default_factory=dict)  # node_id -> role
+    estimated_memory_gb: float = 0.0
+
+
+class UnloadModelResponse(BaseModel):
+    """Response after requesting a model unload."""
+
+    message: str
+    command_id: str
+    model_id: str
+    instance_id: str
+    freed_memory_gb: float = 0.0
+
+
+class SwapModelRequest(BaseModel):
+    """Atomically swap one model for another.
+
+    Unloads ``unload_model_id`` then loads ``load_model_id`` in a single call.
+    Ideal for day/night model rotation scripts.
+    """
+
+    unload_model_id: str
+    load_model_id: str
+    min_nodes: int = 1
+    preferred_sharding: Literal["pipeline", "tensor", "auto"] = "auto"
+
+
+class SwapModelResponse(BaseModel):
+    """Response after a model swap request."""
+
+    message: str
+    unload_command_id: str
+    load_command_id: str
+    unloaded_model: str
+    loaded_model: str
+    freed_memory_gb: float = 0.0
+    estimated_load_memory_gb: float = 0.0
+
+
+class ModelStatusResponse(BaseModel):
+    """Polling-friendly status for a single model by name.
+
+    Hit this in a loop to wait for a model to become ready after loading,
+    or to confirm it's fully unloaded after deletion.
+    """
+
+    model_id: str
+    found: bool = False
+    status: str = "not_loaded"  # not_loaded | downloading | loading | ready | running | failed
+    ready: bool = False
+    progress: str | None = None  # Human-readable progress string
+    nodes: list[str] = Field(default_factory=list)
+    instance_id: str | None = None
+
+
+class ClusterNodesResponse(BaseModel):
+    """List of all nodes in the cluster."""
+
+    node_count: int
+    nodes: list[ClusterNodeSummary]
+    timestamp: float = Field(default_factory=time.time)
+
+
+class ClusterModelsResponse(BaseModel):
+    """All models: loaded, downloading, and available."""
+
+    loaded: list[ClusterModelSummary] = Field(default_factory=list)
+    downloading: list[ClusterDownloadSummary] = Field(default_factory=list)
+    timestamp: float = Field(default_factory=time.time)


### PR DESCRIPTION
## Motivation

EXO has a powerful internal state model, but the only way to query cluster status programmatically is `GET /state`, which returns the full raw state blob. For AI agents, CLI tools, and automation scripts managing an EXO cluster, this requires parsing topology graphs, nested runner status unions, and cross-referencing node IDs across multiple state mappings.

This PR adds a set of `/v1/cluster/*` endpoints that provide flat, pre-digested cluster information designed for programmatic consumption. The primary use case is enabling agents and scripts to manage model lifecycle — e.g., swapping a large model in overnight for batch deep-reasoning work, then switching back to a smaller/faster model during the day.

## Changes

**New file: `src/exo/shared/types/cluster.py`** — 13 Pydantic response/request models

**New endpoints in `src/exo/master/api.py`:**

| Method | Path | Purpose |
|--------|------|---------|
| `GET` | `/v1/cluster` | Full cluster overview in one call (nodes, models, tasks, downloads, memory totals) |
| `GET` | `/v1/cluster/health` | Quick liveness check (healthy?, node count, master ID) |
| `GET` | `/v1/cluster/nodes` | All nodes with flat, agent-friendly summaries |
| `GET` | `/v1/cluster/nodes/{id}` | Single node detail |
| `GET` | `/v1/cluster/models` | Loaded models + active downloads |
| `GET` | `/v1/cluster/models/{id}/status` | Poll model readiness (for waiting on async load/swap) |
| `POST` | `/v1/cluster/models/load` | Load a model by name — cluster handles sharding/placement |
| `POST` | `/v1/cluster/models/swap` | Atomic unload-then-load in one call |
| `DELETE` | `/v1/cluster/models/{id}` | Unload by model name or short name (not instance ID) |

**New file: `src/exo/master/tests/test_cluster_api.py`** — 13 tests with a realistic 2-node cluster fixture

### Design principles

- **Flat fields with units** — `ram_available_gb`, `speed_mb_s`, `temperature_c` (no nested objects to traverse)
- **Error messages suggest fixes** — *"Need 45GB, have 30GB. Currently loaded: Qwen3-30B (20GB). Unload a model to free memory."*
- **404s list what IS available** — node not found? Response includes available node IDs
- **Actions by name** — load/unload/swap by model name, not instance ID
- **Status polling** — `GET /v1/cluster/models/{id}/status` returns `ready: true/false` with human-readable progress for async operations

### Example: day/night model swap

```bash
# 11pm cron — swap to large model for overnight batch work
curl -X POST http://localhost:52415/v1/cluster/models/swap -H 'Content-Type: application/json' -d '{
  "unload_model_id": "Qwen3-30B-A3B-4bit",
  "load_model_id": "mlx-community/MiniMax-M1-80B-A45B-4bit",
  "min_nodes": 2
}'

# Poll until ready
while ! curl -s http://localhost:52415/v1/cluster/models/MiniMax-M1-80B-A45B-4bit/status | jq -e '.ready'; do
  sleep 10
done

# 6am cron — swap back to fast model
curl -X POST http://localhost:52415/v1/cluster/models/swap -d '{
  "unload_model_id": "MiniMax-M1-80B-A45B-4bit",
  "load_model_id": "mlx-community/Qwen3-30B-A3B-4bit"
}'
```

## Why It Works

All endpoints are implemented as methods on the existing `API` class, reading from `self.state` (the same state object the dashboard uses). Write operations (`load`, `unload`, `swap`) send commands through the existing `self._send()` pipeline, so they go through the same master election, placement, and event-sourcing path as dashboard actions. No new infrastructure or state management was added.

Response types are plain `pydantic.BaseModel` (not `CamelCaseModel`) since these are new endpoints with no existing consumers expecting camelCase — field names read naturally as-is (`ram_available_gb`). This is a deliberate choice to maximize readability for the programmatic consumers these endpoints target.

## Test Plan

### Automated Testing

13 new tests in `src/exo/master/tests/test_cluster_api.py`:
- `TestClusterHealth` — healthy cluster, empty cluster
- `TestClusterOverview` — full structure validation, memory math (340+350=690 available)
- `TestClusterNodes` — list, detail, 404 with helpful message
- `TestClusterModels` — loaded models, empty cluster
- `TestClusterModelStatus` — ready model (by full ID and short name), not-loaded model, loading-in-progress with layer count

All tests use a realistic 2-node fixture (two M3 Ultra 512GB nodes with a pipeline-sharded model). Full suite: **97 tests pass** (84 existing + 13 new), zero regressions.

### Manual Testing

Not yet tested against a live cluster (our cluster wasn't running during development). The endpoints read from the same `self.state` object used by the dashboard and existing API, so the data flow is well-established. Would appreciate help testing on a live multi-node cluster.