### PR TITLE
feat: add peer-to-peer model distribution to avoid redundant downloads

### DIFF
--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -1,3 +1,4 @@
+import os
 import base64
 import contextlib
 import json
@@ -352,6 +353,10 @@ class API:
         self.app.get("/v1/traces/{task_id}/raw")(self.get_trace_raw)
         self.app.get("/onboarding")(self.get_onboarding)
         self.app.post("/onboarding")(self.complete_onboarding)
+
+        # P2P model distribution endpoints
+        self.app.get("/p2p/models/{model_id:path}/files")(self.list_model_files)
+        self.app.get("/p2p/models/{model_id:path}/{file_path:path}")(self.serve_model_file)
 
     async def place_instance(self, payload: PlaceInstanceParams):
         command = PlaceInstance(
@@ -1655,6 +1660,50 @@ class API:
                 limit=limit,
             )
         )
+
+    async def list_model_files(self, model_id: str) -> JSONResponse:
+        """List available files for a model (P2P endpoint)."""
+        normalized = model_id.replace("/", "--")
+        from exo.shared.constants import EXO_MODELS_DIR, EXO_MODELS_PATH
+
+        # Search in EXO_MODELS_DIR first, then EXO_MODELS_PATH
+        search_dirs: list[Path] = [EXO_MODELS_DIR / normalized]
+        if EXO_MODELS_PATH is not None:
+            search_dirs.extend(p / normalized for p in EXO_MODELS_PATH)
+
+        for model_dir in search_dirs:
+            if model_dir.is_dir():
+                files: list[str] = []
+                for dirpath, _, filenames in os.walk(model_dir):
+                    for fname in filenames:
+                        if fname.endswith(".partial"):
+                            continue
+                        full = Path(dirpath) / fname
+                        rel = str(full.relative_to(model_dir))
+                        files.append(rel)
+                return JSONResponse({"model_id": model_id, "files": sorted(files)})
+
+        raise HTTPException(status_code=404, detail=f"Model {model_id} not found")
+
+    async def serve_model_file(self, model_id: str, file_path: str) -> FileResponse:
+        """Serve a model file to a peer node (P2P endpoint)."""
+        # Path traversal protection
+        if ".." in file_path:
+            raise HTTPException(status_code=400, detail="Invalid file path")
+
+        normalized = model_id.replace("/", "--")
+        from exo.shared.constants import EXO_MODELS_DIR, EXO_MODELS_PATH
+
+        search_dirs: list[Path] = [EXO_MODELS_DIR / normalized]
+        if EXO_MODELS_PATH is not None:
+            search_dirs.extend(p / normalized for p in EXO_MODELS_PATH)
+
+        for model_dir in search_dirs:
+            candidate = model_dir / file_path
+            if candidate.is_file():
+                return FileResponse(str(candidate))
+
+        raise HTTPException(status_code=404, detail=f"File not found: {model_id}/{file_path}")
 
     async def run(self):
         shutdown_ev = anyio.Event()

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -115,8 +115,8 @@ class DownloadCoordinator:
                     continue
 
                 match cmd.command:
-                    case StartDownload(shard_metadata=shard):
-                        await self._start_download(shard)
+                    case StartDownload(shard_metadata=shard, peer_base_url=peer_base_url):
+                        await self._start_download(shard, peer_base_url=peer_base_url)
                     case DeleteDownload(model_id=model_id):
                         await self._delete_download(model_id)
                     case CancelDownload(model_id=model_id):
@@ -137,7 +137,7 @@ class DownloadCoordinator:
                 NodeDownloadProgress(download_progress=pending)
             )
 
-    async def _start_download(self, shard: ShardMetadata) -> None:
+    async def _start_download(self, shard: ShardMetadata, peer_base_url: str | None = None) -> None:
         model_id = shard.model_card.model_id
 
         # Check if already downloading, complete, or recently failed
@@ -210,10 +210,10 @@ class DownloadCoordinator:
             return
 
         # Start actual download
-        self._start_download_task(shard, initial_progress)
+        self._start_download_task(shard, initial_progress, peer_base_url=peer_base_url)
 
     def _start_download_task(
-        self, shard: ShardMetadata, initial_progress: RepoDownloadProgress
+        self, shard: ShardMetadata, initial_progress: RepoDownloadProgress, peer_base_url: str | None = None
     ) -> None:
         model_id = shard.model_card.model_id
 
@@ -232,7 +232,7 @@ class DownloadCoordinator:
         async def download_wrapper(cancel_scope: anyio.CancelScope) -> None:
             try:
                 with cancel_scope:
-                    await self.shard_downloader.ensure_shard(shard)
+                    await self.shard_downloader.ensure_shard(shard, peer_base_url=peer_base_url)
             except Exception as e:
                 logger.error(f"Download failed for {model_id}: {e}")
                 failed = DownloadFailed(

--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -486,7 +486,16 @@ async def download_file_with_retry(
     on_progress: Callable[[int, int, bool], None] = lambda _, __, ___: None,
     on_connection_lost: Callable[[], None] = lambda: None,
     skip_internet: bool = False,
+    peer_base_url: str | None = None,
 ) -> Path:
+    # Try P2P download first if a peer has the model
+    if peer_base_url:
+        success = await _download_file_from_peer(
+            peer_base_url, model_id, path, target_dir, on_progress
+        )
+        if success:
+            return target_dir / path
+
     n_attempts = 3
     for attempt in range(n_attempts):
         try:
@@ -718,6 +727,70 @@ async def get_downloaded_size(path: Path) -> int:
     return 0
 
 
+async def _download_file_from_peer(
+    peer_base_url: str,
+    model_id: ModelId,
+    file_path: str,
+    target_dir: Path,
+    on_progress: Callable[[int, int, bool], None] = lambda _, __, ___: None,
+) -> bool:
+    """Download a single file from a peer node. Returns True on success."""
+    normalized = str(model_id).replace("/", "--")
+    url = f"{peer_base_url}/p2p/models/{normalized}/{file_path}"
+    local_path = target_dir / file_path
+    partial_path = target_dir / f"{file_path}.partial"
+
+    # If file already exists, skip
+    if await aios.path.exists(local_path):
+        return True
+
+    await aios.makedirs(local_path.parent, exist_ok=True)
+
+    # Support resume via Range header
+    existing_size = 0
+    if await aios.path.exists(partial_path):
+        existing_size = (await aios.stat(partial_path)).st_size
+
+    headers: dict[str, str] = {}
+    if existing_size > 0:
+        headers["Range"] = f"bytes={existing_size}-"
+
+    try:
+        async with (
+            aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=3600, connect=10, sock_read=60)
+            ) as session,
+            session.get(url, headers=headers) as resp,
+        ):
+            if resp.status == 404:
+                logger.debug(f"P2P: peer does not have {file_path}")
+                return False
+            if resp.status not in (200, 206):
+                logger.warning(f"P2P: unexpected status {resp.status} for {file_path}")
+                return False
+
+            total_size = existing_size + (resp.content_length or 0)
+            n_read = existing_size
+
+            async with aiofiles.open(
+                partial_path, "ab" if existing_size > 0 else "wb"
+            ) as f:
+                while chunk := await resp.content.read(8 * 1024 * 1024):
+                    n_read += await f.write(chunk)
+                    if total_size > 0:
+                        on_progress(n_read, total_size, False)
+
+        # Rename partial to final
+        await aios.rename(partial_path, local_path)
+        if total_size > 0:
+            on_progress(total_size, total_size, True)
+        logger.info(f"P2P: successfully downloaded {file_path} from peer")
+        return True
+    except Exception as e:
+        logger.warning(f"P2P download failed for {file_path}: {e}")
+        return False
+
+
 async def download_shard(
     shard: ShardMetadata,
     on_progress: Callable[[ShardMetadata, RepoDownloadProgress], Awaitable[None]],
@@ -726,6 +799,7 @@ async def download_shard(
     skip_internet: bool = False,
     allow_patterns: list[str] | None = None,
     on_connection_lost: Callable[[], None] = lambda: None,
+    peer_base_url: str | None = None,
 ) -> tuple[Path, RepoDownloadProgress]:
     if not skip_download:
         logger.debug(f"Downloading {shard.model_card.model_id=}")
@@ -881,6 +955,7 @@ async def download_shard(
                 ),
                 on_connection_lost=on_connection_lost,
                 skip_internet=skip_internet,
+                peer_base_url=peer_base_url,
             )
 
     if not skip_download:

--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -59,11 +59,11 @@ class SingletonShardDownloader(ShardDownloader):
         self.shard_downloader.on_progress(callback)
 
     async def ensure_shard(
-        self, shard: ShardMetadata, config_only: bool = False
+        self, shard: ShardMetadata, config_only: bool = False, peer_base_url: str | None = None
     ) -> Path:
         if shard not in self.active_downloads:
             self.active_downloads[shard] = asyncio.create_task(
-                self.shard_downloader.ensure_shard(shard, config_only)
+                self.shard_downloader.ensure_shard(shard, config_only, peer_base_url=peer_base_url)
             )
         try:
             return await self.active_downloads[shard]
@@ -104,7 +104,7 @@ class ResumableShardDownloader(ShardDownloader):
         self.on_progress_callbacks.append(callback)
 
     async def ensure_shard(
-        self, shard: ShardMetadata, config_only: bool = False
+        self, shard: ShardMetadata, config_only: bool = False, peer_base_url: str | None = None
     ) -> Path:
         allow_patterns = ["config.json"] if config_only else None
 
@@ -114,6 +114,7 @@ class ResumableShardDownloader(ShardDownloader):
             max_parallel_downloads=self.max_parallel_downloads,
             allow_patterns=allow_patterns,
             skip_internet=self.offline,
+            peer_base_url=peer_base_url,
         )
         return target_dir
 

--- a/src/exo/download/shard_downloader.py
+++ b/src/exo/download/shard_downloader.py
@@ -18,7 +18,7 @@ from exo.shared.types.worker.shards import (
 class ShardDownloader(ABC):
     @abstractmethod
     async def ensure_shard(
-        self, shard: ShardMetadata, config_only: bool = False
+        self, shard: ShardMetadata, config_only: bool = False, peer_base_url: str | None = None
     ) -> Path:
         """
         Ensures that the shard is downloaded.
@@ -56,7 +56,7 @@ class ShardDownloader(ABC):
 
 class NoopShardDownloader(ShardDownloader):
     async def ensure_shard(
-        self, shard: ShardMetadata, config_only: bool = False
+        self, shard: ShardMetadata, config_only: bool = False, peer_base_url: str | None = None
     ) -> Path:
         return Path("/tmp/noop_shard")
 

--- a/src/exo/shared/types/commands.py
+++ b/src/exo/shared/types/commands.py
@@ -69,6 +69,7 @@ class RequestEventLog(BaseCommand):
 class StartDownload(BaseCommand):
     target_node_id: NodeId
     shard_metadata: ShardMetadata
+    peer_base_url: str | None = None
 
 
 class DeleteDownload(BaseCommand):

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -139,6 +139,24 @@ class Worker:
                 if isinstance(event, CustomModelCardDeleted):
                     await delete_custom_card(event.model_id)
 
+    def _find_peer_with_model(self, model_id) -> str | None:
+        """Find a peer node that has already completed downloading this model."""
+        for node_id, downloads in self.state.downloads.items():
+            if node_id == self.node_id:
+                continue
+            for mid, status in downloads.items():
+                if mid == model_id and isinstance(status, DownloadCompleted):
+                    # Find a reachable IP for this peer from topology
+                    for conn in self.state.topology.out_edges(self.node_id):
+                        if conn.sink == node_id and isinstance(conn.edge, SocketConnection):
+                            ip = conn.edge.sink_multiaddr.ip_address
+                            port = conn.edge.sink_multiaddr.port
+                            logger.info(
+                                f"P2P: found peer {node_id[:20]}... at {ip}:{port} with model {model_id}"
+                            )
+                            return f"http://{ip}:{port}"
+        return None
+
     async def plan_step(self):
         while True:
             await anyio.sleep(0.1)
@@ -202,12 +220,14 @@ class Worker:
                             )
                         )
                     else:
+                        peer_base_url = self._find_peer_with_model(shard.model_card.model_id)
                         await self.download_command_sender.send(
                             ForwarderDownloadCommand(
                                 origin=self._system_id,
                                 command=StartDownload(
                                     target_node_id=self.node_id,
                                     shard_metadata=shard,
+                                    peer_base_url=peer_base_url,
                                 ),
                             )
                         )


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                 
            
  When multiple nodes join an Exo cluster, each independently downloads model files from HuggingFace. With N nodes, the same multi-GB model downloads N times over the internet. This wastes bandwidth and is painfully slow — especially for 100+ GB models like MiniMax M2.5.
                                                                                                                                                                                                                                                                               
  This PR adds **peer-to-peer model distribution**: when a node needs a model that another peer already has, it fetches files directly from the peer over the local network instead of from HuggingFace.
                                                                                                                                                                                                                                                                               
  - Worker checks `state.downloads` for peers with `DownloadCompleted` status                                                                                                                                                                                                
  - Resolves peer IP from topology edges                                                                                                                                                                                                                                       
  - New `/p2p/models/{model_id}/{file_path}` endpoint serves model files to peers                                                                                                                                                                                            
  - New `/p2p/models/{model_id}/files` endpoint lists available files                                                                                                                                                                                                          
  - `_download_file_from_peer()` uses aiohttp with resume support (Range headers, `.partial` files)                                                                                                                                                                            
  - Falls back to HuggingFace if peer download fails for any file                                  
  - Zero overhead when no peers have the model (`peer_base_url` is `None`)                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                               
## Motivation                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                             
  Example: 2-node cluster connected via 10GbE. A 120GB model transfers locally at ~500MB/s vs ~50MB/s from HuggingFace. With N nodes, this saves (N-1)x internet bandwidth.                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                               
  ## Changes
                                                                                                                                                                                                                                                                               
  - `src/exo/api/main.py` — P2P file serving endpoints                                                                                                                                                                                                                       
  - `src/exo/worker/main.py` — `_find_peer_with_model()` peer discovery                                                                                                                                                                                                        
  - `src/exo/download/download_utils.py` — `_download_file_from_peer()` + threading through download pipeline
  - `src/exo/download/coordinator.py` — Thread `peer_base_url` from command to downloader                                                                                                                                                                                      
  - `src/exo/download/impl_shard_downloader.py` — Pass through `peer_base_url`                                                                                                                                                                                                 
  - `src/exo/download/shard_downloader.py` — Add parameter to abstract interface                                                                                                                                                                                               
  - `src/exo/shared/types/commands.py` — Add `peer_base_url` field to `StartDownload`                                                                                                                                                                                          
                                                                                                                                                                                                                                                                               
  ## Test plan                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                               
  - [ ] Single node: no peers → downloads from HuggingFace as before (no regression)                                                                                                                                                                                           
  - [ ] Two nodes: node A has model, node B needs it → B fetches from A's `/p2p/` endpoint                                                                                                                                                                                     
  - [ ] Peer goes offline mid-download → falls back to HuggingFace seamlessly             
  - [ ] Resume: partial P2P download can be resumed from either peer or HuggingFace                                                                                                                                                                                            
                                                                                                                                                                                                                                                                               