### PR TITLE
Fix reasoning_tokens always reported as 0 for thinking models

### DIFF
--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -41,6 +41,7 @@ from exo.worker.engines.mlx.generator.generate import (
     prefill,
 )
 from exo.worker.engines.mlx.utils_mlx import (
+    detect_thinking_prompt_suffix,
     fix_unmatched_think_end_tokens,
     system_prompt_token_count,
 )
@@ -269,6 +270,7 @@ class ExoBatchGenerator:
             prefill_tps=_prefill_tps,
             generation_time_at_start=self._mlx_gen._stats.generation_time,
             media_regions=media_regions,
+            in_thinking=detect_thinking_prompt_suffix(prompt, self.tokenizer),
         )
 
         return uid

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -53,6 +53,7 @@ from exo.worker.engines.mlx.constants import (
 )
 from exo.worker.engines.mlx.utils_mlx import (
     apply_chat_template,
+    detect_thinking_prompt_suffix,
     fix_unmatched_think_end_tokens,
     mx_barrier,
     system_prompt_token_count,
@@ -596,7 +597,7 @@ def mlx_generate(
     generated_text_parts: list[str] = []
     generation_start_time = time.perf_counter()
     usage: Usage | None = None
-    in_thinking = False
+    in_thinking = detect_thinking_prompt_suffix(prompt, tokenizer)
     reasoning_tokens = 0
     think_start = tokenizer.think_start
     think_end = tokenizer.think_end


### PR DESCRIPTION
When `enable_thinking` is set, chat templates (Qwen3, DeepSeek, etc.) append `<think>` to the prompt. The model starts generating thinking content directly without emitting a `<think>` token in the output stream.

Both generators initialized `in_thinking = False` and only set it to `True` on seeing a `<think>` token in output. Since that token was part of the prompt, the flag never flipped and `reasoning_tokens` stayed at 0 in the usage response.

Fix: initialize `in_thinking` from `detect_thinking_prompt_suffix()`, which already exists and is used by `model_output_parsers` for routing thinking content correctly.