### PR TITLE
fix(download): treat HF size=None as "size unknown, trust filesystem"

### DIFF
--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -900,17 +900,26 @@ async def download_shard(
     for file in filtered_file_list:
         downloaded_bytes = await get_downloaded_size(target_dir / file.path)
         final_file_exists = await aios.path.exists(target_dir / file.path)
+        # HuggingFace's tree API occasionally returns ``size=None`` for entries
+        # it can't report a size for (observed in the wild for very large repos
+        # such as Kimi K2.5). When that happens, ``downloaded_bytes == None`` is
+        # always False and the file would be permanently marked ``not_started``
+        # — which causes the periodic re-scan in ``DownloadCoordinator`` to demote
+        # a fully-downloaded model back to ``DownloadPending`` every 60s.
+        # File existence is a strictly stronger signal than absence of HF-reported
+        # size info, so trust the filesystem in that case.
         file_progress[file.path] = RepoFileDownloadProgress(
             repo_id=model_id,
             repo_revision=revision,
             file_path=file.path,
             downloaded=Memory.from_bytes(downloaded_bytes),
             downloaded_this_session=Memory.from_bytes(0),
-            total=Memory.from_bytes(file.size or 0),
+            total=Memory.from_bytes(file.size or downloaded_bytes),
             speed=0,
             eta=timedelta(0),
             status="complete"
-            if final_file_exists and downloaded_bytes == file.size
+            if final_file_exists
+            and (file.size is None or downloaded_bytes == file.size)
             else "not_started",
             start_time=time.time(),
         )

--- a/src/exo/download/tests/test_download_verification.py
+++ b/src/exo/download/tests/test_download_verification.py
@@ -12,11 +12,14 @@ from pydantic import TypeAdapter
 
 from exo.download.download_utils import (
     delete_model,
+    download_shard,
     fetch_file_list_with_cache,
 )
+from exo.shared.models.model_cards import ModelCard, ModelTask
 from exo.shared.types.common import ModelId
 from exo.shared.types.memory import Memory
 from exo.shared.types.worker.downloads import FileListEntry, RepoFileDownloadProgress
+from exo.shared.types.worker.shards import PipelineShardMetadata, ShardMetadata
 
 
 @pytest.fixture
@@ -451,3 +454,185 @@ class TestProgressResetOnRedownload:
         assert downloaded_this_session == 600_000, (
             "downloaded_this_session should equal total downloaded so far"
         )
+
+
+def _make_shard(model_id: ModelId) -> ShardMetadata:
+    """Build a minimal shard for a text-generation model."""
+    return PipelineShardMetadata(
+        model_card=ModelCard(
+            model_id=model_id,
+            storage_size=Memory.from_bytes(0),
+            n_layers=1,
+            hidden_size=1,
+            supports_tensor=False,
+            tasks=[ModelTask.TextGeneration],
+        ),
+        device_rank=0,
+        world_size=1,
+        start_layer=0,
+        end_layer=1,
+        n_layers=1,
+    )
+
+
+class TestSkipDownloadStatusWithMissingSize:
+    """Tests that ``download_shard(skip_download=True)`` reports a fully-downloaded
+    model as ``status="complete"`` even when HuggingFace's tree API returns
+    ``size=None`` for one or more files.
+
+    Regression test for the Kimi K2.5 "downloaded status keeps reverting" bug:
+    when the ``DownloadCoordinator`` periodic re-scan runs ``download_shard`` with
+    ``skip_download=True``, a ``None`` size on any file would make the equality
+    check ``downloaded_bytes == file.size`` always False, so the whole repo got
+    classified ``in_progress`` and the coordinator demoted it back to
+    ``DownloadPending`` every 60 seconds.
+    """
+
+    async def test_status_complete_when_file_size_is_none(
+        self, model_id: ModelId, tmp_path: Path
+    ) -> None:
+        """HF tree API reporting ``size=None`` for a file on a complete model
+        should not cause that file to be reported ``not_started``."""
+        models_dir = tmp_path / "models"
+        model_dir = models_dir / model_id.normalize()
+        await aios.makedirs(model_dir, exist_ok=True)
+
+        # Create the files on disk as a "fully downloaded" model would have them.
+        weight_content = b"x" * 1000
+        config_content = b'{"hello": "world"}'
+        async with aiofiles.open(model_dir / "model.safetensors", "wb") as f:
+            await f.write(weight_content)
+        async with aiofiles.open(model_dir / "config.json", "wb") as f:
+            await f.write(config_content)
+
+        # Simulate what HF's tree API returns for Kimi K2.5: most files have a
+        # size, but at least one comes back with ``size=None``.
+        file_list = [
+            FileListEntry(
+                type="file", path="model.safetensors", size=len(weight_content)
+            ),
+            FileListEntry(type="file", path="config.json", size=None),
+        ]
+
+        shard = _make_shard(model_id)
+        collected_progress: list[object] = []
+
+        async def on_progress(_shard: ShardMetadata, progress: object) -> None:
+            collected_progress.append(progress)
+
+        with (
+            patch("exo.download.download_utils.EXO_MODELS_DIRS", (models_dir,)),
+            patch("exo.download.download_utils.EXO_MODELS_READ_ONLY_DIRS", ()),
+            patch("exo.download.download_utils.EXO_DEFAULT_MODELS_DIR", models_dir),
+            patch(
+                "exo.download.download_utils.fetch_file_list_with_cache",
+                new_callable=AsyncMock,
+                return_value=file_list,
+            ),
+        ):
+            target_dir, progress = await download_shard(
+                shard,
+                on_progress,
+                skip_download=True,
+            )
+
+        assert target_dir == model_dir
+        assert progress.status == "complete", (
+            f"Expected status='complete' when all files exist on disk "
+            f"(even with size=None in HF response), got {progress.status!r}. "
+            f"file_progress: "
+            f"{ {path: fp.status for path, fp in progress.file_progress.items()} }"
+        )
+        assert progress.file_progress["config.json"].status == "complete"
+        assert progress.file_progress["model.safetensors"].status == "complete"
+
+    async def test_status_not_started_when_file_with_none_size_missing(
+        self, model_id: ModelId, tmp_path: Path
+    ) -> None:
+        """Files reported with ``size=None`` that are ALSO missing on disk must
+        still be reported as ``not_started`` \u2014 we only waive size-verification
+        when the file physically exists."""
+        models_dir = tmp_path / "models"
+        model_dir = models_dir / model_id.normalize()
+        await aios.makedirs(model_dir, exist_ok=True)
+
+        # Create only the sized file; the size=None file is missing.
+        weight_content = b"x" * 1000
+        async with aiofiles.open(model_dir / "model.safetensors", "wb") as f:
+            await f.write(weight_content)
+
+        file_list = [
+            FileListEntry(
+                type="file", path="model.safetensors", size=len(weight_content)
+            ),
+            FileListEntry(type="file", path="config.json", size=None),
+        ]
+
+        shard = _make_shard(model_id)
+
+        async def on_progress(_shard: ShardMetadata, _progress: object) -> None:
+            pass
+
+        with (
+            patch("exo.download.download_utils.EXO_MODELS_DIRS", (models_dir,)),
+            patch("exo.download.download_utils.EXO_MODELS_READ_ONLY_DIRS", ()),
+            patch("exo.download.download_utils.EXO_DEFAULT_MODELS_DIR", models_dir),
+            patch(
+                "exo.download.download_utils.fetch_file_list_with_cache",
+                new_callable=AsyncMock,
+                return_value=file_list,
+            ),
+        ):
+            _, progress = await download_shard(
+                shard,
+                on_progress,
+                skip_download=True,
+            )
+
+        # model.safetensors exists with matching size -> complete.
+        # config.json is missing -> not_started, which makes overall not_started.
+        assert progress.file_progress["model.safetensors"].status == "complete"
+        assert progress.file_progress["config.json"].status == "not_started"
+        assert progress.status == "not_started"
+
+    async def test_status_not_started_when_sized_file_size_mismatch(
+        self, model_id: ModelId, tmp_path: Path
+    ) -> None:
+        """Guard against regressions: a size mismatch on a sized file is still
+        reported as ``not_started``. The fix must only relax the check for
+        ``size=None``, not for genuine size disagreements."""
+        models_dir = tmp_path / "models"
+        model_dir = models_dir / model_id.normalize()
+        await aios.makedirs(model_dir, exist_ok=True)
+
+        # On-disk size is 500, HF says 1000 \u2192 mismatch.
+        async with aiofiles.open(model_dir / "model.safetensors", "wb") as f:
+            await f.write(b"x" * 500)
+
+        file_list = [
+            FileListEntry(type="file", path="model.safetensors", size=1000),
+        ]
+
+        shard = _make_shard(model_id)
+
+        async def on_progress(_shard: ShardMetadata, _progress: object) -> None:
+            pass
+
+        with (
+            patch("exo.download.download_utils.EXO_MODELS_DIRS", (models_dir,)),
+            patch("exo.download.download_utils.EXO_MODELS_READ_ONLY_DIRS", ()),
+            patch("exo.download.download_utils.EXO_DEFAULT_MODELS_DIR", models_dir),
+            patch(
+                "exo.download.download_utils.fetch_file_list_with_cache",
+                new_callable=AsyncMock,
+                return_value=file_list,
+            ),
+        ):
+            _, progress = await download_shard(
+                shard,
+                on_progress,
+                skip_download=True,
+            )
+
+        assert progress.file_progress["model.safetensors"].status == "not_started"
+        assert progress.status == "not_started"


### PR DESCRIPTION
Fixes #1918 — the "fully-downloaded status keeps reverting" bug reported for Kimi K2.5 on a 2-node Mac Studio setup: a model that's already 612/612 GB on disk loses its green checkmark every 1–2 minutes and disappears from the "downloaded" filter, reappearing only when the user clicks the download arrow.

## Root cause

`DownloadCoordinator._emit_existing_download_progress` runs a periodic re-scan every 60 s (`src/exo/download/coordinator.py:345`, `await anyio.sleep(60)`) that calls `shard_downloader.get_shard_download_status()` for every known model. That ultimately ends up in `download_shard(skip_download=True)` at `src/exo/download/download_utils.py:763`, which loops over the file list returned by HuggingFace's tree API and builds per-file status with:

```python
status="complete"
if final_file_exists and downloaded_bytes == file.size
else "not_started",
```

`FileListEntry.size` is `int | None`. For very large repos (Kimi K2.5 is the reproducer) HuggingFace's tree API can return `size=None` for at least one entry. The moment that happens:

1. `downloaded_bytes == None` is always `False`, regardless of what's on disk
2. That file gets tagged `not_started`
3. `calculate_repo_progress` (line 654) then classifies the whole repo as `in_progress` (any not-complete → repo not complete)
4. Back in the coordinator periodic loop:
   ```python
   elif progress.status in ["in_progress", "not_started"]:
       if progress.downloaded_this_session.in_bytes == 0:
           status = DownloadPending(...)    # ← demotes Completed → Pending
   ```
5. The `DownloadCompleted` status gets overwritten every 60 s, which the UI renders as losing the green checkmark and being removed from the "downloaded" filter.

Why clicking the download arrow fixes it temporarily: `StartDownload` goes through `_start_download` which calls `resolve_existing_model` → `is_model_directory_complete`. That verification uses the safetensors index on disk (`_scan_model_directory`), not the HF tree API, so it correctly reports "complete". But 60 s later the periodic scan runs again and demotes it.

Why other large models don't trigger this: they happen not to contain any file for which HF's tree API returns `size=None`. Kimi K2.5 does, presumably because of its size/structure (384 safetensor shards plus custom Python modeling files and assorted configs).

## The fix

In `download_shard`, when `file.size is None` we have no authoritative remote size to compare against — but we still know whether the file exists on disk. File existence is a strictly stronger signal than absence of HF-reported size info, so the check becomes:

```python
status="complete"
if final_file_exists
and (file.size is None or downloaded_bytes == file.size)
else "not_started",
```

The `total` field is also adjusted from a hard-coded `0` to the on-disk byte count in the `size=None` case, so the UI shows an accurate total.

All other verification paths are untouched. In particular, `_download_file` (the active-download path that verifies hashes and sizes during actual downloads) is unchanged — this PR only loosens the no-remote-size-available branch of the passive status check.

## Tests

Three new regression tests in `TestSkipDownloadStatusWithMissingSize`:

| Test | Asserts |
|---|---|
| `test_status_complete_when_file_size_is_none` | Fully-downloaded model with a `size=None` entry reports `"complete"` |
| `test_status_not_started_when_file_with_none_size_missing` | A file with `size=None` that's **missing** on disk still reports `"not_started"` — the fix only waives size-verification, not existence-verification |
| `test_status_not_started_when_sized_file_size_mismatch` | A genuine size mismatch on a sized file still reports `"not_started"` (no regression) |

All three pass; existing 44 download-module tests continue to pass; full non-slow test suite (364 tests) passes.

## Why I can't verify end-to-end

I don't have the hardware to reproduce the original report (no 2× Mac Studio, no 612 GB free for Kimi K2.5). The fix is derived from reading the code path, and the unit tests encode the exact scenario (`FileListEntry(path=..., size=None)` + file present on disk). Verification against a real Kimi K2.5 download would be valuable before merge.

## Checklist

- [x] `uv run ruff check` passes
- [x] `uv run basedpyright` passes with 0 errors, 0 warnings
- [x] `uv run ruff format --check` passes
- [x] `uv run pytest` passes (364 passed, 1 skipped, 154 deselected)
- [ ] `nix fmt` — not available in my dev environment; `ruff format` was used as the Python-side proxy
- [x] Single focused change per CONTRIBUTING.md
