### PR TITLE
Convert startup stalls into terminal runner failure

### DIFF
--- a/src/exo/worker/runner/runner_supervisor.py
+++ b/src/exo/worker/runner/runner_supervisor.py
@@ -1,6 +1,8 @@
 import contextlib
 import multiprocessing as mp
+import os
 import signal
+import time
 from dataclasses import dataclass, field
 from typing import Self
 
@@ -34,7 +36,9 @@ from exo.shared.types.worker.runners import (
     RunnerConnecting,
     RunnerFailed,
     RunnerIdle,
+    RunnerLoaded,
     RunnerLoading,
+    RunnerReady,
     RunnerRunning,
     RunnerShuttingDown,
     RunnerStatus,
@@ -47,6 +51,9 @@ from exo.worker.runner.bootstrap import entrypoint
 
 PREFILL_TIMEOUT_SECONDS = 60
 DECODE_TIMEOUT_SECONDS = 5
+STARTUP_STALL_TIMEOUT_SECONDS = float(
+    os.environ.get("EXO_STARTUP_STALL_TIMEOUT", str(PREFILL_TIMEOUT_SECONDS))
+)
 
 
 @dataclass(eq=False)
@@ -68,6 +75,10 @@ class RunnerSupervisor:
     _cancel_watch_runner: anyio.CancelScope = field(
         default_factory=anyio.CancelScope, init=False
     )
+    _last_event_time: float = field(default_factory=time.time, init=False)
+    _last_status_change_time: float = field(default_factory=time.time, init=False)
+    _last_loading_progress_time: float = field(default_factory=time.time, init=False)
+    _last_loading_layers: int = field(default=-1, init=False)
 
     @classmethod
     def create(
@@ -189,8 +200,13 @@ class RunnerSupervisor:
         try:
             with self._ev_recv as events:
                 async for event in events:
+                    self._last_event_time = time.time()
                     if isinstance(event, RunnerStatusUpdated):
+                        previous_status = self.status
                         self.status = event.runner_status
+                        self._record_status_progress(
+                            previous_status, event.runner_status
+                        )
                     if isinstance(event, TaskAcknowledged):
                         self.pending.pop(event.task_id).set()
                         continue
@@ -230,14 +246,80 @@ class RunnerSupervisor:
                 await anyio.sleep(5)
                 if not self.runner_process.is_alive():
                     await self._check_runner(RuntimeError("Runner found to be dead"))
+                    continue
 
-    async def _check_runner(self, e: Exception) -> None:
+                if stall_reason := self._startup_stall_reason():
+                    logger.error(
+                        "ROOT_CAUSE=runner_startup_stalled %s",
+                        stall_reason,
+                    )
+                    await self._check_runner(
+                        TimeoutError(stall_reason),
+                        failure_message=stall_reason,
+                    )
+                    continue
+
+    def _record_status_progress(
+        self, previous_status: RunnerStatus, runner_status: RunnerStatus
+    ) -> None:
+        now = time.time()
+        if not isinstance(previous_status, type(runner_status)):
+            self._last_status_change_time = now
+
+        if isinstance(runner_status, RunnerLoading):
+            if runner_status.layers_loaded > self._last_loading_layers:
+                self._last_loading_layers = runner_status.layers_loaded
+                self._last_loading_progress_time = now
+        else:
+            self._last_loading_layers = -1
+            self._last_loading_progress_time = now
+
+    def _startup_stall_reason(self) -> str | None:
+        now = time.time()
+
+        if isinstance(self.status, RunnerLoading):
+            stalled_for = now - self._last_loading_progress_time
+            if stalled_for > STARTUP_STALL_TIMEOUT_SECONDS:
+                return (
+                    "Runner startup stalled in RunnerLoading for "
+                    f"{stalled_for:.1f}s without layer progress"
+                )
+
+        if isinstance(self.status, (RunnerConnecting, RunnerLoaded, RunnerWarmingUp)):
+            stalled_for = now - self._last_status_change_time
+            if stalled_for > STARTUP_STALL_TIMEOUT_SECONDS:
+                return (
+                    f"Runner startup stalled in {type(self.status).__name__} "
+                    f"for {stalled_for:.1f}s"
+                )
+
+        if isinstance(
+            self.status,
+            (RunnerReady, RunnerRunning, RunnerIdle, RunnerFailed, RunnerShuttingDown),
+        ):
+            return None
+
+        return None
+
+    async def _check_runner(
+        self, e: Exception, *, failure_message: str | None = None
+    ) -> None:
         if not self._cancel_watch_runner.cancel_called:
             self._cancel_watch_runner.cancel()
         logger.info("Checking runner's status")
         if self.runner_process.is_alive():
             logger.info("Runner was found to be alive, attempting to join process")
             await to_thread.run_sync(self.runner_process.join, 5)
+        if self.runner_process.is_alive() and failure_message is not None:
+            logger.warning(
+                "Runner remained alive after watchdog join; terminating unhealthy startup process"
+            )
+            self.runner_process.terminate()
+            await to_thread.run_sync(self.runner_process.join, 3)
+            if self.runner_process.is_alive():
+                logger.critical("Runner ignored SIGTERM after startup stall; killing")
+                self.runner_process.kill()
+                await to_thread.run_sync(self.runner_process.join, 1)
         rc = self.runner_process.exitcode
         logger.info(f"Runner exited with exit code {rc}")
         if rc == 0:
@@ -251,6 +333,9 @@ class RunnerSupervisor:
                 cause = f"signal={sig}"
         else:
             cause = f"exitcode={rc}"
+
+        if failure_message is not None:
+            cause = f"{failure_message} ({cause})"
 
         logger.opt(exception=e).error(f"Runner terminated with {cause}")
 

--- a/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
@@ -1,4 +1,5 @@
 import multiprocessing as mp
+import time
 from typing import cast
 
 import anyio
@@ -11,9 +12,17 @@ from exo.shared.types.events import ChunkGenerated, Event, RunnerStatusUpdated
 from exo.shared.types.tasks import Task, TaskId, TextGeneration
 from exo.shared.types.text_generation import InputMessage, TextGenerationTaskParams
 from exo.shared.types.worker.instances import BoundInstance, InstanceId
-from exo.shared.types.worker.runners import RunnerFailed, RunnerId
+from exo.shared.types.worker.runners import (
+    RunnerFailed,
+    RunnerId,
+    RunnerLoaded,
+    RunnerLoading,
+)
 from exo.utils.channels import channel, mp_channel
-from exo.worker.runner.runner_supervisor import RunnerSupervisor
+from exo.worker.runner.runner_supervisor import (
+    STARTUP_STALL_TIMEOUT_SECONDS,
+    RunnerSupervisor,
+)
 from exo.worker.tests.unittests.conftest import get_bound_mlx_ring_instance
 
 
@@ -34,6 +43,29 @@ class _DeadProcess:
 
     def kill(self) -> None:
         return None
+
+
+class _AliveProcess:
+    def __init__(self) -> None:
+        self.exitcode: int | None = None
+        self._alive = True
+
+    def start(self) -> None:
+        return None
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+    def join(self, _timeout: float | None = None) -> None:
+        return None
+
+    def terminate(self) -> None:
+        self._alive = False
+        self.exitcode = -15
+
+    def kill(self) -> None:
+        self._alive = False
+        self.exitcode = -9
 
 
 @pytest.mark.asyncio
@@ -87,6 +119,126 @@ async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> 
 
     assert isinstance(got_status, RunnerStatusUpdated)
     assert isinstance(got_status.runner_status, RunnerFailed)
+
+    event_sender.close()
+    with anyio.move_on_after(0.1):
+        await event_receiver.aclose()
+
+
+@pytest.mark.asyncio
+async def test_startup_stall_reason_detects_runner_loaded_stall() -> None:
+    event_sender, _ = channel[Event]()
+    task_sender, _ = mp_channel[Task]()
+    cancel_sender, _ = mp_channel[TaskId]()
+    _, ev_recv = mp_channel[Event]()
+
+    bound_instance: BoundInstance = get_bound_mlx_ring_instance(
+        instance_id=InstanceId("instance-b"),
+        model_id=ModelId("mlx-community/Llama-3.2-1B-Instruct-4bit"),
+        runner_id=RunnerId("runner-b"),
+        node_id=NodeId("node-b"),
+    )
+
+    process = _AliveProcess()
+    supervisor = RunnerSupervisor(
+        shard_metadata=bound_instance.bound_shard,
+        bound_instance=bound_instance,
+        runner_process=cast("mp.Process", cast(object, process)),
+        initialize_timeout=400,
+        _ev_recv=ev_recv,
+        _task_sender=task_sender,
+        _event_sender=event_sender,
+        _cancel_sender=cancel_sender,
+    )
+    supervisor.status = RunnerLoaded()
+    supervisor._last_status_change_time = (  # pyright: ignore[reportPrivateUsage]
+        time.time() - STARTUP_STALL_TIMEOUT_SECONDS - 1
+    )
+
+    reason = supervisor._startup_stall_reason()  # pyright: ignore[reportPrivateUsage]
+
+    assert reason is not None
+    assert "RunnerLoaded" in reason
+    process.terminate()
+
+
+@pytest.mark.asyncio
+async def test_startup_stall_reason_detects_runner_loading_progress_stall() -> None:
+    event_sender, _ = channel[Event]()
+    task_sender, _ = mp_channel[Task]()
+    cancel_sender, _ = mp_channel[TaskId]()
+    _, ev_recv = mp_channel[Event]()
+
+    bound_instance: BoundInstance = get_bound_mlx_ring_instance(
+        instance_id=InstanceId("instance-c"),
+        model_id=ModelId("mlx-community/Llama-3.2-1B-Instruct-4bit"),
+        runner_id=RunnerId("runner-c"),
+        node_id=NodeId("node-c"),
+    )
+
+    process = _AliveProcess()
+    supervisor = RunnerSupervisor(
+        shard_metadata=bound_instance.bound_shard,
+        bound_instance=bound_instance,
+        runner_process=cast("mp.Process", cast(object, process)),
+        initialize_timeout=400,
+        _ev_recv=ev_recv,
+        _task_sender=task_sender,
+        _event_sender=event_sender,
+        _cancel_sender=cancel_sender,
+    )
+    supervisor.status = RunnerLoading(layers_loaded=2, total_layers=16)
+    supervisor._last_loading_progress_time = (  # pyright: ignore[reportPrivateUsage]
+        time.time() - STARTUP_STALL_TIMEOUT_SECONDS - 1
+    )
+
+    reason = supervisor._startup_stall_reason()  # pyright: ignore[reportPrivateUsage]
+
+    assert reason is not None
+    assert "RunnerLoading" in reason
+    assert "without layer progress" in reason
+    process.terminate()
+
+
+@pytest.mark.asyncio
+async def test_check_runner_turns_startup_stall_into_runner_failed() -> None:
+    event_sender, event_receiver = channel[Event]()
+    task_sender, _ = mp_channel[Task]()
+    cancel_sender, _ = mp_channel[TaskId]()
+    _, ev_recv = mp_channel[Event]()
+
+    bound_instance: BoundInstance = get_bound_mlx_ring_instance(
+        instance_id=InstanceId("instance-d"),
+        model_id=ModelId("mlx-community/Llama-3.2-1B-Instruct-4bit"),
+        runner_id=RunnerId("runner-d"),
+        node_id=NodeId("node-d"),
+    )
+    process = _AliveProcess()
+
+    supervisor = RunnerSupervisor(
+        shard_metadata=bound_instance.bound_shard,
+        bound_instance=bound_instance,
+        runner_process=cast("mp.Process", cast(object, process)),
+        initialize_timeout=400,
+        _ev_recv=ev_recv,
+        _task_sender=task_sender,
+        _event_sender=event_sender,
+        _cancel_sender=cancel_sender,
+    )
+    supervisor.shutdown = lambda: None
+
+    failure_message = "Runner startup stalled in RunnerLoaded for 121.0s"
+    await supervisor._check_runner(  # pyright: ignore[reportPrivateUsage]
+        TimeoutError(failure_message),
+        failure_message=failure_message,
+    )
+
+    got_status = await event_receiver.receive()
+
+    assert isinstance(got_status, RunnerStatusUpdated)
+    assert isinstance(got_status.runner_status, RunnerFailed)
+    assert failure_message in (got_status.runner_status.error_message or "")
+    assert process.exitcode == -15
 
     event_sender.close()
     with anyio.move_on_after(0.1):


### PR DESCRIPTION
Closes #1731

Merge note: suggested order `2/6` in the lifecycle hardening series.

## Summary

This PR makes startup-phase hangs terminal instead of leaving runners in ambiguous non-terminal startup states.

Before this change, a runner could stop making forward progress during `Loading`, `Loaded`, `Connecting`, or `WarmingUp` and EXO would continue treating it as in-progress until a higher-level timeout expired.

This change teaches the runner supervisor to detect startup stalls and emit `RunnerFailed` with a phase-aware reason.

## Problem

EXO currently conflates "still starting" with "stuck during startup". For long model loads that creates unnecessary ambiguity:

- readiness waits longer than it should
- placement sees timeout instead of terminal failure
- operators cannot tell whether the runner is slow or dead

## Change

- track last startup status change time
- track last loading progress time
- apply a bounded startup stall timeout
- terminate the runner if startup stops progressing
- emit `RunnerFailed` with the startup stall cause

## Why This Is Safe

This patch narrows failure semantics to a clear invariant: a runner that has stopped making startup progress past a bounded deadline is terminally failed for operational purposes.

## Tests

- `RunnerLoaded` stall becomes `RunnerFailed`
- `RunnerLoading` progress stall becomes `RunnerFailed`
- startup stalls no longer remain indefinite non-terminal states

## Validation

Validated as part of the full lifecycle set on a live 4-node Apple Silicon cluster. The main value is that startup failure becomes explicit and recoverable instead of remaining ambiguous.
