### PR TITLE
add assertion to event router

### DIFF
--- a/src/exo/routing/event_router.py
+++ b/src/exo/routing/event_router.py
@@ -72,6 +72,7 @@ class EventRouter:
         return send
 
     def receiver(self) -> Receiver[IndexedEvent]:
+        assert not self._tg.is_running()
         send, recv = channel[IndexedEvent]()
         self.internal_outbound.append(send)
         return recv


### PR DESCRIPTION
followup to #1894, in order to ensure every receiver receives every event, we should ensure all are created before we start the event router.