### PR TITLE
Fix macOS build bundling wrong macmon binary

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -159,7 +159,7 @@ jobs:
           fi
 
       - name: Install Homebrew packages
-        run: brew install just awscli macmon
+        run: brew install just awscli
 
       - name: Install UV
         uses: astral-sh/setup-uv@v6
@@ -242,6 +242,14 @@ jobs:
       # ============================================================
       # Build the bundle
       # ============================================================
+
+      - name: Add pinned macmon to PATH
+        run: |
+          MACMON_DIR=$(nix develop --command sh -c 'dirname $(which macmon)')
+          echo "Using macmon from: $MACMON_DIR"
+          echo "$MACMON_DIR" >> $GITHUB_PATH
+          # Remove any Homebrew macmon so PyInstaller can't accidentally pick it up
+          brew uninstall macmon 2>/dev/null || true
 
       - name: Build PyInstaller bundle
         run: uv run pyinstaller packaging/pyinstaller/exo.spec


### PR DESCRIPTION
## Motivation

PR #1747 fixed macmon support for M5 Pro/Max by pinning the `swiftraccoon/macmon` fork in `flake.nix`. This works when running from source (via Nix) but the distributed macOS `.app` build was still broken on M5 Pro/Max because it was bundling the wrong macmon.

The error on M5 Pro/Max:
```
macmon preflight failed with return code -6: thread 'main' panicked at src/sources.rs:394:41
```

## Changes

- Removed `macmon` from `brew install` in `build-app.yml` — this was installing the upstream `vladkens/macmon` which doesn't support M5 Pro/Max
- Added a new step that resolves the pinned macmon fork from the Nix dev shell (same `swiftraccoon/macmon` at rev `9154d23` already defined in `flake.nix`) and adds it to `$GITHUB_PATH`
- Added a safety `brew uninstall macmon` to ensure no Homebrew macmon can shadow the pinned version

## Why It Works

PyInstaller bundles macmon via `shutil.which("macmon")`. Previously this found the Homebrew (upstream) binary. Now it finds the Nix-overlayed fork that has M5 Pro/Max support, because `$GITHUB_PATH` prepends the Nix store path before the PyInstaller step runs.

## Test Plan

### Manual Testing
<!-- Hardware: M5 Pro -->
- Trigger a macOS build and verify the bundled macmon is the pinned fork
- Run the built `.app` on M5 Pro/Max and confirm macmon preflight succeeds

### Automated Testing
- Existing CI build workflow will validate that the macmon binary is found and bundled correctly