### PR TITLE
fix: SSE stream hangs when DeepSeek V3.2 generates tokens containing `<`

### DIFF
--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -196,11 +196,14 @@ class SequentialGenerator(InferenceGenerator):
 
         task, mlx_gen, queue, output_generator = self._active
         response = None
+        drained: list[tuple[TaskId, GenerationResponse | ToolCallResponse | Cancelled | Finished]] = []
         try:
             queue.push(next(mlx_gen))
             response = next(output_generator)
         except (StopIteration, PrefillCancelled):
-            response = Finished()
+            while (extra := next(output_generator)) is not None:
+                drained.append((task.task_id, extra))
+            drained.append((task.task_id, Finished()))
             self._active = None
             if self._queue:
                 self._start_next()
@@ -210,6 +213,7 @@ class SequentialGenerator(InferenceGenerator):
             raise
         return itertools.chain(
             [] if response is None else [(task.task_id, response)],
+            drained,
             map(lambda task: (task, Cancelled()), self._cancelled_tasks),
         )
 
@@ -433,6 +437,8 @@ class BatchGenerator(InferenceGenerator):
                 output.append((task.task_id, parsed))
 
             if response.finish_reason is not None:
+                while (extra := next(output_generator)) is not None:
+                    output.append((task.task_id, extra))
                 output.append((task.task_id, Finished()))
                 del self._active_tasks[uid]
 

--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -218,6 +218,18 @@ def parse_deepseek_v32(
             continue
 
         # ── Detect start of tool call block ──
+
+        # Always yield tokens with finish_reason to avoid hanging the chunk stream.
+        # The DSML prefix detection below may buffer tokens, and a buffered final
+        # token would never be flushed (no subsequent token to trigger the flush).
+        if response.finish_reason is not None:
+            for buf_resp in pending_buffer:
+                yield buf_resp
+            pending_buffer = []
+            accumulated = ""
+            yield response
+            continue
+
         accumulated += response.text
 
         if TOOL_CALLS_START in accumulated:


### PR DESCRIPTION
## Summary

The DSML tool-call prefix detection in `parse_deepseek_v32` buffers any token whose text could be the start of a `<｜DSML｜function_calls>` marker — any token ending with `<` triggers this. When the final generation token (carrying `finish_reason=stop`) arrives while the buffer is non-empty, the generator's `step()` method consumes only the first flushed buffer item and marks the task as `Finished`, losing the actual finish chunk. The SSE stream then waits indefinitely for a `finish_reason` that never arrives, hanging the HTTP connection until client timeout.

**Reproduction:** send any streaming chat completion request to a DeepSeek V3.2 model where the response contains `<` characters (common in markdown, HTML, math comparisons). Trivially reproducible by asking the model to output several `<` characters — the stream hangs immediately at 100% prompt processing with zero decoded tokens delivered.

### Fix (two layers of defense)

1. **Parser** (`parse_deepseek_v32`): check `finish_reason` before DSML prefix detection — flush the pending buffer and yield the final token immediately. This mirrors the existing safeguard in `parse_thinking_models` (line 311: *"Always yields tokens with finish_reason to avoid hanging the chunk stream"*).

2. **Generators** (`BatchGenerator.step()`, `SequentialGenerator.step()`): drain all remaining parser outputs when a generation finishes. This is defense-in-depth against any current or future parser producing multiple yields per input token.

### Files changed

- `src/exo/worker/runner/llm_inference/model_output_parsers.py` — parser-level fix
- `src/exo/worker/runner/llm_inference/batch_generator.py` — generator-level drain

## Test plan

- [x] `basedpyright` — 0 errors
- [x] `ruff check` — all checks passed
- [x] `pytest` (non-MLX) — 103 passed
- [x] Manual: dashboard chat with "output several < characters" — previously hung at 100% processing, now completes normally
- [x] Manual: streaming API request with long compliance-analysis prompt (DeepSeek-V3.2-8bit) — previously hung after generation, now delivers `finish_reason=stop` and `[DONE]` correctly