### PR TITLE
fix(api): honor use_prefix_cache on /v1/chat/completions

### DIFF
--- a/src/exo/api/adapters/chat_completions.py
+++ b/src/exo/api/adapters/chat_completions.py
@@ -168,6 +168,7 @@ async def chat_request_to_text_generation(
         min_p=request.min_p,
         repetition_penalty=request.repetition_penalty,
         repetition_context_size=request.repetition_context_size,
+        use_prefix_cache=request.use_prefix_cache,
         images=images,
     )
 

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -230,10 +230,11 @@ class ChatCompletionRequest(BaseModel):
     tool_choice: str | dict[str, Any] | None = None
     parallel_tool_calls: bool | None = None
     user: str | None = None
+    use_prefix_cache: bool = False
 
 
 class BenchChatCompletionRequest(ChatCompletionRequest):
-    use_prefix_cache: bool = False
+    pass
 
 
 class AddCustomModelParams(BaseModel):


### PR DESCRIPTION
## Summary

`POST /v1/chat/completions` silently dropped the `use_prefix_cache` request field because it was declared only on `BenchChatCompletionRequest`, not on `ChatCompletionRequest`. Pydantic discarded the unknown field, and `chat_request_to_text_generation()` didn't pass it through — so every production task landed with `use_prefix_cache=False` regardless of what clients sent. Prefix caching was effectively disabled for any real OpenAI-compat workload.

This PR moves the field up to `ChatCompletionRequest` (inherited by the bench subclass, so no behavior change to `/bench/chat/completions`) and wires it through the adapter to `TextGenerationTaskParams`.

## Changes

- `src/exo/api/types/api.py`: add `use_prefix_cache: bool = False` to `ChatCompletionRequest`; `BenchChatCompletionRequest` now inherits it rather than redeclaring.
- `src/exo/api/adapters/chat_completions.py`: pass `use_prefix_cache=request.use_prefix_cache` into `TextGenerationTaskParams`.

Net diff: +3 / -1.

## Why this matters — agent-swarm workloads

#1888 noted that prefix caching across chat-template turns often doesn't help because template re-formatting breaks cache continuity within a single conversation. Agreed for that case.

But agent-swarm workloads have a different sharing pattern: N independent sessions sharing a common system prompt + tool spec. That's a stable prefix across sessions, not within one conversation — the chat-template discontinuity doesn't apply, and prefix caching gives massive speedups.

### Measured impact (2× M3 Ultra, `mlx-community/Qwen3.6-35B-A3B-8bit`, v1.0.70)

Using `/bench/chat/completions` with `use_prefix_cache: true` and a 4,464-token prompt (system + tool spec + context, realistic for an agent turn):

| Run | Wall time | `prefix_cache_hit` | Energy |
|---|---|---|---|
| 1 (cold) | 2.94s | `none` | 230 J |
| 2 (warm) | 0.72s | `exact` | 123 J |
| 3 (warm) | 0.67s | `exact` | 101 J |

**4.4× faster and 2.3× less energy on cache hits.** Flag-gating confirmed (same prompt, toggling the flag):

| Flag | Wall time | `prefix_cache_hit` |
|---|---|---|
| `false` | 2.50s | `none` |
| `true` (cold slot) | 2.22s | `none` |
| `false` | 2.17s | `none` |
| `true` (warm slot) | **0.57s** | **`exact`** |

For a 24-agent swarm sending ~20–30k-token turns, extrapolation suggests roughly **1–2s vs. 15+s per turn** between a cache hit and a cold prefill — practically the difference between a usable and unusable swarm.

## Reproduce the original bug (pre-fix)

```bash
curl -X POST http://localhost:52415/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "mlx-community/Qwen3.6-35B-A3B-8bit",
    "messages": [{"role":"user","content":"hi"}],
    "use_prefix_cache": true
  }'
```

Server log:
```
TextGenerationTaskParams(..., use_prefix_cache=False, ...)
```

## Test plan

- [ ] CI checks pass (type, lint, format, existing tests)
- [ ] Manual verification on local exo: `use_prefix_cache=True` appears in task params when client passes the flag
- [ ] `/bench/chat/completions` behavior unchanged (same inherited field, same bench handler override)

Happy to add an adapter-level unit test if maintainers would like — didn't find an existing `test_chat_completions.py` to extend naturally, so left it out of this minimal change.

## Bonus (separate PR candidate)

`generation_stats.prefix_cache_hit` on `/bench/chat/completions` is a great observability signal. Exposing it on `/v1/chat/completions` (e.g., as an `X-Prefix-Cache-Hit` response header) would let operators observe cache hit rate in production. Would file separately if of interest.
