### PR TITLE
KV cache: multi-conversation slot separation + disk persistence

### DIFF
--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -16,6 +16,13 @@ from mlx_lm.tokenizer_utils import TokenizerWrapper
 from exo.shared.types.memory import Memory
 from exo.shared.types.mlx import KVCacheType, Model
 from exo.worker.engines.mlx.constants import CACHE_GROUP_SIZE, KV_CACHE_BITS
+import hashlib
+import time
+from pathlib import Path
+
+import numpy as np
+from mlx_lm.models.cache import save_prompt_cache, load_prompt_cache
+
 from exo.worker.runner.bootstrap import logger
 
 if TYPE_CHECKING:
@@ -80,7 +87,7 @@ def has_non_kv_caches(cache: KVCacheType) -> bool:
 
 
 class KVPrefixCache:
-    def __init__(self, group: mx.distributed.Group | None):
+    def __init__(self, group: mx.distributed.Group | None, model_id: str | None = None):
         self.prompts: list[mx.array] = []  # mx array of tokens (ints)
         self.caches: list[KVCacheType] = []
         self._snapshots: list[list[CacheSnapshot] | None] = []
@@ -88,6 +95,15 @@ class KVPrefixCache:
         self._last_used: list[int] = []  # monotonic counter of last access per entry
         self._access_counter: int = 0
         self._group = group
+        self._model_id = model_id
+        self._disk_dirty = False
+        self._flush_requested_at = 0.0
+        self._cache_dir: Path | None = None
+        if model_id is not None:
+            model_hash = hashlib.sha256(model_id.encode()).hexdigest()[:16]
+            self._cache_dir = Path(os.path.expanduser(f"~/.exo/kv-cache/{model_hash}"))
+            self._cache_dir.mkdir(parents=True, exist_ok=True)
+            logger.info(f"KV disk cache dir: {self._cache_dir}")
 
     def clear(self):
         """Clear all cached prompts and caches."""
@@ -113,6 +129,9 @@ class KVPrefixCache:
         self._access_counter += 1
         self._last_used.append(self._access_counter)
         logger.info(f"KV cache added: {len(prompt_tokens)} tokens")
+        self._disk_dirty = True
+        if self._flush_requested_at == 0.0:
+            self._flush_requested_at = time.time()
 
     def update_kv_cache(
         self,
@@ -138,6 +157,9 @@ class KVPrefixCache:
         self._access_counter += 1
         self._last_used[index] = self._access_counter
         logger.info(f"KV cache updated (index {index}): {len(prompt_tokens)} tokens")
+        self._disk_dirty = True
+        if self._flush_requested_at == 0.0:
+            self._flush_requested_at = time.time()
 
     def _get_snapshot(
         self, entry_index: int, target_token_count: int
@@ -281,6 +303,73 @@ class KVPrefixCache:
             logger.info(
                 f"KV cache evicted LRU entry ({evicted_tokens} tokens) due to memory usage"
             )
+
+
+    def flush_to_disk(self, force: bool = False) -> None:
+        """Save dirty slots to disk after 15s idle or on forced shutdown.
+
+        Uses mlx-lm's save_prompt_cache which calls mx.save_safetensors
+        directly — no numpy, no bf16 cast, writes from unified memory.
+        """
+        if self._cache_dir is None or not self._disk_dirty or len(self.caches) == 0:
+            return
+        if not force and (time.time() - self._flush_requested_at) < 15:
+            return
+
+        self._disk_dirty = False
+        self._flush_requested_at = 0.0
+
+        for i in range(len(self.caches)):
+            try:
+                t0 = time.time()
+                cache_path = str(self._cache_dir / f"slot_{i}.safetensors")
+                tokens_path = str(self._cache_dir / f"slot_{i}_tokens.npy")
+
+                # save_prompt_cache writes directly from MLX buffers (~1-2s)
+                save_prompt_cache(
+                    cache_path,
+                    self.caches[i],
+                    metadata={"model_id": self._model_id or "", "token_count": str(len(self.prompts[i]))},
+                )
+
+                # Save token array separately (small, fast)
+                np.save(tokens_path, np.array(self.prompts[i].tolist(), dtype=np.int32))
+
+                elapsed = (time.time() - t0) * 1000
+                size_mb = Path(cache_path).stat().st_size / 1024 / 1024
+                logger.info(f"Disk cache saved: slot_{i} ({size_mb:.0f} MB, {len(self.prompts[i])} tokens) in {elapsed:.0f}ms")
+            except Exception:
+                logger.warning(f"Failed to save slot {i} to disk", exc_info=True)
+
+    def load_from_disk(self, model) -> int:
+        """Load persisted slots from disk on startup."""
+        if self._cache_dir is None:
+            return 0
+
+        loaded = 0
+        for i in range(8):  # max 8 slots
+            cache_path = self._cache_dir / f"slot_{i}.safetensors"
+            tokens_path = self._cache_dir / f"slot_{i}_tokens.npy"
+
+            if not cache_path.exists() or not tokens_path.exists():
+                continue
+
+            try:
+                cache = load_prompt_cache(str(cache_path))
+                tokens_np = np.load(str(tokens_path))
+                tokens = mx.array(tokens_np.tolist())
+
+                self.prompts.append(tokens)
+                self.caches.append(cache)
+                self._snapshots.append(None)
+                self._access_counter += 1
+                self._last_used.append(self._access_counter)
+                loaded += 1
+                logger.info(f"Restored disk cache slot {i}: {len(tokens)} tokens")
+            except Exception:
+                logger.warning(f"Failed to load disk slot {i}", exc_info=True)
+
+        return loaded
 
     def get_memory_used_percentage(self) -> float:
         local_pressure: float = get_memory_used_percentage()

--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -445,18 +445,27 @@ class ExoBatchGenerator:
                 if len(all_prompt_tokens) > 0
                 else 0.0
             )
-            if matched_index is not None and (
-                prefix_hit_length >= min_prefix_hit_length
-                and hit_ratio >= _MIN_PREFIX_HIT_RATIO_TO_UPDATE
-            ):
-                self.kv_prefix_cache.update_kv_cache(
-                    matched_index,
-                    all_prompt_tokens,
-                    cache,
-                    cache_snapshots,
-                    restore_pos=prefix_hit_length,
-                    media_regions=media_regions,
-                )
+            if matched_index is not None:
+                cached_len = len(self.kv_prefix_cache.prompts[matched_index])
+                cached_coverage = prefix_hit_length / cached_len if cached_len > 0 else 0.0
+                is_extension = cached_coverage >= 0.95
+
+                if is_extension and (
+                    prefix_hit_length >= min_prefix_hit_length
+                    and hit_ratio >= _MIN_PREFIX_HIT_RATIO_TO_UPDATE
+                ):
+                    self.kv_prefix_cache.update_kv_cache(
+                        matched_index,
+                        all_prompt_tokens,
+                        cache,
+                        cache_snapshots,
+                        restore_pos=prefix_hit_length,
+                        media_regions=media_regions,
+                    )
+                else:
+                    self.kv_prefix_cache.add_kv_cache(
+                        all_prompt_tokens, cache, cache_snapshots
+                    )
             else:
                 self.kv_prefix_cache.add_kv_cache(
                     all_prompt_tokens,

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -715,18 +715,27 @@ def mlx_generate(
                     if len(all_prompt_tokens) > 0
                     else 0.0
                 )
-                if matched_index is not None and (
-                    prefix_hit_length >= min_prefix_hit_length
-                    and hit_ratio >= _MIN_PREFIX_HIT_RATIO_TO_UPDATE
-                ):
-                    kv_prefix_cache.update_kv_cache(
-                        matched_index,
-                        full_prompt_tokens,
-                        caches,
-                        cache_snapshots,
-                        restore_pos=prefix_hit_length,
-                        media_regions=media_regions,
-                    )
+                if matched_index is not None:
+                    cached_len = len(kv_prefix_cache.prompts[matched_index])
+                    cached_coverage = prefix_hit_length / cached_len if cached_len > 0 else 0.0
+                    is_extension = cached_coverage >= 0.95
+
+                    if is_extension and (
+                        prefix_hit_length >= min_prefix_hit_length
+                        and hit_ratio >= _MIN_PREFIX_HIT_RATIO_TO_UPDATE
+                    ):
+                        kv_prefix_cache.update_kv_cache(
+                            matched_index,
+                            full_prompt_tokens,
+                            caches,
+                            cache_snapshots,
+                            restore_pos=prefix_hit_length,
+                            media_regions=media_regions,
+                        )
+                    else:
+                        kv_prefix_cache.add_kv_cache(
+                            full_prompt_tokens, caches, cache_snapshots
+                        )
                 else:
                     kv_prefix_cache.add_kv_cache(
                         full_prompt_tokens,

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -224,6 +224,12 @@ class Runner:
 
                 self.generator.warmup()
 
+                # Load persisted KV cache from disk
+                if hasattr(self.generator, 'kv_prefix_cache') and self.generator.kv_prefix_cache is not None:
+                    loaded = self.generator.kv_prefix_cache.load_from_disk(self.generator.model)
+                    if loaded > 0:
+                        logger.info(f"Loaded {loaded} KV cache slot(s) from disk")
+
                 logger.info(
                     f"runner initialized in {time.time() - self.setup_start_time} seconds"
                 )
@@ -250,6 +256,9 @@ class Runner:
         logger.info("runner shutting down")
         self.update_status(RunnerShuttingDown())
         self.acknowledge_task(task)
+        if isinstance(self.generator, InferenceGenerator) and hasattr(self.generator, 'kv_prefix_cache'):
+            if self.generator.kv_prefix_cache is not None:
+                self.generator.kv_prefix_cache.flush_to_disk(force=True)
         if isinstance(self.generator, InferenceGenerator):
             self.generator.close()
         mx.clear_cache()
@@ -317,6 +326,11 @@ class Runner:
 
             except WouldBlock:
                 pass
+
+        # Flush KV cache to disk if idle long enough
+        if isinstance(self.generator, InferenceGenerator) and hasattr(self.generator, 'kv_prefix_cache'):
+            if self.generator.kv_prefix_cache is not None:
+                self.generator.kv_prefix_cache.flush_to_disk()
 
         self.update_status(RunnerReady())
         logger.info("runner ready")
@@ -412,7 +426,7 @@ class Builder:
                 self.tokenizer.tool_parser,  # type: ignore
             )
 
-        kv_prefix_cache = KVPrefixCache(self.group)
+        kv_prefix_cache = KVPrefixCache(self.group, model_id=self.model_id)
 
         device_rank = 0 if self.group is None else self.group.rank()
         if os.environ.get("EXO_NO_BATCH"):


### PR DESCRIPTION
## KV cache: multi-conversation slot separation + disk persistence

### Summary

Two improvements to `KVPrefixCache` that together eliminate unnecessary full prefills in multi-conversation and restart scenarios:

1. **Slot separation** — prevents different conversations from overwriting each other's cache slots by detecting whether a new prompt is a genuine extension of the cached one
2. **Disk persistence** — saves/restores cache slots to disk via mlx-lm's `save_prompt_cache` / `load_prompt_cache`, surviving runner restarts

### The Problem

**Slot overwriting:** When multiple conversations share the same system prompt (common with tool-calling models served to multiple channels/users), the prefix matcher sees high overlap and overwrites the existing slot. Every conversation switch forces a full prefill — 50k+ tokens reprocessed from scratch.

```
Conversation A: 50k tokens → saved at slot 0
Conversation B: 35k tokens → matches slot 0 at 92% → OVERWRITES slot 0
Conversation A returns: slot 0 is now B's cache → full prefill of 50k tokens
```

**Cache loss on restart:** All KV cache state lives in RAM inside the runner subprocess. Any runner restart (watchdog, model reload, crash) destroys all cached state.

### The Fix

#### Slot separation: `cached_coverage` guard

The key insight: a legitimate cache update occurs only when the new prompt is a **strict extension** of the cached prompt. Cross-conversation collisions look different — the match covers only a fraction of the cached prompt.

Added `cached_coverage` (ratio of matched tokens to *cached* prompt length) alongside the existing `hit_ratio` (ratio of matched tokens to *incoming* prompt length):

```python
cached_len = len(kv_prefix_cache.prompts[matched_index])
cached_coverage = prefix_hit_length / cached_len if cached_len > 0 else 0.0
is_extension = cached_coverage >= 0.95

if is_extension and (hit conditions):
    update_kv_cache(...)  # Same conversation, extended
else:
    add_kv_cache(...)     # Different conversation → new slot
```

| Scenario | `cached_coverage` | Decision |
|---|---|---|
| Same conversation + new messages (50k→52k) | 100% | Update slot |
| Different conversation, shared prefix (50k cached, 32k match) | 64% | New slot |
| Subagent with different prompt (50k cached, 2k match) | 4% | New slot |

#### Disk persistence: `save_prompt_cache` / `load_prompt_cache`

Uses mlx-lm's built-in cache serialization which calls `mx.save_safetensors` internally — writes directly from unified memory, handles bfloat16 natively, no numpy conversion needed. ~1-2 seconds for a 35k-token cache on NVMe SSD.

Save timing uses a 15-second idle timer to avoid blocking active inference:
- `add_kv_cache` / `update_kv_cache` set a `_disk_dirty` flag
- `flush_to_disk()` is called when the runner goes idle, but only executes if 15+ seconds have elapsed since the flag was set
- `flush_to_disk(force=True)` on runner shutdown ensures the latest state is always persisted

On startup, `load_from_disk()` restores persisted slots before the first request.

Storage location: `~/.exo/kv-cache/<model_hash>/slot_N.safetensors` + `slot_N_tokens.npy`

### Results

**Before:**
```
KV cache hit: 2044/51905 tokens cached (3.9%)
Prefilling 49860 tokens...  (~140 seconds at 350 tok/s)
```

**After (conversation switching):**
```
Channel A:  KV cache updated (index 0): 36458 tokens
Channel B:  KV cache updated (index 1): 32836 tokens   ← separate slot
Channel A:  KV cache hit: 36458/36773 (99.1%)           ← slot 0 intact
```

**After (runner restart):**
```
Restored disk cache slot 0: 35916 tokens
KV cache hit: 35916/36216 tokens cached (99.2%)
Prefilling 299 tokens...  (~6 seconds)
```

### Files Changed

| File | Changes |
|---|---|
| `cache.py` | `model_id` param on `KVPrefixCache.__init__`, `_disk_dirty` flag, `flush_to_disk()`, `load_from_disk()`, imports for `save_prompt_cache`/`load_prompt_cache` |
| `batch_generate.py` | `cached_coverage >= 0.95` guard in `_save_prefix_cache()` |
| `generate.py` | `cached_coverage >= 0.95` guard in `mlx_generate()` save logic |
| `runner.py` | Pass `model_id` to `KVPrefixCache`, call `load_from_disk()` after warmup, `flush_to_disk()` on idle, `flush_to_disk(force=True)` on shutdown |

### Testing

Tested on 2× Mac Studio M3 Ultra (512GB each) connected via Thunderbolt 5 RDMA, running Kimi-K2.5 with 30-50k token multi-turn conversations across multiple Discord channels.

- Verified separate slots are created for different conversations
- Verified same-conversation continuations correctly update existing slots
- Verified disk save completes in ~1-2 seconds without blocking inference
- Verified cache restores correctly after model reload (99%+ hit rate on first message)
- Verified bfloat16 tensors survive the save/load round-trip without dtype mismatch

---

Co-developed with Claude.