### PR TITLE
feat: filter invalid tool calls against known tool list

### DIFF
--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -361,6 +361,16 @@ def parse_tool_calls(
                 yield response.model_copy(update={"text": combined})
                 continue
 
+            if tools is not None:
+                known_names = {t["function"]["name"] for t in tools if "function" in t}
+                valid = [tc for tc in parsed if tc.name in known_names]
+                invalid = [tc for tc in parsed if tc.name not in known_names]
+                if invalid:
+                    logger.warning(f"filtered {len(invalid)} hallucinated tool calls: {[tc.name for tc in invalid]}")
+                if not valid:
+                    continue
+                parsed = valid
+
             yield ToolCallResponse(
                 tool_calls=parsed, usage=response.usage, stats=response.stats
             )


### PR DESCRIPTION
## Summary

Validates parsed tool call names against the tool list provided in the request. Tool calls with names that don't match any known tool are logged and filtered out.

## Problem

The tool call parser accepts any content between tool call tags as valid, regardless of whether the function name actually exists in the tools provided by the client. Invalid tool calls get sent to the client which can't execute them.

## Fix

After parsing, each tool call's `name` is checked against the set of known tool names from the request's `tools` parameter. Invalid entries are filtered out and a warning is logged. If all parsed tool calls in a batch are invalid, the batch is dropped silently.

No filtering is applied when `tools` is `None`.

## Test plan

- [ ] Valid tool calls pass through unchanged
- [ ] Invalid tool call names are filtered and logged
- [ ] Batches with a mix of valid/invalid retain only valid calls
- [ ] No filtering when tools parameter is None

🤖 Generated with [Claude Code](https://claude.com/claude-code)