### PR TITLE
Persist terminal runner failures when the event sender is closed

### DIFF
--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -46,6 +46,7 @@ from exo.utils.info_gatherer.net_profile import check_reachable
 from exo.utils.keyed_backoff import KeyedBackoff
 from exo.utils.task_group import TaskGroup
 from exo.worker.plan import plan
+from exo.worker.runner.failure_store import replay_persisted_runner_failures
 from exo.worker.runner.runner_supervisor import RunnerSupervisor
 
 
@@ -92,6 +93,7 @@ class Worker:
                 tg.start_soon(self.plan_step)
                 tg.start_soon(self._event_applier)
                 tg.start_soon(self._poll_connection_updates)
+                tg.start_soon(self._replay_runner_failures)
         finally:
             # Actual shutdown code - waits for all tasks to complete before executing.
             logger.info("Stopping Worker")
@@ -333,3 +335,13 @@ class Worker:
                     await self.event_sender.send(TopologyEdgeDeleted(conn=conn))
 
             await anyio.sleep(10)
+
+    async def _replay_runner_failures(self) -> None:
+        while True:
+            replayed = await replay_persisted_runner_failures(self.event_sender)
+            if replayed:
+                logger.warning(
+                    "Replayed {} persisted runner failure event(s) into worker event stream",
+                    replayed,
+                )
+            await anyio.sleep(1)

--- a/src/exo/worker/runner/bootstrap.py
+++ b/src/exo/worker/runner/bootstrap.py
@@ -8,6 +8,7 @@ from exo.shared.types.tasks import Task, TaskId
 from exo.shared.types.worker.instances import BoundInstance
 from exo.shared.types.worker.runners import RunnerFailed
 from exo.utils.channels import ClosedResourceError, MpReceiver, MpSender
+from exo.worker.runner.failure_store import persist_runner_failure
 
 logger: "loguru.Logger" = loguru.logger
 
@@ -56,12 +57,19 @@ def entrypoint(
         logger.opt(exception=e).warning(
             f"Runner {bound_instance.bound_runner_id} crashed with critical exception {e}"
         )
-        event_sender.send(
-            RunnerStatusUpdated(
-                runner_id=bound_instance.bound_runner_id,
-                runner_status=RunnerFailed(error_message=str(e)),
+        try:
+            event_sender.send(
+                RunnerStatusUpdated(
+                    runner_id=bound_instance.bound_runner_id,
+                    runner_status=RunnerFailed(error_message=str(e)),
+                )
             )
-        )
+        except (BrokenPipeError, OSError, ClosedResourceError):
+            persist_runner_failure(
+                bound_instance,
+                error_message=str(e),
+                source="runner_bootstrap_exception",
+            )
     finally:
         try:
             event_sender.close()

--- a/src/exo/worker/runner/failure_store.py
+++ b/src/exo/worker/runner/failure_store.py
@@ -1,0 +1,78 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from anyio import BrokenResourceError, ClosedResourceError
+from loguru import logger
+
+from exo.shared.constants import EXO_LOG_DIR
+from exo.shared.types.events import Event, RunnerStatusUpdated
+from exo.shared.types.worker.instances import BoundInstance
+from exo.shared.types.worker.runners import RunnerFailed, RunnerId
+from exo.utils.channels import Sender
+
+
+def _pending_runner_failure_dir() -> Path:
+    return EXO_LOG_DIR / "pending_runner_failures"
+
+
+def persist_runner_failure(
+    bound_instance: BoundInstance,
+    *,
+    error_message: str,
+    source: str,
+) -> Path:
+    failure_dir = _pending_runner_failure_dir()
+    failure_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    runner_id = str(bound_instance.bound_runner_id)
+    payload = {
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+        "runner_id": runner_id,
+        "instance_id": str(bound_instance.instance.instance_id),
+        "node_id": str(bound_instance.bound_node_id),
+        "model_id": str(bound_instance.instance.shard_assignments.model_id),
+        "error_message": error_message,
+        "source": source,
+    }
+
+    final_path = failure_dir / f"runner_failure_{timestamp}_{runner_id[:8]}.json"
+    temp_path = final_path.with_suffix(".tmp")
+    temp_path.write_text(json.dumps(payload, indent=2))
+    temp_path.replace(final_path)
+    logger.warning("Persisted terminal runner failure to {}", final_path)
+    return final_path
+
+
+async def replay_persisted_runner_failures(event_sender: Sender[Event]) -> int:
+    failure_dir = _pending_runner_failure_dir()
+    if not failure_dir.exists():
+        return 0
+
+    replayed = 0
+    for path in sorted(failure_dir.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text())
+            runner_id = RunnerId(payload["runner_id"])
+            error_message = str(payload["error_message"])
+            await event_sender.send(
+                RunnerStatusUpdated(
+                    runner_id=runner_id,
+                    runner_status=RunnerFailed(error_message=error_message),
+                )
+            )
+            path.unlink()
+            replayed += 1
+        except (ClosedResourceError, BrokenResourceError):
+            break
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            invalid_path = path.with_suffix(".invalid")
+            path.replace(invalid_path)
+            logger.warning(
+                "Invalid persisted runner failure record {}: {}",
+                invalid_path,
+                exc,
+            )
+
+    return replayed

--- a/src/exo/worker/runner/runner_supervisor.py
+++ b/src/exo/worker/runner/runner_supervisor.py
@@ -44,6 +44,7 @@ from exo.shared.types.worker.shards import ShardMetadata
 from exo.utils.channels import MpReceiver, MpSender, Sender, mp_channel
 from exo.utils.task_group import TaskGroup
 from exo.worker.runner.bootstrap import entrypoint
+from exo.worker.runner.failure_store import persist_runner_failure
 
 PREFILL_TIMEOUT_SECONDS = 60
 DECODE_TIMEOUT_SECONDS = 5
@@ -282,6 +283,11 @@ class RunnerSupervisor:
                     )
                 )
         except (ClosedResourceError, BrokenResourceError):
+            persist_runner_failure(
+                self.bound_instance,
+                error_message=self.status.error_message or f"Terminated ({cause})",
+                source="runner_supervisor",
+            )
             logger.warning(
                 "Event sender already closed, unable to report runner failure"
             )

--- a/src/exo/worker/tests/unittests/test_runner/test_failure_store.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_failure_store.py
@@ -1,0 +1,66 @@
+import pytest
+
+from exo.shared.models.model_cards import ModelId
+from exo.shared.types.common import NodeId
+from exo.shared.types.events import Event, RunnerStatusUpdated
+from exo.shared.types.worker.instances import BoundInstance, InstanceId
+from exo.shared.types.worker.runners import RunnerFailed, RunnerId
+from exo.utils.channels import channel
+from exo.worker.runner import failure_store
+from exo.worker.tests.unittests.conftest import get_bound_mlx_ring_instance
+
+
+@pytest.mark.asyncio
+async def test_replay_persisted_runner_failures_republishes_and_clears(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(failure_store, "EXO_LOG_DIR", tmp_path)
+
+    bound_instance: BoundInstance = get_bound_mlx_ring_instance(
+        instance_id=InstanceId("instance-f"),
+        model_id=ModelId("mlx-community/Llama-3.2-1B-Instruct-4bit"),
+        runner_id=RunnerId("runner-f"),
+        node_id=NodeId("node-f"),
+    )
+    stored = failure_store.persist_runner_failure(
+        bound_instance,
+        error_message="persist me",
+        source="unit_test",
+    )
+    assert stored.exists()
+
+    event_sender, event_receiver = channel[Event]()
+
+    replayed = await failure_store.replay_persisted_runner_failures(event_sender)
+    event = await event_receiver.receive()
+
+    assert replayed == 1
+    assert isinstance(event, RunnerStatusUpdated)
+    assert event.runner_id == RunnerId("runner-f")
+    assert isinstance(event.runner_status, RunnerFailed)
+    assert event.runner_status.error_message == "persist me"
+    assert not stored.exists()
+
+    event_sender.close()
+
+
+@pytest.mark.asyncio
+async def test_replay_persisted_runner_failures_quarantines_invalid_records(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(failure_store, "EXO_LOG_DIR", tmp_path)
+
+    pending_dir = tmp_path / "pending_runner_failures"
+    pending_dir.mkdir(parents=True, exist_ok=True)
+    invalid_path = pending_dir / "invalid.json"
+    invalid_path.write_text('{"runner_id":"runner-x"}')
+
+    event_sender, _ = channel[Event]()
+
+    replayed = await failure_store.replay_persisted_runner_failures(event_sender)
+
+    assert replayed == 0
+    assert not invalid_path.exists()
+    assert (pending_dir / "invalid.invalid").exists()
+
+    event_sender.close()

--- a/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
@@ -13,6 +13,7 @@ from exo.shared.types.text_generation import InputMessage, TextGenerationTaskPar
 from exo.shared.types.worker.instances import BoundInstance, InstanceId
 from exo.shared.types.worker.runners import RunnerFailed, RunnerId
 from exo.utils.channels import channel, mp_channel
+from exo.worker.runner import failure_store
 from exo.worker.runner.runner_supervisor import RunnerSupervisor
 from exo.worker.tests.unittests.conftest import get_bound_mlx_ring_instance
 
@@ -91,3 +92,43 @@ async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> 
     event_sender.close()
     with anyio.move_on_after(0.1):
         await event_receiver.aclose()
+
+
+@pytest.mark.asyncio
+async def test_check_runner_persists_failure_when_event_sender_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(failure_store, "EXO_LOG_DIR", tmp_path)
+
+    event_sender, _ = channel[Event]()
+    task_sender, _ = mp_channel[Task]()
+    cancel_sender, _ = mp_channel[TaskId]()
+    _, ev_recv = mp_channel[Event]()
+
+    bound_instance: BoundInstance = get_bound_mlx_ring_instance(
+        instance_id=InstanceId("instance-e"),
+        model_id=ModelId("mlx-community/Llama-3.2-1B-Instruct-4bit"),
+        runner_id=RunnerId("runner-e"),
+        node_id=NodeId("node-e"),
+    )
+
+    supervisor = RunnerSupervisor(
+        shard_metadata=bound_instance.bound_shard,
+        bound_instance=bound_instance,
+        runner_process=cast("mp.Process", cast(object, _DeadProcess())),
+        initialize_timeout=400,
+        _ev_recv=ev_recv,
+        _task_sender=task_sender,
+        _event_sender=event_sender,
+        _cancel_sender=cancel_sender,
+    )
+    supervisor.shutdown = lambda: None
+    event_sender.close()
+
+    await supervisor._check_runner(RuntimeError("boom"))  # pyright: ignore[reportPrivateUsage]
+
+    pending_files = list((tmp_path / "pending_runner_failures").glob("*.json"))
+    assert len(pending_files) == 1
+    payload = pending_files[0].read_text()
+    assert "runner-e" in payload
+    assert "runner_supervisor" in payload


### PR DESCRIPTION
Closes #1736

Merge note: suggested order `4/6` in the lifecycle hardening series.

## Summary

This PR adds a durable fallback for terminal runner failure propagation.

Before this change, EXO could observe a terminal runner failure after the normal event sender had already closed. In that case, the failure could be logged locally but never reach authoritative master state.

This change persists terminal `RunnerFailed` records locally when live publication is unavailable and replays them into the normal event stream once the worker can publish again.

## Problem

The event channel used to report failure can itself be gone during crash and shutdown paths. That makes terminal failure propagation unreliable exactly where reliability matters most.

## Change

- add a durable local failure store for terminal runner failures
- persist `RunnerFailed` when live publication cannot happen
- replay persisted failures on worker startup and during runtime
- clear persisted failures after successful replay

## Why This Is Safe

This does not replace EXO's normal event model. It only adds a bounded fallback so terminal state cannot disappear when the live sender is already closed.

## Tests

- closed-channel failure persists a durable terminal record
- persisted failures replay into `RunnerStatusUpdated`
- replayed failures are removed from the durable inbox

## Validation

Validated on a live cluster during a real `397B` failure path. Worker logs showed persisted failure, closed sender, and later replay into the normal event stream; final cluster readiness still converged to `failed_runners=[]` and `api_verdict=PASS`.
