### PR TITLE
fix: snapshot dicts before iteration in master _plan to prevent RuntimeError

### DIFF
--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -374,9 +374,9 @@ class Master:
     # These plan loops are the cracks showing in our event sourcing architecture - more things could be commands
     async def _plan(self) -> None:
         while True:
-            # kill broken instances
+            # kill broken instances — snapshot to avoid mutation during iteration
             connected_node_ids = set(self.state.topology.list_nodes())
-            for instance_id, instance in self.state.instances.items():
+            for instance_id, instance in list(self.state.instances.items()):
                 for node_id in instance.shard_assignments.node_to_runner:
                     if node_id not in connected_node_ids:
                         await self.event_sender.send(
@@ -384,8 +384,8 @@ class Master:
                         )
                         break
 
-            # time out dead nodes
-            for node_id, time in self.state.last_seen.items():
+            # time out dead nodes — snapshot to avoid mutation during iteration
+            for node_id, time in list(self.state.last_seen.items()):
                 now = datetime.now(tz=timezone.utc)
                 if now - time > timedelta(seconds=30):
                     logger.info(f"Manually removing node {node_id} due to inactivity")


### PR DESCRIPTION
## Problem

`Master._plan` iterates `self.state.instances.items()` and `self.state.last_seen.items()` across `await` points. Any concurrent coroutine that modifies these dicts (node arrival, departure, heartbeat) causes:

```
RuntimeError: dictionary changed size during iteration
```

This crashes the placement loop entirely, leaving the cluster in a degraded state until the next planning cycle.

## Fix

Wrap both loops with `list()` to snapshot before iteration:

```python
# kill broken instances — snapshot to avoid mutation during iteration
for instance_id, instance in list(self.state.instances.items()):

# time out dead nodes — snapshot to avoid mutation during iteration
for node_id, time in list(self.state.last_seen.items()):
```

## Tests

- All existing tests pass (`uv run pytest`)
- 0 type errors (`uv run basedpyright`)
- 0 lint errors (`uv run ruff check`)