### PR TITLE
fix: format ErrorChunk as valid OpenAI streaming chunk

### DIFF
--- a/src/exo/master/adapters/chat_completions.py
+++ b/src/exo/master/adapters/chat_completions.py
@@ -10,8 +10,6 @@ from exo.shared.types.api import (
     ChatCompletionMessageText,
     ChatCompletionRequest,
     ChatCompletionResponse,
-    ErrorInfo,
-    ErrorResponse,
     FinishReason,
     Logprobs,
     LogprobsContentItem,
@@ -163,14 +161,23 @@ async def generate_chat_stream(
                 yield f": prefill_progress {chunk.model_dump_json()}\n\n"
 
             case ErrorChunk():
-                error_response = ErrorResponse(
-                    error=ErrorInfo(
-                        message=chunk.error_message or "Internal server error",
-                        type="InternalServerError",
-                        code=500,
-                    )
+                error_msg = chunk.error_message or "Internal server error"
+                error_chunk_response = ChatCompletionResponse(
+                    id=command_id,
+                    created=int(time.time()),
+                    model=chunk.model,
+                    choices=[
+                        StreamingChoiceResponse(
+                            index=0,
+                            delta=ChatCompletionMessage(
+                                role="assistant",
+                                content=f"\n[error] {error_msg}\n",
+                            ),
+                            finish_reason="stop",
+                        )
+                    ],
                 )
-                yield f"data: {error_response.model_dump_json()}\n\n"
+                yield f"data: {error_chunk_response.model_dump_json()}\n\n"
                 yield "data: [DONE]\n\n"
                 return
 
@@ -244,6 +251,8 @@ async def collect_chat_response(
 
             case ErrorChunk():
                 error_message = chunk.error_message or "Internal server error"
+                if model is None:
+                    model = chunk.model
                 break
 
             case TokenChunk():
@@ -280,7 +289,8 @@ async def collect_chat_response(
                 finish_reason = chunk.finish_reason
 
     if error_message is not None:
-        raise ValueError(error_message)
+        text_parts.append(f"\n[error] {error_message}\n")
+        finish_reason = "stop"
 
     combined_text = "".join(text_parts)
     combined_thinking = "".join(thinking_parts) if thinking_parts else None


### PR DESCRIPTION
## Summary

- Format `ErrorChunk` SSE events as valid OpenAI `ChatCompletionResponse` chunks instead of a non-standard `{"error": {...}}` shape
- Fix the non-streaming path to return the error as content instead of raising a `ValueError`

## Problem

When Exo encounters an error during inference (OOM, internal failure, etc.), the streaming path sends:

```
data: {"error": {"message": "...", "type": "InternalServerError", "code": 500}}
```

This doesn't match the OpenAI streaming chunk schema (`{"choices": [...], "object": "chat.completion.chunk", ...}`). Any OpenAI-compatible client (Goose, LiteLLM, etc.) attempting to deserialize this as a `StreamingChunk` will fail with a "Stream decode error", crashing the client session.

The non-streaming path has a similar issue — it raises a `ValueError` instead of returning a parseable response.

## Fix

**Streaming**: Format the error as a standard `ChatCompletionResponse` with the error message as assistant content and `finish_reason: "stop"`. The client receives a valid chunk it can parse and surface to the user/model.

**Non-streaming**: Append the error as content text and set `finish_reason: "stop"` instead of raising, so the response is still a valid `ChatCompletionResponse`.

## Test plan

- [x] All 42 runner tests pass
- [x] All 84 master tests pass
- [x] Type checking passes (basedpyright)
- [x] Linting passes (ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)