### PR TITLE
Handle missing total_size in safetensors index files

### DIFF
--- a/src/exo/download/tests/test_safetensors_index.py
+++ b/src/exo/download/tests/test_safetensors_index.py
@@ -1,0 +1,35 @@
+"""Tests for safetensors index file parsing."""
+
+from exo.shared.types.worker.downloads import ModelSafetensorsIndex
+
+
+def test_safetensors_index_missing_total_size():
+    """Index files from image models (e.g. FLUX/mflux) have metadata without
+    a total_size field — they use quantization_level and mflux_version instead.
+
+    This must parse successfully — a previous bug caused Pydantic validation to
+    fail silently (total_size was a required PositiveInt), which made
+    _scan_model_directory skip weight-map checks and report incomplete models
+    as complete.
+    """
+    raw = '{"metadata": {"quantization_level": "4", "mflux_version": "0.3.0"}, "weight_map": {"layer.safetensors": "layer.safetensors"}}'
+    index = ModelSafetensorsIndex.model_validate_json(raw)
+    assert index.metadata is not None
+    assert index.metadata.total_size is None
+    assert index.weight_map == {"layer.safetensors": "layer.safetensors"}
+
+
+def test_safetensors_index_valid_total_size():
+    """Standard text model index files with a valid total_size should continue
+    to parse correctly."""
+    raw = '{"metadata": {"total_size": 12345}, "weight_map": {"a.safetensors": "a.safetensors"}}'
+    index = ModelSafetensorsIndex.model_validate_json(raw)
+    assert index.metadata is not None
+    assert index.metadata.total_size == 12345
+
+
+def test_safetensors_index_null_metadata():
+    """Index files with null metadata should parse correctly."""
+    raw = '{"metadata": null, "weight_map": {"a.safetensors": "a.safetensors"}}'
+    index = ModelSafetensorsIndex.model_validate_json(raw)
+    assert index.metadata is None

--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -367,7 +367,7 @@ async def fetch_safetensors_size(model_id: ModelId) -> Memory:
         index_data = ModelSafetensorsIndex.model_validate_json(await f.read())
 
     metadata = index_data.metadata
-    if metadata is not None:
+    if metadata is not None and metadata.total_size is not None:
         return Memory.from_bytes(metadata.total_size)
 
     info = model_info(model_id)

--- a/src/exo/shared/types/worker/downloads.py
+++ b/src/exo/shared/types/worker/downloads.py
@@ -53,7 +53,7 @@ DownloadProgress = (
 
 
 class ModelSafetensorsIndexMetadata(BaseModel):
-    total_size: PositiveInt
+    total_size: PositiveInt | None = None
 
 
 class ModelSafetensorsIndex(BaseModel):


### PR DESCRIPTION
## Motivation

Image models fail to load after a mid-download instance deletion and recreation. The system skips the download and crashes with `FileNotFoundError: No safetensors files found in .../vae`.

## Changes

- Make `ModelSafetensorsIndexMetadata.total_size` optional (`PositiveInt | None = None`)
- Add null guard in `fetch_safetensors_size`
- Add regression test

## Why It Works

Exolabs quantized image models have safetensors index files with mflux metadata (`quantization_level`, `mflux_version`) but no `total_size`. The required `PositiveInt` field caused Pydantic validation to fail, which was silently swallowed by `except Exception: continue` in `_scan_model_directory`. This skipped all weight map checks, making incomplete models appear complete.

## Test Plan

### Manual Testing

- Hardware: Mac Studio
- Before: `CreateRunner → LoadModel` (crash). After: `CreateRunner → DownloadModel` (correct).

### Automated Testing

- `test_safetensors_index.py`: 3 cases covering missing, valid, and null metadata
