### PR TITLE
fix(dashboard): treat RunnerIdle as ready status

### DIFF
--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -1902,6 +1902,7 @@
           RunnerLoaded: "Loaded",
           RunnerWarmingUp: "WarmingUp",
           RunnerReady: "Ready",
+          RunnerIdle: "Idle",
           RunnerRunning: "Running",
           RunnerShutdown: "Shutdown",
           RunnerFailed: "Failed",
@@ -1954,6 +1955,7 @@
       return { statusText: "WARMING UP", statusClass: "starting" };
     if (has("Running"))
       return { statusText: "RUNNING", statusClass: "running" };
+    if (has("Idle")) return { statusText: "READY", statusClass: "loaded" };
     if (has("Ready")) return { statusText: "READY", statusClass: "loaded" };
     if (has("Loaded")) return { statusText: "LOADED", statusClass: "loaded" };
     if (has("WaitingForModel"))


### PR DESCRIPTION
## Summary
- map RunnerIdle in dashboard instance status derivation
- treat RunnerIdle as READY so active instances do not display as PREPARING

## Why
Runners can report RunnerIdle between requests. This state was not handled, which produced false PREPARING status in the dashboard.

## Validation
- dashboard build succeeds
- state-based status derivation resolves RunnerIdle to READY
