### PR TITLE
fix: skip KV cache quantization in single-node BatchGenerator mode

### DIFF
--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -417,6 +417,37 @@ def get_memory_used_percentage() -> float:
     return float(mem.percent / 100)
 
 
+def _model_is_pipeline_parallel(model: Model) -> bool:
+    """True iff the model has pipeline-parallel layer wrappers installed.
+
+    Only the PP path is safe to combine with QuantizedKVCache right now:
+    the single-node BatchGenerator code path in mlx-lm calls
+    ``_merge_caches`` on every step (even for a single in-flight request),
+    and QuantizedKVCache does not implement ``merge``. Attempting to use
+    a quantized cache in that path crashes with::
+
+        <class 'mlx_lm.models.cache.QuantizedKVCache'> does not yet
+        support batching with history
+
+    Detecting PP mode by layer type is cheap and avoids threading the
+    distributed group through every cache call site.
+    """
+    try:
+        from exo.worker.engines.mlx.auto_parallel import (
+            PipelineFirstLayer,
+            PipelineLastLayer,
+        )
+    except Exception:
+        return False
+    layers = getattr(model, "layers", None)
+    if layers is None:
+        return False
+    for layer in layers:  # type: ignore[reportUnknownVariableType]
+        if isinstance(layer, (PipelineFirstLayer, PipelineLastLayer)):
+            return True
+    return False
+
+
 def make_kv_cache(
     model: Model, max_kv_size: int | None = None, keep: int = 0
 ) -> KVCacheType:
@@ -427,8 +458,14 @@ def make_kv_cache(
         return model.make_cache()  # type: ignore
 
     if max_kv_size is None:
-        if KV_CACHE_BITS is None:
-            logger.info("Using default KV cache")
+        if KV_CACHE_BITS is None or not _model_is_pipeline_parallel(model):
+            if KV_CACHE_BITS is not None:
+                logger.info(
+                    f"EXO_KV_CACHE_BITS={KV_CACHE_BITS} ignored in single-node mode "
+                    f"(QuantizedKVCache has no merge() support, required by BatchGenerator)"
+                )
+            else:
+                logger.info("Using default KV cache")
             return [KVCache() for _ in model.layers]
         else:
             logger.info("Using quantized KV cache")


### PR DESCRIPTION
Single-node inference crashed with:
  `ValueError: <class 'mlx_lm.models.cache.QuantizedKVCache'> does not yet support batching with history`

mlx-lm's BatchGenerator calls `_merge_caches` on every step — even when there's only one prompt in flight — and that helper requires every layer's cache to implement `.merge()`. `QuantizedKVCache` has no merge implementation, so any single-node inference with `EXO_KV_CACHE_BITS` set crashes on the first real request.

Fix: only build `QuantizedKVCache` when the model is actually running in PP mode (detected by PipelineFirstLayer/PipelineLastLayer wrappers). Single-node falls back to vanilla KVCache, and logs that `EXO_KV_CACHE_BITS` is being ignored so the operator can see what's happening. Fixes #1875.