### PR TITLE
fix: expire stale entries in out_for_delivery to prevent unbounded memory growth

### DIFF
--- a/src/exo/routing/event_router.py
+++ b/src/exo/routing/event_router.py
@@ -57,11 +57,19 @@ class EventRouter:
     async def _simple_retry(self):
         while True:
             await anyio.sleep(1 + random())
+            now = anyio.current_time()
+            stale: list[EventId] = []
             # list here is a shallow clone for shared mutation
             for e_id, (time, event) in list(self.out_for_delivery.items()):
-                if anyio.current_time() > time + 5:
-                    self.out_for_delivery[e_id] = (anyio.current_time(), event)
+                if now > time + 60:
+                    # Drop events older than 60 s to prevent unbounded growth
+                    # under prolonged network partition.
+                    stale.append(e_id)
+                elif now > time + 5:
+                    self.out_for_delivery[e_id] = (now, event)
                     await self.external_outbound.send(event)
+            for e_id in stale:
+                self.out_for_delivery.pop(e_id, None)
 
     def sender(self) -> Sender[Event]:
         send, recv = channel[Event]()


### PR DESCRIPTION
## Problem

`EventRouter.out_for_delivery` is a dict keyed by `EventId`. Entries are added when an event is sent and removed only on ACK. Under network partition (or peer disconnect), events are never ACK'd → the dict grows unbounded → memory leak and increasing retry overhead.

## Fix

Added a 60-second TTL: entries older than 60s are pruned each retry cycle. The current time is captured once per cycle (not per-entry) so all comparisons are consistent:

```python
async def _simple_retry(self):
    while True:
        await anyio.sleep(1 + random())
        now = anyio.current_time()
        stale: list[EventId] = []
        for e_id, (time, event) in list(self.out_for_delivery.items()):
            if now > time + 60:
                stale.append(e_id)
            elif now > time + 5:
                self.out_for_delivery[e_id] = (now, event)
                await self.external_outbound.send(event)
        for e_id in stale:
            self.out_for_delivery.pop(e_id, None)
```

## Tests

- All existing tests pass (`uv run pytest`)
- 0 type errors (`uv run basedpyright`)
- 0 lint errors (`uv run ruff check`)