### PR TITLE
build: remove pyinstaller temp artifacts

### DIFF
--- a/justfile
+++ b/justfile
@@ -34,6 +34,7 @@ build-dashboard:
 
 package: build-dashboard
     uv run pyinstaller packaging/pyinstaller/exo.spec
+    rm -rf build
 
 build-app: package
     xcodebuild build -project app/EXO/EXO.xcodeproj -scheme EXO -configuration Debug -derivedDataPath app/EXO/build


### PR DESCRIPTION
## Summary
- remove PyInstaller `build/` leftovers after the package recipe completes
- keep the final packaged output intact

## Notes
- release artifacts that may be used in production are preserved
- cleanup only targets debug and intermediate build artifacts by default

## Validation
- `just --dry-run package`
- `git diff --check`