### PR TITLE
Roll back failed multi-runner instances atomically

### DIFF
--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -10,6 +10,7 @@ from exo.master.placement import (
     delete_instance,
     get_transition_events,
     place_instance,
+    rollback_failed_instances,
 )
 from exo.shared.apply import apply
 from exo.shared.constants import EXO_EVENT_LOG_DIR, EXO_TRACING_ENABLED
@@ -361,6 +362,27 @@ class Master:
     # These plan loops are the cracks showing in our event sourcing architecture - more things could be commands
     async def _plan(self) -> None:
         while True:
+            placement, transition_events = rollback_failed_instances(
+                self.state.instances,
+                self.state.runners,
+                self.state.tasks,
+            )
+            if transition_events:
+                logger.warning(
+                    "Rolling back {} failed instance(s) after runner failure",
+                    len(self.state.instances) - len(placement),
+                )
+                for cmd in cancel_unnecessary_downloads(
+                    placement, self.state.downloads
+                ):
+                    await self.download_command_sender.send(
+                        ForwarderDownloadCommand(
+                            origin=self._system_id, command=cmd
+                        )
+                    )
+                for event in transition_events:
+                    await self.event_sender.send(event)
+
             # kill broken instances
             connected_node_ids = set(self.state.topology.list_nodes())
             for instance_id, instance in self.state.instances.items():

--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -42,6 +42,7 @@ from exo.shared.types.worker.instances import (
     MlxJacclInstance,
     MlxRingInstance,
 )
+from exo.shared.types.worker.runners import RunnerFailed, RunnerId, RunnerStatus
 from exo.shared.types.worker.shards import Sharding
 
 
@@ -252,6 +253,35 @@ def get_transition_events(
             )
 
     return events
+
+
+def rollback_failed_instances(
+    current_instances: Mapping[InstanceId, Instance],
+    runners: Mapping[RunnerId, RunnerStatus],
+    tasks: Mapping[TaskId, Task],
+) -> tuple[Mapping[InstanceId, Instance], Sequence[Event]]:
+    failed_instance_ids = {
+        instance_id
+        for instance_id, instance in current_instances.items()
+        if any(
+            isinstance(runners.get(runner_id), RunnerFailed)
+            for runner_id in instance.shard_assignments.runner_to_shard
+        )
+    }
+
+    if not failed_instance_ids:
+        return current_instances, ()
+
+    target_instances = {
+        instance_id: instance
+        for instance_id, instance in current_instances.items()
+        if instance_id not in failed_instance_ids
+    }
+    return target_instances, get_transition_events(
+        current_instances,
+        target_instances,
+        tasks,
+    )
 
 
 def cancel_unnecessary_downloads(

--- a/src/exo/master/tests/test_master.py
+++ b/src/exo/master/tests/test_master.py
@@ -20,23 +20,29 @@ from exo.shared.types.events import (
     Event,
     GlobalForwarderEvent,
     IndexedEvent,
+    InstanceDeleted,
     InstanceCreated,
     LocalForwarderEvent,
     NodeGatheredInfo,
     TaskCreated,
+    TaskStatusUpdated,
 )
 from exo.shared.types.memory import Memory
 from exo.shared.types.profiling import (
     MemoryUsage,
 )
-from exo.shared.types.tasks import TaskStatus
+from exo.shared.types.tasks import TaskId, TaskStatus
 from exo.shared.types.tasks import TextGeneration as TextGenerationTask
 from exo.shared.types.text_generation import InputMessage, TextGenerationTaskParams
+from exo.shared.types.state import State
 from exo.shared.types.worker.instances import (
+    Instance,
+    InstanceId,
     InstanceMeta,
     MlxRingInstance,
     ShardAssignments,
 )
+from exo.shared.types.worker.runners import RunnerFailed, RunnerId
 from exo.shared.types.worker.shards import PipelineShardMetadata, Sharding
 from exo.utils.channels import channel
 
@@ -218,3 +224,88 @@ async def test_master():
 
         ev_send.close()
         await master.shutdown()
+
+
+def _make_instance(*, instance_id: str, runner_id: str, model_id: str = "test-model") -> Instance:
+    model_card = ModelCard(
+        model_id=ModelId(model_id),
+        n_layers=16,
+        storage_size=Memory.from_bytes(678948),
+        hidden_size=7168,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+    )
+    rid = RunnerId(runner_id)
+    node_id = NodeId(f"node-{runner_id}")
+    return MlxRingInstance(
+        instance_id=InstanceId(instance_id),
+        shard_assignments=ShardAssignments(
+            model_id=model_card.model_id,
+            runner_to_shard={
+                rid: PipelineShardMetadata(
+                    start_layer=0,
+                    end_layer=16,
+                    n_layers=16,
+                    model_card=model_card,
+                    device_rank=0,
+                    world_size=1,
+                )
+            },
+            node_to_runner={node_id: rid},
+        ),
+        hosts_by_node={},
+        ephemeral_port=50000,
+    )
+
+
+@pytest.mark.asyncio
+async def test_master_rolls_back_failed_instance() -> None:
+    ge_sender, _global_event_receiver = channel[GlobalForwarderEvent]()
+    command_sender, co_receiver = channel[ForwarderCommand]()
+    local_event_sender, le_receiver = channel[LocalForwarderEvent]()
+    fcds, _fcdr = channel[ForwarderDownloadCommand]()
+    ev_send, ev_recv = channel[Event]()
+
+    node_id = NodeId("node0")
+    session_id = SessionId(master_node_id=node_id, election_clock=0)
+    instance = _make_instance(instance_id="instance-failed", runner_id="runner-failed")
+    runner_id = next(iter(instance.shard_assignments.runner_to_shard))
+
+    master = Master(
+        node_id,
+        session_id,
+        event_sender=ev_send,
+        global_event_sender=ge_sender,
+        local_event_receiver=le_receiver,
+        command_receiver=co_receiver,
+        download_command_sender=fcds,
+    )
+    master.state = State(
+        instances={instance.instance_id: instance},
+        runners={runner_id: RunnerFailed(error_message="boom")},
+        tasks={
+            TaskId("task-failed"): TextGenerationTask(
+                task_id=TaskId("task-failed"),
+                command_id=CommandId("cmd-failed"),
+                instance_id=instance.instance_id,
+                task_status=TaskStatus.Running,
+                task_params=TextGenerationTaskParams(
+                    model=instance.shard_assignments.model_id,
+                    input=[InputMessage(role="user", content="hi")],
+                ),
+            )
+        },
+    )
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(master._plan)
+
+        task_status_event = await ev_recv.receive()
+        instance_deleted_event = await ev_recv.receive()
+
+        tg.cancel_scope.cancel()
+
+    assert isinstance(task_status_event, TaskStatusUpdated)
+    assert task_status_event.task_status == TaskStatus.Cancelled
+    assert isinstance(instance_deleted_event, InstanceDeleted)
+    assert instance_deleted_event.instance_id == instance.instance_id

--- a/src/exo/master/tests/test_placement.py
+++ b/src/exo/master/tests/test_placement.py
@@ -3,6 +3,7 @@ import pytest
 from exo.master.placement import (
     get_transition_events,
     place_instance,
+    rollback_failed_instances,
 )
 from exo.master.tests.conftest import (
     create_node_memory,
@@ -32,20 +33,55 @@ from exo.shared.types.worker.instances import (
     MlxJacclInstance,
     MlxRingInstance,
 )
-from exo.shared.types.worker.runners import ShardAssignments
-from exo.shared.types.worker.shards import Sharding
+from exo.shared.types.worker.runners import (
+    RunnerFailed,
+    RunnerId,
+    RunnerLoaded,
+    ShardAssignments,
+)
+from exo.shared.types.worker.shards import PipelineShardMetadata, Sharding
 
 
-@pytest.fixture
-def instance() -> Instance:
+def _make_instance(*, runner_count: int = 1) -> Instance:
+    model_id = ModelId("test-model")
+    model_card = ModelCard(
+        model_id=model_id,
+        storage_size=Memory.from_kb(1000),
+        n_layers=10,
+        hidden_size=30,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+    )
+    runner_to_shard = {}
+    node_to_runner = {}
+    for device_rank in range(runner_count):
+        runner_id = RunnerId()
+        node_id = NodeId()
+        runner_to_shard[runner_id] = PipelineShardMetadata(
+            model_card=model_card,
+            device_rank=device_rank,
+            world_size=runner_count,
+            start_layer=device_rank,
+            end_layer=device_rank + 1,
+            n_layers=runner_count,
+        )
+        node_to_runner[node_id] = runner_id
+
     return MlxRingInstance(
         instance_id=InstanceId(),
         shard_assignments=ShardAssignments(
-            model_id=ModelId("test-model"), runner_to_shard={}, node_to_runner={}
+            model_id=model_id,
+            runner_to_shard=runner_to_shard,
+            node_to_runner=node_to_runner,
         ),
         hosts_by_node={},
         ephemeral_port=50000,
     )
+
+
+@pytest.fixture
+def instance() -> Instance:
+    return _make_instance()
 
 
 @pytest.fixture
@@ -576,3 +612,48 @@ def test_get_transition_events_delete_instance_cancels_only_matching_tasks(
     assert cancel_events[0].task_status == TaskStatus.Cancelled
     assert len(delete_events) == 1
     assert delete_events[0].instance_id == instance_id_a
+
+
+def test_rollback_failed_instances_deletes_only_failed_instances() -> None:
+    failed_instance_id = InstanceId()
+    healthy_instance_id = InstanceId()
+    failed_instance = _make_instance(runner_count=2)
+    healthy_instance = _make_instance(runner_count=2)
+
+    failed_runner_ids = list(failed_instance.shard_assignments.runner_to_shard)
+    healthy_runner_ids = list(healthy_instance.shard_assignments.runner_to_shard)
+
+    current_instances: dict[InstanceId, Instance] = {
+        failed_instance_id: failed_instance,
+        healthy_instance_id: healthy_instance,
+    }
+    failed_task = _make_task(failed_instance_id, TaskStatus.Running)
+    healthy_task = _make_task(healthy_instance_id, TaskStatus.Running)
+    tasks = {
+        failed_task.task_id: failed_task,
+        healthy_task.task_id: healthy_task,
+    }
+    runners = {
+        failed_runner_ids[0]: RunnerFailed(error_message="boom"),
+        failed_runner_ids[1]: RunnerLoaded(),
+        healthy_runner_ids[0]: RunnerLoaded(),
+        healthy_runner_ids[1]: RunnerLoaded(),
+    }
+
+    target_instances, events = rollback_failed_instances(
+        current_instances,
+        runners,
+        tasks,
+    )
+
+    assert set(target_instances) == {healthy_instance_id}
+    cancel_events = [event for event in events if isinstance(event, TaskStatusUpdated)]
+    instance_delete_events = [
+        event for event in events if isinstance(event, InstanceDeleted)
+    ]
+
+    assert len(cancel_events) == 1
+    assert cancel_events[0].task_id == failed_task.task_id
+    assert cancel_events[0].task_status == TaskStatus.Cancelled
+    assert len(instance_delete_events) == 1
+    assert instance_delete_events[0].instance_id == failed_instance_id


### PR DESCRIPTION
Closes #1740

Merge note: suggested order `5/6` in the lifecycle hardening series.

## Summary

This PR makes shard failure an instance-level placement failure.

Before this change, one runner in a multi-runner placement could fail while the instance remained partially present in authoritative state. That left partial placement behind and made cleanup depend on external intervention.

This change automatically rolls back any instance that has a bound `RunnerFailed`.

## Problem

Distributed placement should not leave a partially alive instance after shard failure. Once a bound runner has failed terminally, the instance is no longer a valid placement.

## Change

- detect instances with bound failed runners
- roll them back automatically
- reuse the existing deletion transition path instead of inventing a separate rollback mechanism

## Why This Is Safe

This does not create a new teardown model. It routes automatic rollback through the same transition chain already used for normal instance deletion, which keeps lifecycle semantics consistent.

## Tests

- helper-level rollback removes failed instances and preserves healthy ones
- master-level rollback deletes failed multi-runner instances automatically once runner failure reaches authoritative state

## Validation

Validated on a live cluster during a real `397B` startup failure. The clean-restart run exited nonzero for the `397B` readiness failure, but the final cluster state still converged to `ready=true`, `api_verdict=PASS`, `failed_runners=[]`, and no partial `397B` placement remained.
