### PR TITLE
Don't download original/ and metal/ folders from HF

### DIFF
--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -770,7 +770,10 @@ async def download_shard(
         return target_dir, not_started_progress
     filtered_file_list = list(
         filter_repo_objects(
-            file_list, allow_patterns=allow_patterns, key=lambda x: x.path
+            file_list,
+            allow_patterns=allow_patterns,
+            ignore_patterns=["original/*", "metal/*"],
+            key=lambda x: x.path,
         )
     )
 


### PR DESCRIPTION
## Motivation
Let's be able to launch models like openai/gpt-oss-120b without downloading 3x the model size.

## Changes

Ignore metal/ and original/ folders