### PR TITLE
Delete bound runners when deleting an instance

### DIFF
--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -26,6 +26,7 @@ from exo.shared.types.events import (
     Event,
     InstanceCreated,
     InstanceDeleted,
+    RunnerDeleted,
     TaskStatusUpdated,
 )
 from exo.shared.types.memory import Memory
@@ -233,6 +234,7 @@ def get_transition_events(
     # find instances to delete
     for instance_id in current_instances:
         if instance_id not in target_instances:
+            instance = current_instances[instance_id]
             for task in tasks.values():
                 if task.instance_id == instance_id and task.task_status in [
                     TaskStatus.Pending,
@@ -244,6 +246,13 @@ def get_transition_events(
                             task_id=task.task_id,
                         )
                     )
+
+            for runner_id in instance.shard_assignments.runner_to_shard:
+                events.append(
+                    RunnerDeleted(
+                        runner_id=runner_id,
+                    )
+                )
 
             events.append(
                 InstanceDeleted(

--- a/src/exo/master/tests/test_placement.py
+++ b/src/exo/master/tests/test_placement.py
@@ -17,6 +17,7 @@ from exo.shared.types.common import CommandId, NodeId
 from exo.shared.types.events import (
     InstanceCreated,
     InstanceDeleted,
+    RunnerDeleted,
     TaskStatusUpdated,
 )
 from exo.shared.types.memory import Memory
@@ -32,16 +33,36 @@ from exo.shared.types.worker.instances import (
     MlxJacclInstance,
     MlxRingInstance,
 )
-from exo.shared.types.worker.runners import ShardAssignments
-from exo.shared.types.worker.shards import Sharding
+from exo.shared.types.worker.runners import RunnerId, ShardAssignments
+from exo.shared.types.worker.shards import PipelineShardMetadata, Sharding
 
 
 @pytest.fixture
 def instance() -> Instance:
+    model_card = ModelCard(
+        model_id=ModelId("test-model"),
+        storage_size=Memory.from_kb(1000),
+        n_layers=10,
+        hidden_size=30,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+    )
+    runner_id = RunnerId()
     return MlxRingInstance(
         instance_id=InstanceId(),
         shard_assignments=ShardAssignments(
-            model_id=ModelId("test-model"), runner_to_shard={}, node_to_runner={}
+            model_id=model_card.model_id,
+            runner_to_shard={
+                runner_id: PipelineShardMetadata(
+                    model_card=model_card,
+                    device_rank=0,
+                    world_size=1,
+                    start_layer=0,
+                    end_layer=10,
+                    n_layers=10,
+                )
+            },
+            node_to_runner={NodeId(): runner_id},
         ),
         hosts_by_node={},
         ephemeral_port=50000,
@@ -275,9 +296,10 @@ def test_get_transition_events_delete_instance(instance: Instance):
     events = get_transition_events(current_instances, target_instances, {})
 
     # assert
-    assert len(events) == 1
-    assert isinstance(events[0], InstanceDeleted)
-    assert events[0].instance_id == instance_id
+    assert len(events) == 2
+    assert isinstance(events[0], RunnerDeleted)
+    assert isinstance(events[1], InstanceDeleted)
+    assert events[1].instance_id == instance_id
 
 
 def test_placement_selects_leaf_nodes(
@@ -493,13 +515,14 @@ def test_get_transition_events_delete_instance_cancels_running_tasks(
     # act
     events = get_transition_events(current_instances, target_instances, tasks)
 
-    # assert – cancellation event should come before the deletion event
-    assert len(events) == 2
+    # assert – cancellation event should come before runner and instance deletion
+    assert len(events) == 3
     assert isinstance(events[0], TaskStatusUpdated)
     assert events[0].task_id == task.task_id
     assert events[0].task_status == TaskStatus.Cancelled
-    assert isinstance(events[1], InstanceDeleted)
-    assert events[1].instance_id == instance_id
+    assert isinstance(events[1], RunnerDeleted)
+    assert isinstance(events[2], InstanceDeleted)
+    assert events[2].instance_id == instance_id
 
 
 def test_get_transition_events_delete_instance_cancels_pending_tasks(
@@ -516,11 +539,12 @@ def test_get_transition_events_delete_instance_cancels_pending_tasks(
     events = get_transition_events(current_instances, target_instances, tasks)
 
     # assert
-    assert len(events) == 2
+    assert len(events) == 3
     assert isinstance(events[0], TaskStatusUpdated)
     assert events[0].task_id == task.task_id
     assert events[0].task_status == TaskStatus.Cancelled
-    assert isinstance(events[1], InstanceDeleted)
+    assert isinstance(events[1], RunnerDeleted)
+    assert isinstance(events[2], InstanceDeleted)
 
 
 def test_get_transition_events_delete_instance_ignores_completed_tasks(
@@ -543,9 +567,10 @@ def test_get_transition_events_delete_instance_ignores_completed_tasks(
     # act
     events = get_transition_events(current_instances, target_instances, tasks)
 
-    # assert – only the InstanceDeleted event, no cancellations
-    assert len(events) == 1
-    assert isinstance(events[0], InstanceDeleted)
+    # assert – only runner and instance deletion events, no cancellations
+    assert len(events) == 2
+    assert isinstance(events[0], RunnerDeleted)
+    assert isinstance(events[1], InstanceDeleted)
 
 
 def test_get_transition_events_delete_instance_cancels_only_matching_tasks(

--- a/src/exo/shared/apply.py
+++ b/src/exo/shared/apply.py
@@ -15,6 +15,7 @@ from exo.shared.types.events import (
     NodeDownloadProgress,
     NodeGatheredInfo,
     NodeTimedOut,
+    RunnerDeleted,
     RunnerStatusUpdated,
     TaskAcknowledged,
     TaskCreated,
@@ -77,6 +78,8 @@ def event_apply(event: Event, state: State) -> State:
             return apply_node_download_progress(event, state)
         case NodeGatheredInfo():
             return apply_node_gathered_info(event, state)
+        case RunnerDeleted():
+            return apply_runner_deleted(event, state)
         case RunnerStatusUpdated():
             return apply_runner_status_updated(event, state)
         case TaskCreated():
@@ -196,6 +199,13 @@ def apply_runner_status_updated(event: RunnerStatusUpdated, state: State) -> Sta
     new_runners = {
         **state.runners,
         event.runner_id: event.runner_status,
+    }
+    return state.model_copy(update={"runners": new_runners})
+
+
+def apply_runner_deleted(event: RunnerDeleted, state: State) -> State:
+    new_runners: Mapping[RunnerId, RunnerStatus] = {
+        rid: rs for rid, rs in state.runners.items() if rid != event.runner_id
     }
     return state.model_copy(update={"runners": new_runners})
 

--- a/src/exo/shared/tests/test_apply/test_instance_runner_cleanup.py
+++ b/src/exo/shared/tests/test_apply/test_instance_runner_cleanup.py
@@ -1,0 +1,55 @@
+from exo.shared.apply import event_apply
+from exo.shared.models.model_cards import ModelCard, ModelId, ModelTask
+from exo.shared.types.common import NodeId
+from exo.shared.types.events import InstanceDeleted, RunnerDeleted
+from exo.shared.types.memory import Memory
+from exo.shared.types.state import State
+from exo.shared.types.worker.instances import Instance, InstanceId, MlxRingInstance
+from exo.shared.types.worker.runners import RunnerId, RunnerReady, ShardAssignments
+from exo.shared.types.worker.shards import PipelineShardMetadata
+
+
+def _make_instance() -> Instance:
+    model_card = ModelCard(
+        model_id=ModelId("test-model"),
+        storage_size=Memory.from_kb(1000),
+        n_layers=10,
+        hidden_size=30,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+    )
+    runner_id = RunnerId()
+    return MlxRingInstance(
+        instance_id=InstanceId(),
+        shard_assignments=ShardAssignments(
+            model_id=model_card.model_id,
+            runner_to_shard={
+                runner_id: PipelineShardMetadata(
+                    model_card=model_card,
+                    device_rank=0,
+                    world_size=1,
+                    start_layer=0,
+                    end_layer=10,
+                    n_layers=10,
+                )
+            },
+            node_to_runner={NodeId(): runner_id},
+        ),
+        hosts_by_node={},
+        ephemeral_port=50000,
+    )
+
+
+def test_instance_delete_sequence_removes_bound_runners_from_state() -> None:
+    instance = _make_instance()
+    runner_id = next(iter(instance.shard_assignments.runner_to_shard))
+    state = State(
+        instances={instance.instance_id: instance},
+        runners={runner_id: RunnerReady()},
+    )
+
+    state = event_apply(RunnerDeleted(runner_id=runner_id), state)
+    state = event_apply(InstanceDeleted(instance_id=instance.instance_id), state)
+
+    assert instance.instance_id not in state.instances
+    assert runner_id not in state.runners

--- a/src/exo/shared/types/events.py
+++ b/src/exo/shared/types/events.py
@@ -73,6 +73,10 @@ class RunnerStatusUpdated(BaseEvent):
     runner_status: RunnerStatus
 
 
+class RunnerDeleted(BaseEvent):
+    runner_id: RunnerId
+
+
 class NodeTimedOut(BaseEvent):
     node_id: NodeId
 
@@ -138,6 +142,7 @@ Event = (
     | InstanceCreated
     | InstanceDeleted
     | RunnerStatusUpdated
+    | RunnerDeleted
     | NodeTimedOut
     | NodeGatheredInfo
     | NodeDownloadProgress


### PR DESCRIPTION
Closes #1732

Merge note: suggested order `1/6` in the lifecycle hardening series.

## Summary

This PR fixes a lifecycle asymmetry in instance teardown.

Before this change, EXO could delete an instance from placement state while leaving the instance's runners in authoritative runner state. That could keep health and readiness degraded even though cleanup appeared to have succeeded.

This change makes instance deletion emit `RunnerDeleted` for all runners bound to the instance before `InstanceDeleted`.

## Problem

Instance lifecycle and runner lifecycle were not being torn down together. In practice this meant:

- the instance could disappear from `state.instances`
- its runners could remain in `state.runners`
- operator cleanup and rollback could leave stale failed state behind

## Change

- emit `RunnerDeleted` for each runner bound to a deleted instance
- preserve the existing deletion path instead of creating a separate cleanup mechanism

## Why This Is Safe

The patch narrows teardown behavior to match EXO's existing ownership model. It does not add new policy. It only makes deletion clean up the child state the deleted instance already owns.

## Tests

- deleting an instance emits runner cleanup events for all bound runners
- applying those events removes runner state from authoritative state

## Validation

Validated as part of a larger lifecycle patchset on a live 4-node Apple Silicon cluster. The relevant cluster-level outcome was that failed placement cleanup no longer left stale failed runner state behind after teardown.
