### PR TITLE
KV cache: per-conversation slot separation + disk persistence/offload

### DIFF
--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -91,7 +91,8 @@ class KVPrefixCache:
         self._group = group
         # Disk persistence state
         self._model_id = model_id
-        self._disk_dir = self._init_disk_dir() if model_id else None
+        self._disk_enabled = os.environ.get("EXO_KV_DISK_PERSISTENCE", "1") != "0"
+        self._disk_dir = self._init_disk_dir() if model_id and self._disk_enabled else None
         self._disk_dirty = False
         self._flush_requested_at: float = 0.0
         self._hot_slot_disk_id: int | None = None
@@ -272,7 +273,8 @@ class KVPrefixCache:
 
     def _init_disk_dir(self):
         h = hashlib.sha256(self._model_id.encode()).hexdigest()[:16]
-        d = _Path.home() / ".exo" / "kv-cache" / h
+        base = _Path(os.environ.get("EXO_KV_DISK_PATH", str(_Path.home() / ".exo" / "kv-cache")))
+        d = base / h
         d.mkdir(parents=True, exist_ok=True)
         logger.info(f"KV cache disk dir: {d}")
         return d
@@ -322,10 +324,12 @@ class KVPrefixCache:
         except Exception as e:
             logger.warning(f"KV cache disk flush failed: {e}")
 
-    def _evict_stale_disk_slots(self, max_age_hours=24, max_size_gb=500):
-        """Delete disk slots older than max_age_hours, then evict oldest if over max_size_gb."""
+    def _evict_stale_disk_slots(self):
+        """Delete stale disk slots (TTL) then evict oldest if over size limit."""
         if not self._disk_dir:
             return
+        max_age_hours = float(os.environ.get("EXO_KV_DISK_TTL_HOURS", "24"))
+        max_size_gb = float(os.environ.get("EXO_KV_DISK_MAX_SIZE_GB", "500"))
         # Phase 1: TTL eviction
         cutoff = _time.time() - (max_age_hours * 3600)
         for meta_file in self._disk_dir.glob("slot_*_meta.json"):

--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -301,13 +301,20 @@ class KVPrefixCache:
         if len(self.caches) == 0:
             return
         try:
-            from mlx_lm.models.cache import save_prompt_cache
+            from mlx.nn.utils import tree_flatten
             self._disk_dir.mkdir(parents=True, exist_ok=True)
             slot_id = self._hot_slot_disk_id if self._hot_slot_disk_id is not None else self._next_disk_slot_id()
             base = self._disk_dir / f"slot_{slot_id}"
             # Save cache (atomic: write tmp then rename)
+            # Inline save_prompt_cache with empty-array filter for GLM/other models
+            cache = list(self.caches[0])
+            cache_data = dict(tree_flatten([c.state for c in cache]))
+            cache_data = {k: v for k, v in cache_data.items() if v.size > 0}
+            cache_info = [c.meta_state for c in cache]
+            cache_classes = [type(c).__name__ for c in cache]
+            cache_metadata = dict(tree_flatten([cache_info, {}, cache_classes]))
             tmp_cache = str(base) + "_tmp_cache.safetensors"
-            save_prompt_cache(tmp_cache, list(self.caches[0]))
+            mx.save_safetensors(tmp_cache, cache_data, cache_metadata)
             os.rename(tmp_cache, str(base) + "_cache.safetensors")
             # Save tokens
             tmp_tokens = str(base) + "_tmp_tokens.safetensors"

--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -322,10 +322,11 @@ class KVPrefixCache:
         except Exception as e:
             logger.warning(f"KV cache disk flush failed: {e}")
 
-    def _evict_stale_disk_slots(self, max_age_hours=24):
-        """Delete disk slots older than max_age_hours."""
+    def _evict_stale_disk_slots(self, max_age_hours=24, max_size_gb=500):
+        """Delete disk slots older than max_age_hours, then evict oldest if over max_size_gb."""
         if not self._disk_dir:
             return
+        # Phase 1: TTL eviction
         cutoff = _time.time() - (max_age_hours * 3600)
         for meta_file in self._disk_dir.glob("slot_*_meta.json"):
             try:
@@ -344,6 +345,38 @@ class KVPrefixCache:
                     logger.info(f"KV cache evicted stale disk slot_{slot_id}")
             except Exception:
                 continue
+        # Phase 2: Size-based eviction (oldest first)
+        max_bytes = max_size_gb * 1024 * 1024 * 1024
+        while True:
+            slots = []
+            total_size = 0
+            for meta_file in self._disk_dir.glob("slot_*_meta.json"):
+                try:
+                    with open(meta_file) as f:
+                        meta = json.load(f)
+                    slot_id = int(meta_file.stem.split("_")[1])
+                    if slot_id == self._hot_slot_disk_id:
+                        continue
+                    base = self._disk_dir / f"slot_{slot_id}"
+                    slot_size = sum(
+                        f.stat().st_size for ext in ["_cache.safetensors", "_tokens.safetensors", "_meta.json"]
+                        if (f := _Path(str(base) + ext)).exists()
+                    )
+                    total_size += slot_size
+                    slots.append((meta.get("timestamp", 0), slot_id, slot_size))
+                except Exception:
+                    continue
+            if total_size <= max_bytes or not slots:
+                break
+            slots.sort()
+            oldest_ts, oldest_id, oldest_size = slots[0]
+            base = self._disk_dir / f"slot_{oldest_id}"
+            for ext in ["_cache.safetensors", "_tokens.safetensors", "_meta.json"]:
+                try:
+                    os.remove(str(base) + ext)
+                except FileNotFoundError:
+                    pass
+            logger.info(f"KV cache evicted disk slot_{oldest_id} ({oldest_size / 1024 / 1024 / 1024:.1f} GB) — directory over {max_size_gb} GB limit")
 
     def flush_to_disk(self, force=False):
         """Flush hot slot to disk if dirty and idle for 15s (or force)."""

--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -17,6 +17,12 @@ from exo.shared.types.mlx import KVCacheType, Model
 from exo.worker.engines.mlx.constants import CACHE_GROUP_SIZE, KV_CACHE_BITS
 from exo.worker.runner.bootstrap import logger
 
+# Checkpoint 2A: disk persistence
+import hashlib
+import json
+import time as _time
+from pathlib import Path as _Path
+
 
 # Fraction of device memory above which LRU eviction kicks in.
 # Smaller machines need more aggressive eviction.
@@ -76,13 +82,19 @@ def has_non_kv_caches(cache: KVCacheType) -> bool:
 
 
 class KVPrefixCache:
-    def __init__(self, group: mx.distributed.Group | None):
+    def __init__(self, group: mx.distributed.Group | None, model_id: str = ""):
         self.prompts: list[mx.array] = []  # mx array of tokens (ints)
         self.caches: list[KVCacheType] = []
         self._snapshots: list[list[CacheSnapshot] | None] = []
         self._last_used: list[int] = []  # monotonic counter of last access per entry
         self._access_counter: int = 0
         self._group = group
+        # Disk persistence state
+        self._model_id = model_id
+        self._disk_dir = self._init_disk_dir() if model_id else None
+        self._disk_dirty = False
+        self._flush_requested_at: float = 0.0
+        self._hot_slot_disk_id: int | None = None
 
     def clear(self):
         """Clear all cached prompts and caches."""
@@ -97,13 +109,25 @@ class KVPrefixCache:
         cache: KVCacheType,
         ssm_snapshots: list[CacheSnapshot] | None = None,
     ):
-        """Add a new cache entry. Evicts LRU entries if memory is high."""
-        self._evict_if_needed()
+        """Add a new cache entry. Single hot slot: flush current to disk first."""
+        if self._disk_dir and len(self.caches) > 0:
+            if self._disk_dirty:
+                self._flush_hot_slot()
+            self.prompts.clear()
+            self.caches.clear()
+            self._snapshots.clear()
+            self._last_used.clear()
+            self._hot_slot_disk_id = None
+        else:
+            self._evict_if_needed()
         self.prompts.append(prompt_tokens)
         self.caches.append(deepcopy(cache))
         self._snapshots.append(ssm_snapshots)
         self._access_counter += 1
         self._last_used.append(self._access_counter)
+        self._disk_dirty = True
+        if not self._flush_requested_at:
+            self._flush_requested_at = _time.time()
         logger.info(f"KV cache added: {len(prompt_tokens)} tokens")
 
     def update_kv_cache(
@@ -127,7 +151,10 @@ class KVPrefixCache:
         self._snapshots[index] = merged or None
         self._access_counter += 1
         self._last_used[index] = self._access_counter
-        logger.info(f"KV cache updated (index {index}): {len(prompt_tokens)} tokens")
+        self._disk_dirty = True
+        if not self._flush_requested_at:
+            self._flush_requested_at = _time.time()
+        logger.info(f"KV cache updated (index {index}, disk slot {self._hot_slot_disk_id}): {len(prompt_tokens)} tokens")
 
     def _get_snapshot(
         self, entry_index: int, target_token_count: int
@@ -178,7 +205,20 @@ class KVPrefixCache:
             if length > best_length:
                 best_index, best_length = i, length
 
+        # Disk fallback: cross-conversation match or no in-memory match
+        if best_index is not None and self._disk_dir:
+            _cached_len = len(self.prompts[best_index])
+            _cached_cov = best_length / _cached_len if _cached_len > 0 else 0.0
+            if best_length < _cached_len - 1:
+                _disk_result = self._try_load_from_disk(model, prompt_tokens, min_prefix=best_length)
+                if _disk_result is not None:
+                    return _disk_result
+
         if best_index is None:
+            if self._disk_dir:
+                _disk_result = self._try_load_from_disk(model, prompt_tokens)
+                if _disk_result is not None:
+                    return _disk_result
             return make_kv_cache(model), prompt_tokens, None
 
         # For exact match: trim to max_length-1 so remaining has the last token
@@ -227,6 +267,155 @@ class KVPrefixCache:
             logger.info(
                 f"KV cache evicted LRU entry ({evicted_tokens} tokens) due to memory usage"
             )
+
+    # ── Disk persistence methods ──
+
+    def _init_disk_dir(self):
+        h = hashlib.sha256(self._model_id.encode()).hexdigest()[:16]
+        d = _Path.home() / ".exo" / "kv-cache" / h
+        d.mkdir(parents=True, exist_ok=True)
+        logger.info(f"KV cache disk dir: {d}")
+        return d
+
+    def _list_disk_slots(self):
+        """List all disk slot IDs."""
+        if not self._disk_dir:
+            return []
+        slots = []
+        for f in self._disk_dir.glob("slot_*_tokens.safetensors"):
+            try:
+                slot_id = int(f.stem.split("_")[1])
+                slots.append(slot_id)
+            except (IndexError, ValueError):
+                continue
+        return sorted(slots)
+
+    def _next_disk_slot_id(self):
+        existing = self._list_disk_slots()
+        return max(existing) + 1 if existing else 0
+
+    def _flush_hot_slot(self):
+        """Save current hot slot to disk immediately."""
+        if len(self.caches) == 0:
+            return
+        try:
+            from mlx_lm.models.cache import save_prompt_cache
+            slot_id = self._hot_slot_disk_id if self._hot_slot_disk_id is not None else self._next_disk_slot_id()
+            base = self._disk_dir / f"slot_{slot_id}"
+            # Save cache (atomic: write tmp then rename)
+            tmp_cache = str(base) + "_tmp_cache.safetensors"
+            save_prompt_cache(tmp_cache, list(self.caches[0]))
+            os.rename(tmp_cache, str(base) + "_cache.safetensors")
+            # Save tokens
+            tmp_tokens = str(base) + "_tmp_tokens.safetensors"
+            mx.save_safetensors(tmp_tokens, {"tokens": self.prompts[0]})
+            os.rename(tmp_tokens, str(base) + "_tokens.safetensors")
+            # Save metadata
+            meta = {"model_id": self._model_id, "token_count": int(len(self.prompts[0])), "timestamp": _time.time()}
+            with open(str(base) + "_meta.json", "w") as f:
+                json.dump(meta, f)
+            self._hot_slot_disk_id = slot_id
+            self._disk_dirty = False
+            self._flush_requested_at = 0.0
+            logger.info(f"KV cache flushed to disk: slot_{slot_id} ({len(self.prompts[0])} tokens)")
+        except Exception as e:
+            logger.warning(f"KV cache disk flush failed: {e}")
+
+    def _evict_stale_disk_slots(self, max_age_hours=24):
+        """Delete disk slots older than max_age_hours."""
+        if not self._disk_dir:
+            return
+        cutoff = _time.time() - (max_age_hours * 3600)
+        for meta_file in self._disk_dir.glob("slot_*_meta.json"):
+            try:
+                with open(meta_file) as f:
+                    meta = json.load(f)
+                if meta.get("timestamp", 0) < cutoff:
+                    slot_id = int(meta_file.stem.split("_")[1])
+                    if slot_id == self._hot_slot_disk_id:
+                        continue
+                    base = self._disk_dir / f"slot_{slot_id}"
+                    for ext in ["_cache.safetensors", "_tokens.safetensors", "_meta.json"]:
+                        try:
+                            os.remove(str(base) + ext)
+                        except FileNotFoundError:
+                            pass
+                    logger.info(f"KV cache evicted stale disk slot_{slot_id}")
+            except Exception:
+                continue
+
+    def flush_to_disk(self, force=False):
+        """Flush hot slot to disk if dirty and idle for 15s (or force)."""
+        if not self._disk_dir or not self._disk_dirty:
+            return
+        if not force and (_time.time() - self._flush_requested_at) < 15:
+            return
+        self._flush_hot_slot()
+        self._evict_stale_disk_slots()
+
+    def _search_disk(self, prompt_tokens):
+        """Search disk slots for best prefix match. Returns (slot_id, prefix_length) or (None, 0)."""
+        if not self._disk_dir:
+            return None, 0
+        best_id = None
+        best_length = 0
+        for slot_id in self._list_disk_slots():
+            if slot_id == self._hot_slot_disk_id:
+                continue
+            token_file = self._disk_dir / f"slot_{slot_id}_tokens.safetensors"
+            try:
+                cached_tokens = mx.load(str(token_file))["tokens"]
+                prefix_len = get_prefix_length(prompt_tokens, cached_tokens)
+            except Exception:
+                continue
+            if prefix_len > best_length:
+                best_length = prefix_len
+                best_id = slot_id
+        return best_id, best_length
+
+    def _try_load_from_disk(self, model, prompt_tokens, min_prefix=0):
+        """Search disk for matching slot. If found, swap it in and return (cache, remaining, index)."""
+        disk_id, prefix_len = self._search_disk(prompt_tokens)
+        if disk_id is None or prefix_len <= min_prefix or prefix_len < 1000:
+            return None
+        try:
+            from mlx_lm.models.cache import load_prompt_cache
+            # Flush current hot slot if dirty
+            if self._disk_dirty and len(self.caches) > 0:
+                self._flush_hot_slot()
+            # Clear RAM
+            self.prompts.clear()
+            self.caches.clear()
+            self._snapshots.clear()
+            self._last_used.clear()
+            # Load from disk
+            base = self._disk_dir / f"slot_{disk_id}"
+            cache = load_prompt_cache(str(base) + "_cache.safetensors")
+            tokens = mx.load(str(base) + "_tokens.safetensors")["tokens"]
+            # Install as hot slot
+            self.prompts.append(tokens)
+            self.caches.append(cache)
+            self._snapshots.append(None)
+            self._access_counter += 1
+            self._last_used.append(self._access_counter)
+            self._hot_slot_disk_id = disk_id
+            self._disk_dirty = False
+            self._flush_requested_at = 0.0
+            logger.info(f"KV cache loaded from disk: slot_{disk_id} ({len(tokens)} tokens)")
+            # Trim and return
+            prompt_cache = deepcopy(cache)
+            cached_length = cache_length(cache)
+            tokens_to_trim = cached_length - prefix_len
+            if tokens_to_trim > 0:
+                trim_cache(prompt_cache, tokens_to_trim)
+                for c in prompt_cache:
+                    if hasattr(c, "offset"):
+                        c.offset = prefix_len
+            remaining = prompt_tokens[prefix_len:]
+            return prompt_cache, remaining, 0
+        except Exception as e:
+            logger.warning(f"KV cache disk load failed for slot_{disk_id}: {e}")
+            return None
 
     def get_memory_used_percentage(self) -> float:
         local_pressure: float = get_memory_used_percentage()

--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -300,6 +300,7 @@ class KVPrefixCache:
             return
         try:
             from mlx_lm.models.cache import save_prompt_cache
+            self._disk_dir.mkdir(parents=True, exist_ok=True)
             slot_id = self._hot_slot_disk_id if self._hot_slot_disk_id is not None else self._next_disk_slot_id()
             base = self._disk_dir / f"slot_{slot_id}"
             # Save cache (atomic: write tmp then rename)

--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -393,16 +393,24 @@ class ExoBatchGenerator:
                 if len(all_prompt_tokens) > 0
                 else 0.0
             )
-            if matched_index is not None and (
-                prefix_hit_length > 1000 or hit_ratio >= _MIN_PREFIX_HIT_RATIO_TO_UPDATE
-            ):
-                self.kv_prefix_cache.update_kv_cache(
-                    matched_index,
-                    all_prompt_tokens,
-                    cache,
-                    cache_snapshots,
-                    restore_pos=prefix_hit_length,
-                )
+            if matched_index is not None:  # Checkpoint 2B: cached_coverage guard
+                cached_len = len(self.kv_prefix_cache.prompts[matched_index])
+                cached_coverage = prefix_hit_length / cached_len if cached_len > 0 else 0.0
+                is_extension = prefix_hit_length >= cached_len - 1 and cached_coverage >= hit_ratio
+                if is_extension and (
+                    prefix_hit_length > 1000 and hit_ratio >= 0.3 or hit_ratio >= _MIN_PREFIX_HIT_RATIO_TO_UPDATE
+                ):
+                    self.kv_prefix_cache.update_kv_cache(
+                        matched_index,
+                        all_prompt_tokens,
+                        cache,
+                        cache_snapshots,
+                        restore_pos=prefix_hit_length,
+                    )
+                else:
+                    self.kv_prefix_cache.add_kv_cache(
+                        all_prompt_tokens, cache, cache_snapshots
+                    )
             else:
                 self.kv_prefix_cache.add_kv_cache(
                     all_prompt_tokens, cache, cache_snapshots

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -645,17 +645,26 @@ def mlx_generate(
                     if len(all_prompt_tokens) > 0
                     else 0.0
                 )
-                if matched_index is not None and (
-                    prefix_hit_length > 1000
-                    or hit_ratio >= _MIN_PREFIX_HIT_RATIO_TO_UPDATE
-                ):
-                    kv_prefix_cache.update_kv_cache(
-                        matched_index,
-                        full_prompt_tokens,
-                        caches,
-                        cache_snapshots,
-                        restore_pos=prefix_hit_length,
-                    )
+                if matched_index is not None:  # Checkpoint 2B: cached_coverage guard
+                    cached_len = len(kv_prefix_cache.prompts[matched_index])
+                    cached_coverage = prefix_hit_length / cached_len if cached_len > 0 else 0.0
+                    is_extension = prefix_hit_length >= cached_len - 1 and cached_coverage >= hit_ratio
+                    if is_extension and (
+                        prefix_hit_length > 1000 and hit_ratio >= 0.3
+                        or hit_ratio >= _MIN_PREFIX_HIT_RATIO_TO_UPDATE
+                    ):
+                        kv_prefix_cache.update_kv_cache(
+                            matched_index,
+                            full_prompt_tokens,
+                            caches,
+                            cache_snapshots,
+                            restore_pos=prefix_hit_length,
+                        )
+                    else:
+                        kv_prefix_cache.add_kv_cache(
+                            full_prompt_tokens, caches, cache_snapshots
+                        )
+
                 else:
                     kv_prefix_cache.add_kv_cache(
                         full_prompt_tokens, caches, cache_snapshots

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -320,7 +320,7 @@ class Runner:
         # Flush KV cache to disk on idle
         _kv = getattr(getattr(self, "generator", None), "kv_prefix_cache", None)
         if _kv is not None:
-            _kv.flush_to_disk()
+            _kv.flush_to_disk(force=True)
 
         self.update_status(RunnerReady())
         logger.info("runner ready")

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -243,6 +243,10 @@ class Runner:
 
     def shutdown(self, task: Task):
         logger.info("runner shutting down")
+        # Force flush KV cache to disk before shutdown
+        _kv = getattr(getattr(self, "generator", None), "kv_prefix_cache", None)
+        if _kv is not None:
+            _kv.flush_to_disk(force=True)
         self.update_status(RunnerShuttingDown())
         self.acknowledge_task(task)
         if isinstance(self.generator, InferenceGenerator):
@@ -312,6 +316,11 @@ class Runner:
 
             except WouldBlock:
                 pass
+
+        # Flush KV cache to disk on idle
+        _kv = getattr(getattr(self, "generator", None), "kv_prefix_cache", None)
+        if _kv is not None:
+            _kv.flush_to_disk()
 
         self.update_status(RunnerReady())
         logger.info("runner ready")
@@ -404,7 +413,7 @@ class Builder:
                 self.tokenizer.tool_parser,  # type: ignore
             )
 
-        kv_prefix_cache = KVPrefixCache(self.group)
+        kv_prefix_cache = KVPrefixCache(self.group, model_id=self.model_id)  # Checkpoint 2A: disk persistence
 
         device_rank = 0 if self.group is None else self.group.rank()
         if os.environ.get("EXO_NO_BATCH"):


### PR DESCRIPTION
## Problem

`KVPrefixCache` matches slots purely by token prefix overlap. When multiple conversations share a system prompt (typical in multi-channel API gateway setups), the prefix matcher sees 90%+ overlap and overwrites the existing 
slot on every conversation switch — destroying the previous conversation's cache. A 100k-token conversation reverts to a ~20-30k system prompt match if you were to switch to a fresh session, requiring near-full reprefill. The alternative — keeping multiple slots in RAM — scales linearly with conversation count, length, and model architecture, quickly becoming prohibitive. With this patch, you only have 1 slot active at any given time so it prevents OOMs. Additionally, KV cache is RAM-only: restarts and crashes force cold prefills from zero. I am now able to hold multiple conversations in multiple channels with my agent running locally on my computer with near zero prefill downtime (instant switching from one session to the other) after every conversation is fully loaded/flushed to disk, I think of it as a context extender, I hold 3-5 conversations at a time all of which are around 70k-100k tokens on a model as large as Kimi K2.5. 

## Solution

### Per-conversation slot separation

A heuristic in `_save_prefix_cache` distinguishes "same conversation extended" from "different conversation with shared prefix" using an exact prefix check:
```python
cached_len = len(cached_prompt)
is_extension = prefix_hit_length >= cached_len - 1 and cached_coverage >= hit_ratio
```

A legitimate update (same conversation, new messages appended) matches **all** cached tokens as a prefix — `prefix_hit_length >= cached_len - 1`. The new prompt is always longer, so `cached_coverage >= hit_ratio`.

A cross-conversation collision (different channel, shared system prompt) matches only a subset of the cached tokens — even at 98% overlap, the gap of hundreds of unmatched tokens at the end of the cached prompt fails the exact prefix check. This correctly routes to a new slot instead of overwriting.

### Single hot slot + disk persistence

Only **one KV cache slot stays in RAM** at a time (the "hot" slot for the active conversation). All other slots are persisted to disk via mlx-lm's `save_prompt_cache` / `load_prompt_cache`, which call `mx.save_safetensors` internally — writing directly from Apple Silicon unified memory to disk with no numpy intermediate, no bf16 casting, and no GPU→CPU copy.

**Conversation switch flow:**
1. New conversation arrives, hot slot doesn't match → flush hot slot to disk (~1-2s)
2. Search disk for a matching slot → load if found (~1-2s)  
3. If not found → fresh prefill (first time only)
4. Total switch cost: **~2-4s** vs **~2-3 minutes** cold prefill

**Three flush triggers:**
- **15-second idle timer:** Saves the hot slot when the runner has no active tasks for 15+ seconds. Protects against data loss from crashes.
- **Conversation switch:** Immediate synchronous flush before clearing RAM and loading the new conversation.
- **Shutdown:** Force flush on runner shutdown, bypassing the 15-second timer.

## Storage format

```
~/.exo/kv-cache/<model_hash>/
  ├── slot_0_cache.safetensors      # KV tensors (bf16)
  ├── slot_0_tokens.safetensors     # Token array (int32, ~200 KB)
  ├── slot_0_meta.json              # {model_id, token_count, timestamp}
  ├── slot_1_cache.safetensors
  ├── slot_1_tokens.safetensors
  └── slot_1_meta.json
```

Each model gets its own directory via `model_hash` (SHA-256[:16] of model_id). No cross-model contamination.

## Disk eviction

Stale disk slots are cleaned up automatically after every flush:

- **24-hour TTL:** Any slot with a `timestamp` older than 24 hours is deleted. Active conversations have their timestamp refreshed on every flush, so they never expire while in use.
- **No slot count cap:** Disk space is cheap on NVMe SSDs. 20 concurrent conversations ≈ 100 GB — negligible on multi-TB drives. A hard cap would risk evicting active conversations during testing bursts.
- **Hot slot protection:** The currently loaded slot is never evicted, even if its metadata timestamp is stale.
- **Three files per eviction:** `_cache.safetensors`, `_tokens.safetensors`, and `_meta.json` are all removed together.

## Model compatibility

This feature works with any model using standard `KVCache` from mlx-lm, which includes the vast majority of architectures:

- ✅ Standard attention (Llama, Mistral, Qwen, Gemma, Phi, etc.)
- ✅ Multi-Latent Attention / MLA (DeepSeek V3, Kimi-K2.5)
- ✅ Grouped Query Attention / GQA (Llama 3, Mistral, etc.)
- ⚠️ `QuantizedKVCache` — untested but should work via `from_state()` protocol
- ⚠️ `RotatingKVCache` (sliding window) — untested, may need verification
- ❌ Models with `ArraysCache` / SSM layers (Mamba, Jamba) — SSM state snapshots are not persisted to disk. These models fall through gracefully to fresh cache rather than serving corrupt state.

## Configuration

All optional. No configuration required — the feature works out of the box with sensible defaults.

| Variable | Default | Effect |
|---|---|---|
| `EXO_KV_DISK_PERSISTENCE=0` | `1` (enabled) | Disable disk persistence entirely (revert to RAM-only behavior) |
| `EXO_KV_DISK_PATH=/path` | `~/.exo/kv-cache` | Custom storage location (e.g., faster NVMe, larger drive) |
| `EXO_KV_DISK_TTL_HOURS=48` | `24` | Hours before stale slot eviction |
| `EXO_KV_DISK_MAX_SIZE_GB=200` | `500` | Evict oldest slots when directory exceeds this limit |

## Before / After

### Before (Checkpoint 1 only)
```
Channel A:  50k tokens → saved at slot 0
Channel B:  35k tokens → matches slot 0 at 92% → OVERWRITES slot 0
Channel A:  50k tokens → slot 0 is now Channel B → full prefill (~2-3 minutes)
Runner restart: all cache lost → full prefill for everything
```

### After
```
Channel A:  50k tokens → hot slot (index 0), saved to disk as slot_0
Channel B:  35k tokens → flush slot_0 to disk, load or create slot_1, 99.2% hit
Channel A:  50k tokens → flush slot_1 to disk, load slot_0 from disk, 99.1% hit
Runner restart: load from disk → 99% hit, no cold prefill
```

### Measured performance

| Metric | Before | After |
|---|---|---|
| Same-conversation hit rate | 93-99% | 98-99% |
| Cross-conversation hit rate | 0% (overwritten) | 98-99% (separate slots) |
| Conversation switch cost | ~2-3 minutes (full 50k prefill) | ~2-4s (disk swap) |
| Cache survives restart | No | Yes |

## Testing

Tested over multiple hours on:
- **Hardware:** 2× Mac Studio M3 Ultra (512 GB unified memory each), Thunderbolt 5 RDMA
- **Model:** Kimi-K2.5 (DeepSeek V3 architecture, MLA attention, 61 layers, bf16)
- **Conversations:** 4 concurrent Discord channels with 50k-100k token contexts, 0 prefill, instant switching.
- **Scenarios validated:**
  - Repeated channel switching with 98-99% hit rates on both channels
  - Runner reload with immediate cache restoration from disk
  - 15-second idle flush firing correctly between requests
  - Force flush on shutdown preserving cache state
  - 24-hour TTL eviction of stale slots

## Files changed

| File | Changes |
|---|---|
| `cache.py` | `model_id` param, disk persistence methods, single hot slot enforcement, TTL eviction, disk search fallback in `get_kv_cache` |
| `runner.py` | Pass `model_id` to `KVPrefixCache`, flush on idle (AllTasksComplete), force flush on shutdown |
| `generate.py` | `cached_coverage` guard in `_save_prefix_cache` |
| `batch_generate.py` | Same `cached_coverage` guard (active code path) |
