### PR TITLE
Add usage stats to tool calls and handle multiple tool calls correctly

### DIFF
--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -381,29 +381,26 @@ def parse_tool_calls(
     tool_call_text_parts: list[str] = []
     accumulated_tool_calls: list[ToolCallItem] = []
 
-    def yield_tool_calls(
-        tool_calls: list[ToolCallItem], response: GenerationResponse | None
-    ):
-        yield ToolCallResponse(
-            tool_calls=tool_calls,
-            usage=None if response is None else response.usage,
-            stats=None if response is None else response.stats,
-        )
-        tool_calls.clear()
-
     for response in responses:
         if response is None:
             yield None
             continue
 
-        if accumulated_tool_calls and (
-            response.stats is not None or response.finish_reason is not None
-        ):
-            yield_tool_calls(accumulated_tool_calls, response)
-            continue
-
         if not in_tool_call and response.text.startswith(tool_parser.start_parsing):
             in_tool_call = True
+
+        if (
+            not in_tool_call
+            and accumulated_tool_calls
+            and (response.stats is not None or response.finish_reason is not None)
+        ):
+            yield ToolCallResponse(
+                tool_calls=accumulated_tool_calls,
+                usage=response.usage,
+                stats=response.stats,
+            )
+            accumulated_tool_calls.clear()
+            continue
 
         if not in_tool_call:
             yield response
@@ -426,8 +423,15 @@ def parse_tool_calls(
                 break
 
             accumulated_tool_calls.extend(parsed)
-            if response.finish_reason is not None or response.stats is not None:
-                yield_tool_calls(accumulated_tool_calls, response)
+            if accumulated_tool_calls and (
+                response.finish_reason is not None or response.stats is not None
+            ):
+                yield ToolCallResponse(
+                    tool_calls=accumulated_tool_calls,
+                    usage=response.usage,
+                    stats=response.stats,
+                )
+                accumulated_tool_calls.clear()
             continue
 
         if response.finish_reason is not None:
@@ -443,8 +447,5 @@ def parse_tool_calls(
             )
             yield response
 
-    if accumulated_tool_calls:
-        logger.critical(
-            "No finish reason on the tool call response - please report this case to us!"
-        )
-        yield_tool_calls(accumulated_tool_calls, None)
+    if not accumulated_tool_calls:
+        logger.warning("Tool calls should have all been emitted but were not")

--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -379,9 +379,21 @@ def parse_tool_calls(
 ) -> Generator[GenerationResponse | ToolCallResponse | None]:
     in_tool_call = False
     tool_call_text_parts: list[str] = []
+    accumulated_tool_calls: list[ToolCallItem] = []
     for response in responses:
         if response is None:
             yield None
+            continue
+
+        if accumulated_tool_calls and (
+            response.stats is not None or response.finish_reason is not None
+        ):
+            yield ToolCallResponse(
+                tool_calls=accumulated_tool_calls,
+                usage=response.usage,
+                stats=response.stats,
+            )
+            accumulated_tool_calls = []
             continue
 
         if not in_tool_call and response.text.startswith(tool_parser.start_parsing):
@@ -407,9 +419,14 @@ def parse_tool_calls(
                 )
                 break
 
-            yield ToolCallResponse(
-                tool_calls=parsed, usage=response.usage, stats=response.stats
-            )
+            accumulated_tool_calls.extend(parsed)
+            if response.finish_reason is not None or response.stats is not None:
+                yield ToolCallResponse(
+                    tool_calls=accumulated_tool_calls,
+                    usage=response.usage,
+                    stats=response.stats,
+                )
+                accumulated_tool_calls = []
             continue
 
         if response.finish_reason is not None:
@@ -424,3 +441,8 @@ def parse_tool_calls(
                 }
             )
             yield response
+
+    if accumulated_tool_calls:
+        yield ToolCallResponse(
+            tool_calls=accumulated_tool_calls, usage=None, stats=None
+        )

--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -380,6 +380,17 @@ def parse_tool_calls(
     in_tool_call = False
     tool_call_text_parts: list[str] = []
     accumulated_tool_calls: list[ToolCallItem] = []
+
+    def yield_tool_calls(
+        tool_calls: list[ToolCallItem], response: GenerationResponse | None
+    ):
+        yield ToolCallResponse(
+            tool_calls=tool_calls,
+            usage=None if response is None else response.usage,
+            stats=None if response is None else response.stats,
+        )
+        tool_calls.clear()
+
     for response in responses:
         if response is None:
             yield None
@@ -388,12 +399,7 @@ def parse_tool_calls(
         if accumulated_tool_calls and (
             response.stats is not None or response.finish_reason is not None
         ):
-            yield ToolCallResponse(
-                tool_calls=accumulated_tool_calls,
-                usage=response.usage,
-                stats=response.stats,
-            )
-            accumulated_tool_calls = []
+            yield_tool_calls(accumulated_tool_calls, response)
             continue
 
         if not in_tool_call and response.text.startswith(tool_parser.start_parsing):
@@ -421,12 +427,7 @@ def parse_tool_calls(
 
             accumulated_tool_calls.extend(parsed)
             if response.finish_reason is not None or response.stats is not None:
-                yield ToolCallResponse(
-                    tool_calls=accumulated_tool_calls,
-                    usage=response.usage,
-                    stats=response.stats,
-                )
-                accumulated_tool_calls = []
+                yield_tool_calls(accumulated_tool_calls, response)
             continue
 
         if response.finish_reason is not None:
@@ -443,6 +444,7 @@ def parse_tool_calls(
             yield response
 
     if accumulated_tool_calls:
-        yield ToolCallResponse(
-            tool_calls=accumulated_tool_calls, usage=None, stats=None
+        logger.critical(
+            "No finish reason on the tool call response - please report this case to us!"
         )
+        yield_tool_calls(accumulated_tool_calls, None)

--- a/src/exo/worker/tests/unittests/test_runner/test_parse_tool_calls.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_parse_tool_calls.py
@@ -9,17 +9,14 @@ from exo.worker.runner.llm_inference.model_output_parsers import parse_tool_call
 from exo.worker.runner.llm_inference.tool_parsers import make_mlx_parser
 
 
-def _make_responses(
-    texts: list[str],
-    finish_on_last: bool = True,
-) -> Generator[GenerationResponse]:
+def _make_responses(texts: list[str]) -> Generator[GenerationResponse]:
     """Create a sequence of GenerationResponses from text strings."""
     for i, text in enumerate(texts):
         is_last = i == len(texts) - 1
         yield GenerationResponse(
             text=text,
             token=i,
-            finish_reason="stop" if (is_last and finish_on_last) else None,
+            finish_reason="stop" if is_last else None,
             usage=None,
         )
 
@@ -39,7 +36,7 @@ class TestParseToolCalls:
         texts = ["<tool_call>", "test_fn", "</tool_call>"]
         results = list(
             parse_tool_calls(
-                _make_responses(texts, finish_on_last=False),
+                _make_responses(texts),
                 _dummy_parser,
                 tools=None,
             )
@@ -78,7 +75,7 @@ class TestParseToolCalls:
         texts = ["<tool_call>", "bad content", "</tool_call>"]
         results = list(
             parse_tool_calls(
-                _make_responses(texts, finish_on_last=False),
+                _make_responses(texts),
                 make_mlx_parser("<tool_call>", "</tool_call>", _failing_parser),
                 tools=None,
             )


### PR DESCRIPTION
## Motivation

Tool calls are usually not end tokens, so they didn't have usage stats.