### PR TITLE
Expose sampling_defaults on /v1/models

### DIFF
--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -1675,6 +1675,7 @@ class API:
                     base_model=card.base_model,
                     capabilities=card.capabilities,
                     context_length=card.context_length,
+                    sampling_defaults=card.sampling_defaults,
                 )
                 for card in cards
             ]

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel, Field, field_validator
 
-from exo.shared.models.model_cards import ModelCard, ModelId
+from exo.shared.models.model_cards import ModelCard, ModelId, SamplingDefaults
 from exo.shared.types.common import CommandId, NodeId
 from exo.shared.types.memory import Memory
 from exo.shared.types.text_generation import ReasoningEffort
@@ -48,6 +48,7 @@ class ModelListModel(BaseModel):
     quantization: str = Field(default="")
     base_model: str = Field(default="")
     capabilities: list[str] = Field(default_factory=list)
+    sampling_defaults: SamplingDefaults | None = None
 
 
 class ModelList(BaseModel):


### PR DESCRIPTION
#1947 added `[sampling_defaults]` blocks to model cards, but the `/v1/models` response schema didn't include the field — the parsed defaults never made it over the wire to clients.

This wires `ModelCard.sampling_defaults` through `ModelListModel` so clients can surface or apply the recommended per-mode sampling values without re-reading the TOMLs themselves.