### PR TITLE
Fix master routing tasks to instances with dead runners

### DIFF
--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -12,6 +12,8 @@ from exo.master.placement import (
 )
 from exo.shared.apply import apply
 from exo.shared.constants import EXO_EVENT_LOG_DIR, EXO_TRACING_ENABLED
+from exo.shared.models.model_cards import ModelId
+from exo.shared.types.chunks import ErrorChunk
 from exo.shared.types.commands import (
     AddCustomModelCard,
     CreateInstance,
@@ -31,6 +33,7 @@ from exo.shared.types.commands import (
 )
 from exo.shared.types.common import CommandId, NodeId, SessionId, SystemId
 from exo.shared.types.events import (
+    ChunkGenerated,
     CustomModelCardAdded,
     CustomModelCardDeleted,
     Event,
@@ -63,6 +66,7 @@ from exo.shared.types.tasks import (
     TextGeneration as TextGenerationTask,
 )
 from exo.shared.types.worker.instances import InstanceId
+from exo.shared.types.worker.runners import RunnerFailed
 from exo.utils.channels import Receiver, Sender
 from exo.utils.disk_event_log import DiskEventLog
 from exo.utils.event_buffer import MultiSourceBuffer
@@ -133,6 +137,15 @@ class Master:
                                     instance.shard_assignments.model_id
                                     == command.task_params.model
                                 ):
+                                    # Skip instances where any runner has failed —
+                                    # the worker won't dispatch tasks to them anyway
+                                    # (plan._kill_runner short-circuits), so routing
+                                    # here just causes the API to hang.
+                                    if any(
+                                        isinstance(self.state.runners.get(rid), RunnerFailed)
+                                        for rid in instance.shard_assignments.node_to_runner.values()
+                                    ):
+                                        continue
                                     task_count = sum(
                                         1
                                         for task in self.state.tasks.values()
@@ -370,6 +383,18 @@ class Master:
                         await self.event_sender.send(event)
                 except ValueError as e:
                     logger.opt(exception=e).warning("Error in command processor")
+                    # For text generation commands, send an error chunk so the API
+                    # doesn't hang waiting for chunks that will never arrive.
+                    if isinstance(command, TextGeneration):
+                        await self.event_sender.send(
+                            ChunkGenerated(
+                                command_id=command.command_id,
+                                chunk=ErrorChunk(
+                                    model=ModelId(command.task_params.model),
+                                    error_message=str(e),
+                                ),
+                            )
+                        )
 
     # These plan loops are the cracks showing in our event sourcing architecture - more things could be commands
     async def _plan(self) -> None:
@@ -383,6 +408,17 @@ class Master:
                             InstanceDeleted(instance_id=instance_id)
                         )
                         break
+                else:
+                    # Also clean up instances where any runner has failed.
+                    # After a crash the node stays connected (EXO process alive)
+                    # but the runners are dead — without this, the instance
+                    # persists as a zombie that can never serve requests.
+                    for rid in instance.shard_assignments.node_to_runner.values():
+                        if isinstance(self.state.runners.get(rid), RunnerFailed):
+                            await self.event_sender.send(
+                                InstanceDeleted(instance_id=instance_id)
+                            )
+                            break
 
             # time out dead nodes
             for node_id, time in self.state.last_seen.items():


### PR DESCRIPTION
## Problem

I hit this running tensor-parallel inference (Qwen3.5-35B, JACCL across 2 Mac Minis) under heavy load — 24 concurrent long-prompt requests. One runner crashed with SIGABRT from Metal GPU synchronization (`mlx::core::Event::wait()` → `IOSurfaceSharedEvent waitUntilSignaledValue:timeoutMS:`). The EXO process stayed alive (HTTP API on port 52415 responding, `/state` returning data) but the runners were dead:

```
Runner 84fa9aa5: RunnerFailed — "Terminated (signal=6 (Abort trap: 6))"
Runner 0131b461: RunnerShuttingDown  (killed by plan._kill_runner after sibling failed)
```

After this, every `/v1/chat/completions` request hung indefinitely. No error, no timeout — just an open connection that never gets a response.

## Root Cause

Three issues in the master compound to cause the hang:

**1. Command processor routes to dead instances**

The TextGeneration handler in `_command_processor` selects the instance with the fewest active tasks. After a crash, the dead instance has 0 tasks (all previous tasks got ErrorChunk from the supervisor), so it gets picked *first*. The worker receives the task but `plan()` short-circuits to `_kill_runner` — the TextGeneration task is never executed. The API's `_token_chunk_stream` blocks forever waiting for chunks.

**2. "No instance found" error is silently swallowed**

The `except ValueError` at the end of `_command_processor` catches "No instance found for model X" and logs a warning, but doesn't send any event back to the API. If the model genuinely isn't loaded (or all instances have dead runners), the API creates a channel and waits for chunks that never arrive.

**3. Zombie instances persist after runner crash**

`_plan()` only deletes instances when nodes disconnect from the topology. After a runner crash, the node is still connected (EXO's main process is alive, HTTP API responds, libp2p peer is up). The instance stays in `state.instances` forever with dead runners — a zombie that matches model lookups but can never serve requests.

## Fix

All changes in `src/exo/master/main.py`:

1. **Skip instances with failed runners** — Before counting an instance as available for TextGeneration routing, I check if any of its runners are in `RunnerFailed` state. I use the negative check (`RunnerFailed`) rather than a positive check (`RunnerReady`/`RunnerRunning`) because during normal startup, runners aren't in `state.runners` yet — a positive check would break task queuing while models are loading.

2. **Send ErrorChunk on "no instance found"** — In the `except ValueError` block, I send a `ChunkGenerated(ErrorChunk)` event for TextGeneration commands so the API gets a proper error response instead of hanging. This follows the same pattern used in `runner_supervisor.py` for runner crash errors.

3. **Delete instances with failed runners in `_plan()`** — Alongside the existing node-disconnect cleanup, I also delete instances where any runner is `RunnerFailed`. I use the `for/else` pattern to avoid double-deleting when both checks would trigger.

## Testing

All existing tests pass (331 passed, 1 skipped).