### PR TITLE
fix: guard against empty cycles list in get_smallest_cycles

### DIFF
--- a/src/exo/master/placement_utils.py
+++ b/src/exo/master/placement_utils.py
@@ -40,6 +40,8 @@ def filter_cycles_by_memory(
 def get_smallest_cycles(
     cycles: list[Cycle],
 ) -> list[Cycle]:
+    if not cycles:
+        return []
     min_nodes = min(len(cycle) for cycle in cycles)
     return [cycle for cycle in cycles if len(cycle) == min_nodes]
 


### PR DESCRIPTION
## Problem

`get_smallest_cycles` calls `min()` on a generator that can be empty when every cycle is filtered out by memory constraints. This raises `ValueError: min() arg is an empty sequence`, crashing placement entirely.

## Fix

Added a two-line early-return guard:

```python
def get_smallest_cycles(cycles: list[Cycle]) -> list[Cycle]:
    if not cycles:
        return []
    min_nodes = min(len(cycle) for cycle in cycles)
    return [cycle for cycle in cycles if len(cycle) == min_nodes]
```

## Reproduction

Place a model with `min_memory` set higher than any available node's memory — `filter_cycles_by_memory` returns `[]` → `get_smallest_cycles` raises `ValueError`.

## Tests

- All existing tests pass (`uv run pytest`)
- 0 type errors (`uv run basedpyright`)
- 0 lint errors (`uv run ruff check`)