### PR TITLE
models: add Qwen3.6-35B-A3B (4bit + 8bit)

### DIFF
--- a/resources/inference_model_cards/mlx-community--Qwen3.6-35B-A3B-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--Qwen3.6-35B-A3B-4bit.toml
@@ -1,0 +1,15 @@
+model_id = "mlx-community/Qwen3.6-35B-A3B-4bit"
+n_layers = 40
+hidden_size = 2048
+num_key_value_heads = 2
+supports_tensor = true
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "4bit"
+base_model = "Qwen3.6 35B A3B"
+capabilities = ["text", "thinking", "thinking_toggle", "vision"]
+
+context_length = 262144
+
+[storage_size]
+in_bytes = 20400000000

--- a/resources/inference_model_cards/mlx-community--Qwen3.6-35B-A3B-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--Qwen3.6-35B-A3B-8bit.toml
@@ -1,0 +1,15 @@
+model_id = "mlx-community/Qwen3.6-35B-A3B-8bit"
+n_layers = 40
+hidden_size = 2048
+num_key_value_heads = 2
+supports_tensor = true
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "8bit"
+base_model = "Qwen3.6 35B A3B"
+capabilities = ["text", "thinking", "thinking_toggle", "vision"]
+
+context_length = 262144
+
+[storage_size]
+in_bytes = 37700000000


### PR DESCRIPTION
## Motivation

Alibaba just released [Qwen3.6-35B-A3B](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) — a sparse MoE model with 35B total parameters and only 3B active per forward pass (Apache 2.0). mlx-community already has both quants available.

## Changes

Adds model cards for:
- `mlx-community/Qwen3.6-35B-A3B-4bit` (20.4 GB)
- `mlx-community/Qwen3.6-35B-A3B-8bit` (37.7 GB)

Uses the existing `Qwen3_5MoeForConditionalGeneration` architecture (no code changes needed). Multimodal with thinking/non-thinking toggle, 262k context.

## Why It Works

The architecture is identical to the already-supported Qwen3.5 MoE family. Only model cards are added.

## Test Plan

### Manual Testing

- Verified both model cards load correctly via `get_model_cards()`

### Automated Testing

- `uv run basedpyright` — no new type errors
- `uv run ruff check` — clean