### PR TITLE
feat: peer-to-peer model distribution

### DIFF
--- a/dashboard/src/lib/stores/app.svelte.ts
+++ b/dashboard/src/lib/stores/app.svelte.ts
@@ -3257,11 +3257,11 @@ class AppStore {
   }
 
   /**
-   * Cancel/pause an active download on a specific node
+   * Pause an active download on a specific node
    */
-  async cancelDownload(nodeId: string, modelId: string): Promise<void> {
+  async pauseDownload(nodeId: string, modelId: string): Promise<void> {
     try {
-      const response = await fetch("/download/cancel", {
+      const response = await fetch("/download/pause", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -3272,11 +3272,11 @@ class AppStore {
       if (!response.ok) {
         const errorText = await response.text();
         throw new Error(
-          `Failed to cancel download: ${response.status} - ${errorText}`,
+          `Failed to pause download: ${response.status} - ${errorText}`,
         );
       }
     } catch (error) {
-      console.error("Error cancelling download:", error);
+      console.error("Error pausing download:", error);
       throw error;
     }
   }
@@ -3502,8 +3502,8 @@ export const resetImageGenerationParams = () =>
 // Download actions
 export const startDownload = (nodeId: string, shardMetadata: object) =>
   appStore.startDownload(nodeId, shardMetadata);
-export const cancelDownload = (nodeId: string, modelId: string) =>
-  appStore.cancelDownload(nodeId, modelId);
+export const pauseDownload = (nodeId: string, modelId: string) =>
+  appStore.pauseDownload(nodeId, modelId);
 export const deleteDownload = (nodeId: string, modelId: string) =>
   appStore.deleteDownload(nodeId, modelId);
 

--- a/dashboard/src/routes/downloads/+page.svelte
+++ b/dashboard/src/routes/downloads/+page.svelte
@@ -9,7 +9,7 @@
     refreshState,
     lastUpdate as lastUpdateStore,
     startDownload,
-    cancelDownload,
+    pauseDownload,
     deleteDownload,
   } from "$lib/stores/app.svelte";
   import {
@@ -572,7 +572,7 @@
                             type="button"
                             class="text-white/50 hover:text-exo-yellow transition-colors cursor-pointer"
                             onclick={() =>
-                              cancelDownload(col.nodeId, row.modelId)}
+                              pauseDownload(col.nodeId, row.modelId)}
                             title="Pause download"
                           >
                             {@render pauseIcon()}

--- a/docs/p2p-model-distribution.md
+++ b/docs/p2p-model-distribution.md
@@ -1,0 +1,151 @@
+# Peer-to-peer model distribution
+
+When more than one node in a cluster needs the same model, exo can have
+nodes that already hold the weights serve them to peers over the local
+network instead of every node fetching independently from HuggingFace.
+On a Thunderbolt-meshed cluster this means a 200 GB model is pulled from
+the internet exactly once and then fans out at link-local speed.
+
+## How it works
+
+Each node runs a small HTTP file server on `EXO_FILE_SERVER_PORT`
+(default `52416`) that serves files under any configured model directory
+(`EXO_MODELS_DIRS` and `EXO_MODELS_READ_ONLY_DIRS`). When a node is
+asked to download a model, the master and the worker both consult
+`find_peer_repo_url` (`src/exo/download/peer_discovery.py`):
+
+1. Look at the global `download_status` for any peer that is in
+   `DownloadCompleted` for that exact model.
+2. From that peer's `node_network` info, pick the best routable IPv4
+   address, ranking interface types
+   `thunderbolt > maybe_ethernet > ethernet > everything else`.
+   IPv6, loopback (`127.0.0.0/8`) and IPv4 link-local
+   (`169.254.0.0/16`) addresses are skipped.
+3. Return `http://<peer-ip>:<port>` as the `repo_url` to use for the
+   download.
+
+If no peer has the model, `repo_url` is left `None` and the downloader
+falls through to the existing HuggingFace flow.
+
+The downloader (`_download_file_from_peer` in
+`src/exo/download/download_utils.py`) shells out to `curl` with
+`-C -` (auto-resume) and `-f` (fail-fast on HTTP error). Per-file
+parallelism is bumped to 16 concurrent files when running against a
+peer (vs the conservative HF default), since the bottleneck is local
+NIC throughput rather than HF rate limits.
+
+## Configuration
+
+| Env var | Default | Effect |
+|---|---|---|
+| `EXO_FILE_SERVER_PORT` | `52416` | TCP port the per-node file server listens on. |
+| `EXO_FILE_SERVER_BIND_HOST` | `0.0.0.0` | Interface the file server binds to. Set to `127.0.0.1` to disable P2P serving on this node, or a specific interface IP to narrow exposure. |
+| `EXO_FILE_SERVER_MAX_CONCURRENCY` | `64` | Cap on concurrent in-flight serves. Excess requests get 503 with `Retry-After: 1`. Sized for a 4-peer fan-out × 16 files-per-peer concurrent download (matches the receiver's per-shard parallelism). |
+| `EXO_MODELS_DIRS` | `~/.cache/exo/models` | Colon-separated writable model dirs. The file server will look for each requested model in each of these. |
+| `EXO_MODELS_READ_ONLY_DIRS` | _(empty)_ | Colon-separated read-only model dirs (e.g. NFS mirrors). Also served by the file server. |
+
+## Runtime requirement
+
+The peer-to-peer download path shells out to `curl`. It must be on
+`$PATH` of every worker that wants to use P2P. macOS and most Linux
+distros ship it preinstalled; on a minimal container image you'll
+need `apt-get install curl` (or equivalent) before the worker starts.
+
+If `curl` is missing, downloads will fall through to the HuggingFace
+path (no P2P speedup), but the existing flow continues to work.
+
+## Security stance
+
+**The file server has no authentication.** Anything you put in
+`EXO_MODELS_DIRS` or `EXO_MODELS_READ_ONLY_DIRS` is served to anyone
+who can reach `EXO_FILE_SERVER_PORT` on the host. The server binds to
+`0.0.0.0` by default because peer IPs are discovered dynamically from
+each node's `NodeNetworkInfo`, so the binding can't be narrowed in
+advance.
+
+This is intentional for the assumed deployment — a private cluster on
+trusted infrastructure (a dedicated Thunderbolt mesh, a private VPC)
+where the operator already controls who can reach the host. **Do not
+expose `EXO_FILE_SERVER_PORT` on a host reachable from the public
+internet** without putting your own auth proxy in front of it.
+
+If you need a tighter posture:
+
+- Block the port at the host firewall (`pf` / `nftables`) and only
+  allow the IP range your peer mesh actually uses.
+- Run exo nodes inside a private VPC / VPN and never expose
+  `EXO_FILE_SERVER_PORT` on a public interface.
+- Set a non-default `EXO_FILE_SERVER_PORT` to dodge naive scanners,
+  though this is obfuscation, not a control.
+
+### What the server does and doesn't defend against
+
+It does:
+
+- Pin every served file to a *specific normalized model subdirectory*,
+  not just to "somewhere under a model dir". A `..`-style traversal
+  that escapes that subdirectory — even sideways into another model
+  inside the same root — is rejected with 404, not by erroring out
+  on the symptom but by checking `is_relative_to` against the exact
+  expected subdir.
+- Reject HTTP traversal sent at the byte level (literal `..`).
+  We test this with a raw-socket request, not aiohttp's URL-normalizing
+  test client, because clients silently collapse `..` and would
+  otherwise hide a server-side bug.
+- Quietly ignore malformed `Range` headers (`bytes=abc-`,
+  `bytes=10-20,30-40`, suffix-form `bytes=-100`) instead of crashing
+  the request handler. Pre-fix this was a trivial DoS — a single
+  malformed header raised an uncaught `ValueError`.
+- Refuse to echo request-path bytes back in error responses.
+  `text/plain` makes XSS-by-itself unlikely, but reflecting attacker
+  input is bad practice and we don't.
+
+It does (continued):
+
+- **Hash-verify P2P-downloaded bytes when the source has a sidecar.**
+  After the HF download path completes its own SHA256 check, it
+  writes a `<file>.sha256` sidecar next to the file. The file server
+  reads the sidecar and emits its contents in an `X-File-SHA256`
+  response header. The receiver captures the header (via
+  `curl -D <file>` so it's a single round-trip), hashes the
+  downloaded bytes, and refuses to rename `.partial` → final on
+  mismatch. The outer retry loop re-invokes the download, and `-C -`
+  auto-resumes — but on a hash mismatch we delete the partial first,
+  so the retry effectively starts over (and may switch peers if a
+  different one is available). When the source has no sidecar (older
+  build, file fetched before sidecar-writing landed) the header is
+  omitted and the receiver proceeds without verification, logged at
+  debug. This catches transmission corruption and disk-side decay on
+  the source. It does **not** defend against a *compromised* peer
+  that recomputes the hash of substituted bytes.
+- **Cap concurrent serves.** A misbehaving peer that spawns enough
+  parallel `curl` fetches to saturate the host gets bounced with
+  `503 Retry-After: 1` once `EXO_FILE_SERVER_MAX_CONCURRENCY` is
+  reached. The receiver's existing retry loop handles the 503 by
+  re-issuing curl, which auto-resumes — so over-cap requests don't
+  lose any bytes, they just queue at the receiver instead of
+  amplifying memory pressure on the server.
+
+It doesn't:
+
+- **Defend against a malicious peer.** Hash verification only
+  protects integrity *given* an honest sidecar. A compromised peer
+  can compute and serve a hash for whatever bytes it likes. The trust
+  boundary remains "every node in your cluster is trusted." If that
+  trust ever breaks, you have bigger problems than P2P weight
+  distribution.
+- **Rate-limit total bandwidth.** The concurrency cap limits the
+  number of in-flight serves, not the bytes/sec each one can move.
+  This is intentional — on a TB-mesh the entire point is to use the
+  full link bandwidth. If you need bytes/sec throttling, do it at
+  the OS (`tc`/`pf`) level.
+
+## State machine note
+
+This PR also separates the `DownloadPaused` state from
+`DownloadPending`. Cancelling an active download was previously
+modelled as a transition back to `DownloadPending`, the same state
+used for "we haven't started yet"; this conflated _paused with bytes
+on disk_ with _never ran_. The two are now distinct, and the
+worker plan loop deliberately doesn't auto-restart `DownloadPaused`
+the way it does `DownloadPending`.

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -81,6 +81,8 @@ from exo.api.types import (
     ImageSize,
     ModelList,
     ModelListModel,
+    PauseDownloadParams,
+    PauseDownloadResponse,
     PlaceInstanceParams,
     PlacementPreview,
     PlacementPreviewResponse,
@@ -368,6 +370,7 @@ class API:
         self.app.get("/state/{path:path}")(self.get_state)
         self.app.get("/events")(self.stream_events)
         self.app.post("/download/start")(self.start_download)
+        self.app.post("/download/pause")(self.pause_download)
         self.app.delete("/download/{node_id}/{model_id:path}")(self.delete_download)
         self.app.post("/download/cancel")(self.cancel_download)
         self.app.get("/v1/traces")(self.list_traces)
@@ -1895,6 +1898,16 @@ class API:
         )
         await self._send_download(command)
         return StartDownloadResponse(command_id=command.command_id)
+
+    async def pause_download(
+        self, payload: PauseDownloadParams
+    ) -> PauseDownloadResponse:
+        command = CancelDownload(
+            target_node_id=payload.target_node_id,
+            model_id=ModelId(payload.model_id),
+        )
+        await self._send_download(command)
+        return PauseDownloadResponse(command_id=command.command_id)
 
     async def delete_download(
         self, node_id: NodeId, model_id: ModelId

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -117,6 +117,7 @@ from exo.api.types.openai_responses import (
     ResponsesRequest,
     ResponsesResponse,
 )
+from exo.download.peer_discovery import find_peer_repo_url
 from exo.master.image_store import ImageStore
 from exo.master.placement import place_instance as get_instance_placements
 from exo.shared.apply import apply
@@ -1881,9 +1882,16 @@ class API:
     async def start_download(
         self, payload: StartDownloadParams
     ) -> StartDownloadResponse:
+        repo_url = payload.repo_url or find_peer_repo_url(
+            node_id=payload.target_node_id,
+            model_id=str(payload.shard_metadata.model_card.model_id),
+            global_download_status=self.state.downloads,
+            node_network=self.state.node_network,
+        )
         command = StartDownload(
             target_node_id=payload.target_node_id,
             shard_metadata=payload.shard_metadata,
+            repo_url=repo_url,
         )
         await self._send_download(command)
         return StartDownloadResponse(command_id=command.command_id)

--- a/src/exo/api/types/__init__.py
+++ b/src/exo/api/types/__init__.py
@@ -39,6 +39,8 @@ from .api import LogprobsContentItem as LogprobsContentItem
 from .api import ModelList as ModelList
 from .api import ModelListModel as ModelListModel
 from .api import NodePowerStats as NodePowerStats
+from .api import PauseDownloadParams as PauseDownloadParams
+from .api import PauseDownloadResponse as PauseDownloadResponse
 from .api import PlaceInstanceParams as PlaceInstanceParams
 from .api import PlacementPreview as PlacementPreview
 from .api import PlacementPreviewResponse as PlacementPreviewResponse

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -441,6 +441,15 @@ class CancelDownloadResponse(FrozenModel):
     command_id: CommandId
 
 
+class PauseDownloadParams(FrozenModel):
+    target_node_id: NodeId
+    model_id: ModelId
+
+
+class PauseDownloadResponse(FrozenModel):
+    command_id: CommandId
+
+
 class TraceEventResponse(FrozenModel):
     name: str
     start_us: int

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -421,6 +421,7 @@ class ImageListResponse(BaseModel, frozen=True):
 class StartDownloadParams(FrozenModel):
     target_node_id: NodeId
     shard_metadata: ShardMetadata
+    repo_url: str | None = None
 
 
 class StartDownloadResponse(FrozenModel):

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -33,6 +33,7 @@ from exo.shared.types.worker.downloads import (
     DownloadCompleted,
     DownloadFailed,
     DownloadOngoing,
+    DownloadPaused,
     DownloadPending,
     DownloadProgress,
 )
@@ -162,7 +163,7 @@ class DownloadCoordinator:
 
     async def _cancel_download(self, model_id: ModelId) -> None:
         if model_id in self.active_downloads and model_id in self.download_status:
-            logger.info(f"Cancelling download for {model_id}")
+            logger.info(f"Pausing download for {model_id}")
             self.active_downloads[model_id].cancel()
             current_status = self.download_status[model_id]
             downloaded = Memory()
@@ -170,16 +171,16 @@ class DownloadCoordinator:
             if isinstance(current_status, DownloadOngoing):
                 downloaded = current_status.download_progress.downloaded
                 total = current_status.download_progress.total
-            pending = DownloadPending(
+            paused = DownloadPaused(
                 shard_metadata=current_status.shard_metadata,
                 node_id=self.node_id,
                 model_directory=self._default_model_dir(model_id),
                 downloaded=downloaded,
                 total=total,
             )
-            self.download_status[model_id] = pending
+            self.download_status[model_id] = paused
             await self.event_sender.send(
-                NodeDownloadProgress(download_progress=pending)
+                NodeDownloadProgress(download_progress=paused)
             )
 
     async def _start_download(self, shard: ShardMetadata, repo_url: str | None = None) -> None:

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -153,8 +153,8 @@ class DownloadCoordinator:
                     continue
 
                 match cmd.command:
-                    case StartDownload(shard_metadata=shard):
-                        await self._start_download(shard)
+                    case StartDownload(shard_metadata=shard, repo_url=repo_url):
+                        await self._start_download(shard, repo_url=repo_url)
                     case DeleteDownload(model_id=model_id):
                         await self._delete_download(model_id)
                     case CancelDownload(model_id=model_id):
@@ -182,7 +182,7 @@ class DownloadCoordinator:
                 NodeDownloadProgress(download_progress=pending)
             )
 
-    async def _start_download(self, shard: ShardMetadata) -> None:
+    async def _start_download(self, shard: ShardMetadata, repo_url: str | None = None) -> None:
         model_id = shard.model_card.model_id
 
         # Check if already downloading, complete, or recently failed
@@ -259,10 +259,10 @@ class DownloadCoordinator:
             return
 
         # Start actual download
-        self._start_download_task(shard, initial_progress)
+        self._start_download_task(shard, initial_progress, repo_url=repo_url)
 
     def _start_download_task(
-        self, shard: ShardMetadata, initial_progress: RepoDownloadProgress
+        self, shard: ShardMetadata, initial_progress: RepoDownloadProgress, repo_url: str | None = None
     ) -> None:
         model_id = shard.model_card.model_id
 
@@ -281,7 +281,7 @@ class DownloadCoordinator:
         async def download_wrapper(cancel_scope: anyio.CancelScope) -> None:
             try:
                 with cancel_scope:
-                    await self.shard_downloader.ensure_shard(shard)
+                    await self.shard_downloader.ensure_shard(shard, repo_url=repo_url)
             except Exception as e:
                 logger.error(f"Download failed for {model_id}: {e}")
                 failed = DownloadFailed(

--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import hashlib
 import os
 import shutil
@@ -525,6 +526,53 @@ async def calc_hash(path: Path, hash_type: Literal["sha1", "sha256"] = "sha1") -
     return hasher.hexdigest()
 
 
+def _sha256_sidecar_path(file_path: Path) -> Path:
+    """Sidecar location for caching a SHA256 hex digest next to its file.
+
+    A separate ``<file>.sha256`` lets the P2P file server emit
+    ``X-File-SHA256`` without re-hashing on every request, and lets the
+    receiver verify what it just downloaded against the same hash the
+    source node verified at HF-download time.
+    """
+    return file_path.with_suffix(file_path.suffix + ".sha256")
+
+
+async def write_sha256_sidecar(file_path: Path, digest: str) -> None:
+    """Best-effort write of a SHA256 sidecar. Failures are logged but never
+    raise — a missing sidecar just means peers downloading from this node
+    won't get hash verification, not that the file itself is bad."""
+    sidecar = _sha256_sidecar_path(file_path)
+    try:
+        async with aiofiles.open(sidecar, "w") as f:
+            await f.write(digest + "\n")
+    except OSError as e:
+        logger.warning(f"Could not write sha256 sidecar for {file_path}: {e}")
+
+
+def _parse_x_file_sha256(headers_text: str) -> str | None:
+    """Pull the ``X-File-SHA256`` value out of a curl ``-D`` header dump.
+
+    Curl with ``-C -`` (resume) may produce more than one response in the
+    dump if the server redirects or the resume protocol does a separate
+    HEAD; we walk the lines and take the *last* matching header so the
+    final response wins.
+    """
+    found: str | None = None
+    for raw_line in headers_text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        prefix, _, value = line.partition(":")
+        if prefix.strip().lower() == "x-file-sha256":
+            value = value.strip()
+            if (
+                len(value) == 64
+                and all(c in "0123456789abcdef" for c in value.lower())
+            ):
+                found = value
+    return found
+
+
 async def file_meta(
     model_id: ModelId, revision: str, path: str, redirected_location: str | None = None
 ) -> tuple[int, str]:
@@ -570,12 +618,15 @@ async def download_file_with_retry(
     on_progress: Callable[[int, int, bool], None] = lambda _, __, ___: None,
     on_connection_lost: Callable[[], None] = lambda: None,
     skip_internet: bool = False,
+    repo_url: str | None = None,
+    session: aiohttp.ClientSession | None = None,
+    expected_size: int = 0,
 ) -> Path:
     n_attempts = 3
     for attempt in range(n_attempts):
         try:
             return await _download_file(
-                model_id, revision, path, target_dir, on_progress, skip_internet
+                model_id, revision, path, target_dir, on_progress, skip_internet, repo_url=repo_url, session=session, expected_size=expected_size
             )
         except HuggingFaceAuthenticationError:
             raise
@@ -610,11 +661,14 @@ async def _download_file(
     target_dir: Path,
     on_progress: Callable[[int, int, bool], None] = lambda _, __, ___: None,
     skip_internet: bool = False,
+    repo_url: str | None = None,
+    session: aiohttp.ClientSession | None = None,
+    expected_size: int = 0,
 ) -> Path:
     target_path = target_dir / path
 
     if await aios.path.exists(target_path):
-        if skip_internet:
+        if skip_internet or repo_url:
             return target_path
 
         local_size = (await aios.stat(target_path)).st_size
@@ -642,6 +696,14 @@ async def _download_file(
         )
 
     await aios.makedirs((target_dir / path).parent, exist_ok=True)
+
+    if repo_url:
+        # P2P download from peer file server — no auth, no hash verification
+        # Don't share the HF session; P2P is local with no TLS overhead
+        return await _download_file_from_peer(
+            repo_url, model_id, path, target_dir, on_progress, total_bytes=expected_size
+        )
+
     length, etag = await file_meta(model_id, revision, path)
     remote_hash = etag[:-5] if etag.endswith("-gzip") else etag
     partial_path = target_dir / f"{path}.partial"
@@ -656,28 +718,35 @@ async def _download_file(
         if resume_byte_pos:
             headers["Range"] = f"bytes={resume_byte_pos}-"
         n_read = resume_byte_pos or 0
-        async with (
-            create_http_session(timeout_profile="long") as session,
-            session.get(url, headers=headers) as r,
-        ):
-            if r.status == 404:
-                raise FileNotFoundError(f"File not found: {url}")
-            if r.status in [401, 403]:
-                msg = await _build_auth_error_message(r.status, model_id)
-                raise HuggingFaceAuthenticationError(msg)
-            assert r.status in [200, 206], (
-                f"Failed to download {path} from {url}: {r.status}"
-            )
-            async with aiofiles.open(
-                partial_path, "ab" if resume_byte_pos else "wb"
-            ) as f:
-                while chunk := await r.content.read(8 * 1024 * 1024):
-                    n_read = n_read + (await f.write(chunk))
-                    on_progress(n_read, length, False)
 
-    final_hash = await calc_hash(
-        partial_path, hash_type="sha256" if len(remote_hash) == 64 else "sha1"
+        async def _do_hf_download(s: aiohttp.ClientSession) -> None:
+            nonlocal n_read
+            async with s.get(url, headers=headers) as r:
+                if r.status == 404:
+                    raise FileNotFoundError(f"File not found: {url}")
+                if r.status in [401, 403]:
+                    msg = await _build_auth_error_message(r.status, model_id)
+                    raise HuggingFaceAuthenticationError(msg)
+                assert r.status in [200, 206], (
+                    f"Failed to download {path} from {url}: {r.status}"
+                )
+                async with aiofiles.open(
+                    partial_path, "ab" if resume_byte_pos else "wb"
+                ) as f:
+                    while chunk := await r.content.read(8 * 1024 * 1024):
+                        n_read = n_read + (await f.write(chunk))
+                        on_progress(n_read, length, False)
+
+        if session is not None:
+            await _do_hf_download(session)
+        else:
+            async with create_http_session(timeout_profile="long") as fallback_session:
+                await _do_hf_download(fallback_session)
+
+    hash_type: Literal["sha1", "sha256"] = (
+        "sha256" if len(remote_hash) == 64 else "sha1"
     )
+    final_hash = await calc_hash(partial_path, hash_type=hash_type)
     integrity = final_hash == remote_hash
     if not integrity:
         try:
@@ -687,9 +756,127 @@ async def _download_file(
         raise Exception(
             f"Downloaded file {target_dir / path} has hash {final_hash} but remote hash is {remote_hash}"
         )
-    await aios.rename(partial_path, target_dir / path)
+    target_path = target_dir / path
+    await aios.rename(partial_path, target_path)
+    # If HF gave us a SHA256 (LFS-tracked safetensors etc.), drop a sidecar so
+    # this node can serve the file to peers via the P2P file server with an
+    # ``X-File-SHA256`` header. SHA1 etags (small text files) are skipped —
+    # those don't need P2P integrity verification, they're tiny and re-fetch
+    # from HF if anything looks off.
+    if hash_type == "sha256":
+        await write_sha256_sidecar(target_path, final_hash)
     on_progress(length, length, True)
-    return target_dir / path
+    return target_path
+
+
+async def _download_file_from_peer(
+    repo_url: str,
+    model_id: ModelId,
+    path: str,
+    target_dir: Path,
+    on_progress: Callable[[int, int, bool], None] = lambda _, __, ___: None,
+    total_bytes: int = 0,
+) -> Path:
+    """Download a file from a peer's file server over the local network.
+
+    Uses curl subprocess for zero-copy transfer — data goes from socket to
+    disk entirely in C without passing through Python.
+
+    Verification: if the peer's response includes an ``X-File-SHA256``
+    header, we hash the downloaded bytes after the transfer and refuse to
+    rename ``.partial → final`` unless they match. The header is best-effort
+    on the server side (only present when the source node has a sidecar);
+    if absent we skip verification, log debug, and proceed. The outer
+    retry loop in :func:`download_file_with_retry` re-invokes us on any
+    failure (non-zero curl exit, hash mismatch, 503 from the server when
+    it's at its concurrency cap), and ``-C -`` auto-resumes from whatever
+    bytes the previous attempt landed.
+    """
+    target_path = target_dir / path
+    url = f"{repo_url}/{model_id}/{path}"
+    partial_path = target_dir / f"{path}.partial"
+    headers_dump = target_dir / f"{path}.headers"
+
+    # Build curl command: -C - auto-resume, -f fail on HTTP errors,
+    # -D headers_dump capture response headers (so we can read X-File-SHA256
+    # without a second round-trip).
+    cmd = [
+        "curl", "-f", "-s", "-C", "-",
+        "-D", str(headers_dump),
+        "-o", str(partial_path),
+        url,
+    ]
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    async def _poll_progress() -> None:
+        while True:
+            await asyncio.sleep(2)
+            try:
+                if await aios.path.exists(partial_path):
+                    current_size = (await aios.stat(partial_path)).st_size
+                    if total_bytes > 0:
+                        on_progress(current_size, total_bytes, False)
+            except OSError:
+                pass
+
+    progress_task = asyncio.create_task(_poll_progress())
+    try:
+        _, stderr_bytes = await proc.communicate()
+    finally:
+        progress_task.cancel()
+
+    expected_sha = await _read_header_dump_sha256(headers_dump)
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"curl failed for {url} (exit {proc.returncode}): {stderr_bytes.decode().strip()}"
+        )
+
+    if expected_sha is not None:
+        actual_sha = await calc_hash(partial_path, hash_type="sha256")
+        if actual_sha != expected_sha:
+            with contextlib.suppress(OSError):
+                await aios.remove(partial_path)
+            raise RuntimeError(
+                f"P2P hash mismatch for {url}: peer reported {expected_sha}, "
+                f"got {actual_sha} after download (will retry)"
+            )
+    else:
+        logger.debug(
+            f"P2P peer {repo_url} did not report X-File-SHA256 for {path}; "
+            "skipping integrity check"
+        )
+
+    final_size = (await aios.stat(partial_path)).st_size
+    await aios.rename(partial_path, target_path)
+    if expected_sha is not None:
+        # Persist the verified hash so this node can in turn serve the file
+        # to other peers with the same X-File-SHA256 header.
+        await write_sha256_sidecar(target_path, expected_sha)
+    on_progress(final_size, final_size, True)
+    logger.info(f"P2P download complete: {path} from {repo_url}")
+    return target_path
+
+
+async def _read_header_dump_sha256(headers_dump: Path) -> str | None:
+    """Read ``curl -D <file>`` output and pull out X-File-SHA256.
+
+    The dump file is removed afterward (best-effort — leaving it around is
+    harmless but clutters target_dir). Returns None on any read error or
+    when the header is absent."""
+    try:
+        async with aiofiles.open(headers_dump, "r") as f:
+            text = await f.read()
+    except OSError:
+        return None
+    with contextlib.suppress(OSError):
+        await aios.remove(headers_dump)
+    return _parse_x_file_sha256(text)
 
 
 def calculate_repo_progress(
@@ -809,6 +996,7 @@ async def download_shard(
     skip_internet: bool = False,
     allow_patterns: list[str] | None = None,
     on_connection_lost: Callable[[], None] = lambda: None,
+    repo_url: str | None = None,
 ) -> tuple[Path, RepoDownloadProgress]:
     if not skip_download:
         logger.debug(f"Downloading {shard.model_card.model_id=}")
@@ -958,7 +1146,9 @@ async def download_shard(
             start_time=time.time(),
         )
 
-    semaphore = asyncio.Semaphore(max_parallel_downloads)
+    # P2P can handle more parallelism than HF CDN, but don't spawn too many processes
+    effective_parallelism = min(16, len(filtered_file_list)) if repo_url else max_parallel_downloads
+    semaphore = asyncio.Semaphore(effective_parallelism)
 
     def schedule_progress(
         file: FileListEntry, curr_bytes: int, total_bytes: int, is_renamed: bool
@@ -967,7 +1157,9 @@ async def download_shard(
             on_progress_wrapper(file, curr_bytes, total_bytes, is_renamed)
         )
 
-    async def download_with_semaphore(file: FileListEntry) -> None:
+    async def download_with_semaphore(
+        file: FileListEntry, session: aiohttp.ClientSession
+    ) -> None:
         async with semaphore:
             await download_file_with_retry(
                 model_id,
@@ -979,12 +1171,16 @@ async def download_shard(
                 ),
                 on_connection_lost=on_connection_lost,
                 skip_internet=skip_internet,
+                repo_url=repo_url,
+                session=session,
+                expected_size=file.size or 0,
             )
 
     if not skip_download:
-        await asyncio.gather(
-            *[download_with_semaphore(file) for file in filtered_file_list]
-        )
+        async with create_http_session(timeout_profile="long") as session:
+            await asyncio.gather(
+                *[download_with_semaphore(file, session) for file in filtered_file_list]
+            )
     final_repo_progress = calculate_repo_progress(
         shard, model_id, revision, file_progress, all_start_time
     )

--- a/src/exo/download/file_server.py
+++ b/src/exo/download/file_server.py
@@ -1,0 +1,239 @@
+"""Lightweight HTTP file server for peer-to-peer model transfer.
+
+Serves model files from EXO_MODELS_DIRS so that peer nodes can download
+model weights over the local network (e.g. Thunderbolt) instead of from
+HuggingFace.
+
+Listens on EXO_FILE_SERVER_PORT (default 52416). Concurrent serves are
+capped at EXO_FILE_SERVER_MAX_CONCURRENCY (default 64); requests beyond
+the cap get 503 with Retry-After: 1 so the receiver's retry loop picks
+them up. When a sidecar ``<file>.sha256`` exists, its contents are
+returned in an ``X-File-SHA256`` response header so the receiver can
+verify the bytes after download.
+"""
+
+import asyncio
+from pathlib import Path
+
+from aiohttp import web
+from loguru import logger
+
+from exo.shared.constants import (
+    EXO_FILE_SERVER_BIND_HOST,
+    EXO_FILE_SERVER_MAX_CONCURRENCY,
+    EXO_FILE_SERVER_PORT,
+    EXO_MODELS_DIRS,
+    EXO_MODELS_READ_ONLY_DIRS,
+)
+
+# Read buffer size when streaming a file out. Large enough to amortize
+# per-chunk overhead, small enough that N concurrent serves don't crush
+# RAM on a heavily-loaded node.
+_STREAM_CHUNK_SIZE = 1 * 1024 * 1024  # 1 MiB
+
+# Lazily-initialized so we share one semaphore across the lifetime of a
+# single ``run_file_server()`` call but always create a fresh one in tests.
+_serve_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_semaphore() -> asyncio.Semaphore:
+    global _serve_semaphore
+    if _serve_semaphore is None:
+        _serve_semaphore = asyncio.Semaphore(EXO_FILE_SERVER_MAX_CONCURRENCY)
+    return _serve_semaphore
+
+
+def _all_model_dirs() -> list[str]:
+    """Return all model directories (writable + read-only) as resolved strings."""
+    seen: set[str] = set()
+    dirs: list[str] = []
+    for d in (*EXO_MODELS_DIRS, *EXO_MODELS_READ_ONLY_DIRS):
+        resolved = str(d.resolve())
+        if resolved not in seen:
+            seen.add(resolved)
+            dirs.append(resolved)
+    return dirs
+
+
+def _resolve_safe(model_dir: str, normalized: str, file_path: str) -> Path | None:
+    """Resolve ``<model_dir>/<normalized>/<file_path>`` and return it only if
+    the result is still inside the *specific* normalized model subdirectory.
+
+    This rejects path-traversal attempts that escape upward (``..``) into a
+    sibling model's directory, even though that sibling is technically inside
+    ``model_dir``. Returns None on any traversal escape, missing file, or OS
+    error.
+    """
+    model_root = Path(model_dir).resolve()
+    expected_subdir = (model_root / normalized).resolve()
+    candidate = (model_root / normalized / file_path).resolve()
+    try:
+        if not candidate.is_relative_to(expected_subdir):
+            return None
+        if not candidate.is_file():
+            return None
+    except (ValueError, OSError):
+        return None
+    return candidate
+
+
+def _read_sidecar_sha256(file_path: Path) -> str | None:
+    """Return the contents of ``<file>.sha256`` (a SHA256 hex digest) if the
+    sidecar exists alongside ``file_path``. Used to populate the
+    ``X-File-SHA256`` response header so peers can verify downloaded bytes
+    against the same hash the source node verified at HF-download time.
+
+    Sidecar absent → returns ``None`` (no header is sent; receiver downloads
+    without verification, logging a debug message). Never computes the hash
+    on demand — that would block the request handler for tens of seconds on
+    a multi-GB safetensors file.
+    """
+    sidecar = file_path.with_suffix(file_path.suffix + ".sha256")
+    try:
+        if not sidecar.is_file():
+            return None
+        text = sidecar.read_text().strip()
+    except OSError:
+        return None
+    # Defensive: a SHA256 hex digest is exactly 64 chars of [0-9a-f]. Reject
+    # anything that doesn't match that shape so we never echo random bytes
+    # back as a hash header.
+    if len(text) != 64 or not all(c in "0123456789abcdef" for c in text.lower()):
+        return None
+    return text
+
+
+def _parse_range_start(range_header: str | None) -> int | None:
+    """Parse a ``Range: bytes=<n>-`` header and return the start offset, or
+    ``None`` if the header is absent / malformed / unsupported.
+
+    Only prefix-form (``bytes=N-``) is supported; suffix-form (``bytes=-N``)
+    and multi-range are not. Malformed headers (non-numeric, negative,
+    non-``bytes=`` unit) do not raise — callers treat ``None`` as "serve
+    the whole file from offset 0".
+    """
+    if not range_header or not range_header.startswith("bytes="):
+        return None
+    spec = range_header[len("bytes="):]
+    if "," in spec:  # multi-range — we don't support
+        return None
+    range_parts = spec.split("-", 1)
+    if len(range_parts) != 2 or not range_parts[0]:
+        return None
+    try:
+        start = int(range_parts[0])
+    except ValueError:
+        return None
+    if start < 0:
+        return None
+    return start
+
+
+async def _handle_model_file(request: web.Request) -> web.StreamResponse:
+    """Serve a model file: GET /{org}/{model}/{file_path}
+
+    ``model_id`` is exactly two URL segments (e.g.
+    ``mlx-community/Qwen3.5-397B-A17B-nvfp4``); on disk it's normalized with
+    ``--`` (``mlx-community--Qwen3.5-397B-A17B-nvfp4``). Supports HTTP Range
+    requests in prefix form (``bytes=N-``) for resumable downloads.
+
+    Concurrency cap: at most ``EXO_FILE_SERVER_MAX_CONCURRENCY`` of these run
+    at once; further requests get 503 with ``Retry-After: 1`` and the
+    receiver's outer retry loop re-issues the curl, auto-resuming via
+    ``-C -``.
+
+    Security boundary: the resolved file path must live inside the requested
+    model's specific normalized subdirectory. ``..`` traversal that escapes
+    that subdirectory — even into a sibling model under the same ``model_dir``
+    root — is rejected with 404. Error responses do not echo the request path
+    back to the client.
+    """
+    semaphore = _get_semaphore()
+    if semaphore.locked():
+        # Already at the cap — fail fast rather than queueing requests
+        # indefinitely (queued requests still hold an aiohttp connection
+        # and amplify memory pressure).
+        raise web.HTTPServiceUnavailable(
+            text="Server busy", headers={"Retry-After": "1"}
+        )
+
+    async with semaphore:
+        return await _serve(request)
+
+
+async def _serve(request: web.Request) -> web.StreamResponse:
+    full_match = request.match_info["path"]
+    parts = full_match.split("/", 2)
+    if len(parts) < 3:
+        raise web.HTTPNotFound(text="Not found")
+
+    model_id = f"{parts[0]}/{parts[1]}"
+    file_path = parts[2]
+    normalized = model_id.replace("/", "--")
+
+    full_path: Path | None = None
+    for model_dir in _all_model_dirs():
+        full_path = _resolve_safe(model_dir, normalized, file_path)
+        if full_path is not None:
+            break
+
+    if full_path is None:
+        raise web.HTTPNotFound(text="Not found")
+
+    file_size = full_path.stat().st_size
+
+    start = _parse_range_start(request.headers.get("Range")) or 0
+
+    if start >= file_size and start != 0:
+        raise web.HTTPRequestRangeNotSatisfiable(
+            headers={"Content-Range": f"bytes */{file_size}"}
+        )
+
+    remaining = file_size - start
+    status = 206 if start > 0 else 200
+
+    headers: dict[str, str] = {
+        "Content-Length": str(remaining),
+        "Content-Type": "application/octet-stream",
+        "Accept-Ranges": "bytes",
+    }
+    if start > 0:
+        headers["Content-Range"] = f"bytes {start}-{file_size - 1}/{file_size}"
+    sha256 = _read_sidecar_sha256(full_path)
+    if sha256:
+        headers["X-File-SHA256"] = sha256
+
+    response = web.StreamResponse(status=status, headers=headers)
+    await response.prepare(request)
+
+    with open(full_path, "rb") as f:
+        if start > 0:
+            f.seek(start)
+        while True:
+            chunk = f.read(_STREAM_CHUNK_SIZE)
+            if not chunk:
+                break
+            await response.write(chunk)
+
+    await response.write_eof()
+    return response
+
+
+async def run_file_server() -> None:
+    """Start the model file server on EXO_FILE_SERVER_PORT."""
+    app = web.Application()
+    app.router.add_get("/{path:.*}", _handle_model_file)
+
+    runner = web.AppRunner(app, access_log=None)
+    await runner.setup()
+    site = web.TCPSite(runner, EXO_FILE_SERVER_BIND_HOST, EXO_FILE_SERVER_PORT)
+    try:
+        await site.start()
+        logger.info(
+            f"Model file server listening on "
+            f"{EXO_FILE_SERVER_BIND_HOST}:{EXO_FILE_SERVER_PORT} "
+            f"(max_concurrency={EXO_FILE_SERVER_MAX_CONCURRENCY})"
+        )
+        await asyncio.Event().wait()
+    finally:
+        await runner.cleanup()

--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -68,11 +68,11 @@ class SingletonShardDownloader(ShardDownloader):
         self.shard_downloader.on_progress(callback)
 
     async def ensure_shard(
-        self, shard: ShardMetadata, config_only: bool = False
+        self, shard: ShardMetadata, config_only: bool = False, repo_url: str | None = None
     ) -> Path:
         if shard not in self.active_downloads:
             self.active_downloads[shard] = asyncio.create_task(
-                self.shard_downloader.ensure_shard(shard, config_only)
+                self.shard_downloader.ensure_shard(shard, config_only, repo_url=repo_url)
             )
         try:
             return await self.active_downloads[shard]
@@ -113,7 +113,7 @@ class ResumableShardDownloader(ShardDownloader):
         self.on_progress_callbacks.append(callback)
 
     async def ensure_shard(
-        self, shard: ShardMetadata, config_only: bool = False
+        self, shard: ShardMetadata, config_only: bool = False, repo_url: str | None = None
     ) -> Path:
         allow_patterns = ["config.json"] if config_only else None
 
@@ -137,6 +137,7 @@ class ResumableShardDownloader(ShardDownloader):
             max_parallel_downloads=self.max_parallel_downloads,
             allow_patterns=allow_patterns,
             skip_internet=self.offline,
+            repo_url=repo_url,
         )
 
         if has_vision_sibling:

--- a/src/exo/download/peer_discovery.py
+++ b/src/exo/download/peer_discovery.py
@@ -1,0 +1,96 @@
+"""Peer discovery for P2P model downloads.
+
+Given the global download status and per-node network information, find a
+peer that already holds a fully-downloaded copy of a model and return the
+URL of its file server. The caller can then point its downloader at that
+URL instead of HuggingFace.
+"""
+
+from collections.abc import Mapping, Sequence
+
+from exo.shared.constants import EXO_FILE_SERVER_PORT
+from exo.shared.types.common import NodeId
+from exo.shared.types.profiling import NodeNetworkInfo
+from exo.shared.types.worker.downloads import DownloadCompleted, DownloadProgress
+
+# Lower number = preferred. Anything not in this map gets the default below.
+# `maybe_ethernet` is preferred over confirmed `ethernet` because on macOS
+# Thunderbolt bridges often land in the maybe_ethernet bucket; on a TB-mesh
+# cluster these are the high-bandwidth paths we actually want to ride.
+_INTERFACE_PRIORITY: dict[str, int] = {
+    "thunderbolt": 0,
+    "maybe_ethernet": 1,
+    "ethernet": 2,
+}
+_DEFAULT_INTERFACE_PRIORITY = 10
+
+
+def find_peer_repo_url(
+    node_id: NodeId,
+    model_id: str,
+    global_download_status: Mapping[NodeId, Sequence[DownloadProgress]],
+    node_network: Mapping[NodeId, NodeNetworkInfo],
+) -> str | None:
+    """Return ``http://<best-peer-ip>:<port>`` if a peer has the model, else None.
+
+    Selection rules:
+      - Skip the requester itself.
+      - Only consider peers in DownloadCompleted for the requested model.
+      - Skip peers with no network info or no interfaces.
+      - Skip IPv6 addresses, link-local IPv4 (169.254.*) and loopback (127.*).
+      - Prefer interface types in this order: thunderbolt > ethernet >
+        maybe_ethernet > everything else.
+      - Among multiple matching peers, the first one yielded by the mapping
+        wins (Python dict insertion order is stable, so this is deterministic
+        for a given input).
+    """
+    for peer_id, peer_downloads in global_download_status.items():
+        if peer_id == node_id:
+            continue
+        if not _peer_has_model(peer_downloads, model_id):
+            continue
+        ip = _best_peer_ip(node_network.get(peer_id))
+        if ip is not None:
+            return f"http://{ip}:{EXO_FILE_SERVER_PORT}"
+    return None
+
+
+def _peer_has_model(
+    peer_downloads: Sequence[DownloadProgress], model_id: str
+) -> bool:
+    return any(
+        isinstance(dp, DownloadCompleted)
+        and dp.shard_metadata.model_card.model_id == model_id
+        for dp in peer_downloads
+    )
+
+
+def _best_peer_ip(net_info: NodeNetworkInfo | None) -> str | None:
+    if net_info is None or not net_info.interfaces:
+        return None
+    best_ip: str | None = None
+    best_priority = _DEFAULT_INTERFACE_PRIORITY + 1
+    for iface in net_info.interfaces:
+        ip = iface.ip_address
+        if not _ip_is_routable(ip):
+            continue
+        priority = _INTERFACE_PRIORITY.get(
+            iface.interface_type, _DEFAULT_INTERFACE_PRIORITY
+        )
+        if priority < best_priority:
+            best_ip = ip
+            best_priority = priority
+    return best_ip
+
+
+def _ip_is_routable(ip: str) -> bool:
+    """True if ``ip`` is an IPv4 address we can reach from another host.
+
+    We deliberately reject:
+      - IPv6 (aiohttp/curl on some hosts won't dial fe80:: link-local)
+      - 127.0.0.0/8 (loopback — peer-on-self isn't useful)
+      - 169.254.0.0/16 (RFC 3927 link-local, often unconfigured)
+    """
+    if ":" in ip:
+        return False
+    return not ip.startswith(("fe80", "127.", "169.254."))

--- a/src/exo/download/shard_downloader.py
+++ b/src/exo/download/shard_downloader.py
@@ -18,7 +18,7 @@ from exo.shared.types.worker.shards import (
 class ShardDownloader(ABC):
     @abstractmethod
     async def ensure_shard(
-        self, shard: ShardMetadata, config_only: bool = False
+        self, shard: ShardMetadata, config_only: bool = False, repo_url: str | None = None
     ) -> Path:
         """
         Ensures that the shard is downloaded.
@@ -56,7 +56,7 @@ class ShardDownloader(ABC):
 
 class NoopShardDownloader(ShardDownloader):
     async def ensure_shard(
-        self, shard: ShardMetadata, config_only: bool = False
+        self, shard: ShardMetadata, config_only: bool = False, repo_url: str | None = None
     ) -> Path:
         return Path("/tmp/noop_shard")
 

--- a/src/exo/download/tests/test_cancel_download.py
+++ b/src/exo/download/tests/test_cancel_download.py
@@ -66,6 +66,7 @@ class SlowShardDownloader(ShardDownloader):
         self,
         shard: ShardMetadata,
         config_only: bool = False,  # noqa: ARG002
+        repo_url: str | None = None,  # noqa: ARG002
     ) -> Path:
         # Fire an in-progress callback, then block forever (until cancelled)
         progress = RepoDownloadProgress(

--- a/src/exo/download/tests/test_cancel_download.py
+++ b/src/exo/download/tests/test_cancel_download.py
@@ -20,7 +20,7 @@ from exo.shared.types.commands import (
 from exo.shared.types.common import NodeId, SystemId
 from exo.shared.types.events import Event, NodeDownloadProgress
 from exo.shared.types.memory import Memory
-from exo.shared.types.worker.downloads import DownloadPending
+from exo.shared.types.worker.downloads import DownloadPaused
 from exo.shared.types.worker.shards import PipelineShardMetadata, ShardMetadata
 from exo.utils.channels import Receiver, Sender, channel
 
@@ -150,17 +150,17 @@ def _setup_coordinator(
     return coordinator, cmd_send, event_recv
 
 
-async def _wait_for_pending(
+async def _wait_for_paused(
     event_recv: Receiver[Event], model_id: ModelId, timeout: float = 2.0
-) -> DownloadPending | None:
-    """Drain events until we see a DownloadPending for the given model, or timeout."""
+) -> DownloadPaused | None:
+    """Drain events until we see a DownloadPaused for the given model, or timeout."""
     try:
         async with asyncio.timeout(timeout):
             while True:
                 event = await event_recv.receive()
                 if (
                     isinstance(event, NodeDownloadProgress)
-                    and isinstance(event.download_progress, DownloadPending)
+                    and isinstance(event.download_progress, DownloadPaused)
                     and event.download_progress.shard_metadata.model_card.model_id
                     == model_id
                 ):
@@ -170,7 +170,7 @@ async def _wait_for_pending(
 
 
 async def test_cancel_active_download_transitions_to_pending() -> None:
-    """Cancelling an in-progress download should emit a DownloadPending event
+    """Cancelling an in-progress download should emit a DownloadPaused event
     and remove the model from active_downloads."""
     slow_downloader = SlowShardDownloader()
     coordinator, cmd_send, event_recv = _setup_coordinator(slow_downloader)
@@ -190,7 +190,7 @@ async def test_cancel_active_download_transitions_to_pending() -> None:
         # Wait for the download to actually start (blocking in ensure_shard)
         await asyncio.wait_for(slow_downloader.download_started.wait(), timeout=2.0)
 
-        # Drain any events emitted before the cancel (initial DownloadPending, DownloadOngoing)
+        # Drain any events emitted before the cancel (initial DownloadPaused, DownloadOngoing)
         while True:
             try:
                 async with asyncio.timeout(0.1):
@@ -206,9 +206,9 @@ async def test_cancel_active_download_transitions_to_pending() -> None:
             )
         )
 
-        # Should receive a DownloadPending event with preserved progress
-        pending = await _wait_for_pending(event_recv, MODEL_ID)
-        assert pending is not None, "Cancel should emit DownloadPending"
+        # Should receive a DownloadPaused event with preserved progress
+        pending = await _wait_for_paused(event_recv, MODEL_ID)
+        assert pending is not None, "Pause should emit DownloadPaused"
         assert pending.shard_metadata.model_card.model_id == MODEL_ID
         assert pending.total == Memory.from_mb(100), "Should preserve total bytes"
 
@@ -219,7 +219,7 @@ async def test_cancel_active_download_transitions_to_pending() -> None:
         assert MODEL_ID not in coordinator.active_downloads
         # But should still be in download_status as pending
         assert MODEL_ID in coordinator.download_status
-        assert isinstance(coordinator.download_status[MODEL_ID], DownloadPending)
+        assert isinstance(coordinator.download_status[MODEL_ID], DownloadPaused)
     finally:
         await coordinator.shutdown()
         coordinator_task.cancel()
@@ -243,8 +243,8 @@ async def test_cancel_nonexistent_download_is_noop() -> None:
             )
         )
 
-        # Should NOT receive any DownloadPending event
-        pending = await _wait_for_pending(event_recv, MODEL_ID, timeout=0.5)
+        # Should NOT receive any DownloadPaused event
+        pending = await _wait_for_paused(event_recv, MODEL_ID, timeout=0.5)
         assert pending is None, "Cancel of non-existent download should not emit events"
 
         # Coordinator state should be empty
@@ -282,8 +282,8 @@ async def test_cancel_then_resume_download() -> None:
                 command=CancelDownload(target_node_id=NODE_ID, model_id=MODEL_ID),
             )
         )
-        pending = await _wait_for_pending(event_recv, MODEL_ID)
-        assert pending is not None, "Cancel should emit DownloadPending"
+        pending = await _wait_for_paused(event_recv, MODEL_ID)
+        assert pending is not None, "Pause should emit DownloadPaused"
 
         await asyncio.sleep(0.05)
 

--- a/src/exo/download/tests/test_download_status_not_lost.py
+++ b/src/exo/download/tests/test_download_status_not_lost.py
@@ -77,6 +77,7 @@ class FakeShardDownloader(ShardDownloader):
         self,
         shard: ShardMetadata,
         config_only: bool = False,  # noqa: ARG002
+        repo_url: str | None = None,  # noqa: ARG002
     ) -> Path:
         return MODEL_DIR  # pragma: no cover
 

--- a/src/exo/download/tests/test_file_server.py
+++ b/src/exo/download/tests/test_file_server.py
@@ -1,0 +1,523 @@
+# pyright: reportPrivateUsage = false, reportMissingTypeArgument = false, reportUnknownParameterType = false, reportUnknownMemberType = false, reportUnknownVariableType = false, reportAny = false
+
+"""Tests for the P2P model file server.
+
+We don't bind to a real port — instead we mount the file_server's URL
+handler in an aiohttp `TestServer` so each test gets a fresh in-process
+server with a local tmp_path standing in for the model directories.
+"""
+
+import asyncio
+import socket
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from exo.download import file_server
+
+
+def _write_model_file(model_dir: Path, model_id: str, file_path: str, content: bytes) -> Path:
+    """Create a fake model file at ``<model_dir>/<normalized-id>/<file_path>``
+    and return the absolute path."""
+    normalized = model_id.replace("/", "--")
+    target = model_dir / normalized / file_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    return target
+
+
+@pytest_asyncio.fixture
+async def client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[tuple[Any, Path]]:
+    """Spin up an in-process server that uses ``tmp_path`` as its only
+    model directory. Yields ``(test_client, model_dir)`` so each test
+    can both write fixture files and make HTTP requests."""
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    monkeypatch.setattr(file_server, "EXO_MODELS_DIRS", (model_dir,))
+    monkeypatch.setattr(file_server, "EXO_MODELS_READ_ONLY_DIRS", ())
+
+    app = web.Application()
+    app.router.add_get("/{path:.*}", file_server._handle_model_file)
+
+    async with TestClient(TestServer(app)) as test_client:
+        yield test_client, model_dir
+
+
+# ---- happy paths ------------------------------------------------------------
+
+
+async def test_serves_existing_file(client: tuple[Any, Path]) -> None:
+    payload = b"hello world" * 1000
+    _write_model_file(client[1], "test-org/m1", "model.safetensors", payload) 
+
+    async with client[0].get("/test-org/m1/model.safetensors") as resp:
+        assert resp.status == 200
+        assert resp.headers["Content-Length"] == str(len(payload))
+        assert resp.headers["Accept-Ranges"] == "bytes"
+        assert await resp.read() == payload
+
+
+async def test_nested_subdirectory_path(client: tuple[Any, Path]) -> None:
+    """Files inside subdirectories of the model (e.g. tokenizer/, configs/)
+    should be served — the path after model_id can have any depth."""
+    payload = b"nested"
+    _write_model_file(
+        client[1], 
+        "test-org/m1",
+        "tokenizer/special_tokens_map.json",
+        payload,
+    )
+    async with client[0].get(
+        "/test-org/m1/tokenizer/special_tokens_map.json"
+    ) as resp:
+        assert resp.status == 200
+        assert await resp.read() == payload
+
+
+# ---- range requests ---------------------------------------------------------
+
+
+async def test_range_request_returns_206_partial(client: tuple[Any, Path]) -> None:
+    payload = b"0123456789" * 1000  # 10000 bytes
+    _write_model_file(client[1], "test-org/m1", "weights.bin", payload) 
+
+    async with client[0].get(
+        "/test-org/m1/weights.bin", headers={"Range": "bytes=2000-"}
+    ) as resp:
+        assert resp.status == 206
+        assert resp.headers["Content-Length"] == str(len(payload) - 2000)
+        assert (
+            resp.headers["Content-Range"]
+            == f"bytes 2000-{len(payload) - 1}/{len(payload)}"
+        )
+        assert await resp.read() == payload[2000:]
+
+
+async def test_range_request_at_zero_returns_200_not_206(client: tuple[Any, Path]) -> None:
+    """A `Range: bytes=0-` header is technically a range request but covers
+    the whole file. The server returns 200, not 206 — matches what
+    curl/aiohttp produce when streaming a fresh download."""
+    payload = b"AB" * 50
+    _write_model_file(client[1], "test-org/m1", "f.bin", payload) 
+
+    async with client[0].get(
+        "/test-org/m1/f.bin", headers={"Range": "bytes=0-"}
+    ) as resp:
+        assert resp.status == 200
+        assert "Content-Range" not in resp.headers
+        assert await resp.read() == payload
+
+
+async def test_range_past_end_returns_416(client: tuple[Any, Path]) -> None:
+    payload = b"short"
+    _write_model_file(client[1], "test-org/m1", "f.bin", payload) 
+
+    async with client[0].get(
+        "/test-org/m1/f.bin", headers={"Range": "bytes=1000-"}
+    ) as resp:
+        assert resp.status == 416
+        assert resp.headers.get("Content-Range") == f"bytes */{len(payload)}"
+
+
+# ---- error paths ------------------------------------------------------------
+
+
+async def test_missing_file_returns_404(client: tuple[Any, Path]) -> None:
+    async with client[0].get("/test-org/m1/never-existed.safetensors") as resp:
+        assert resp.status == 404
+
+
+async def test_missing_model_returns_404(client: tuple[Any, Path]) -> None:
+    """The file_path exists in concept but the model dir doesn't."""
+    async with client[0].get("/test-org/never-downloaded/file.bin") as resp:
+        assert resp.status == 404
+
+
+async def test_path_too_short_returns_404(client: tuple[Any, Path]) -> None:
+    """The handler requires at least three segments: org/model/file. Two
+    segments is not a valid model file URL."""
+    async with client[0].get("/just-two/segments") as resp:
+        assert resp.status == 404
+
+
+async def test_internals_resolve_safe_rejects_lateral_traversal(
+    tmp_path: Path,
+) -> None:
+    """``_resolve_safe`` must reject a ``..`` traversal that lands inside
+    a *sibling* model dir under the same ``model_dir`` root.
+
+    The previous implementation only checked ``is_relative_to(model_dir)``,
+    which allowed a sideways escape from ``<root>/foo--m1/`` into
+    ``<root>/foo--m1-ROGUE/`` because both are technically inside ``root``.
+    The current implementation pins the check to the *specific* normalized
+    subdirectory, so the lateral escape is rejected.
+
+    We test the helper directly — aiohttp client URL parsers normalize
+    ``..`` segments away client-side, which would let a buggy server
+    silently pass this test. The protocol-level test below
+    (``test_lateral_traversal_blocked_at_protocol_level``) closes that
+    loop by sending a raw HTTP request.
+    """
+    model_dir = tmp_path / "models"
+    (model_dir / "test-org--m1").mkdir(parents=True)
+    (model_dir / "test-org--m1" / "real.bin").write_bytes(b"ok")
+    (model_dir / "test-org--m1-ROGUE").mkdir()
+    rogue = model_dir / "test-org--m1-ROGUE" / "secret.txt"
+    rogue.write_bytes(b"do not leak")
+
+    # The exact attack: ask for /<requested-model>/../<sibling>/<file>.
+    assert (
+        file_server._resolve_safe(
+            str(model_dir), "test-org--m1", "../test-org--m1-ROGUE/secret.txt"
+        )
+        is None
+    )
+    # And a sanity check — the legit lookup still works.
+    found = file_server._resolve_safe(str(model_dir), "test-org--m1", "real.bin")
+    assert found is not None
+    assert found.read_bytes() == b"ok"
+
+
+async def test_internals_resolve_safe_rejects_escape_to_root(
+    tmp_path: Path,
+) -> None:
+    """Going far enough up that we leave ``model_dir`` entirely is also
+    rejected (the original ``is_relative_to(model_dir)`` check covered
+    this — keep a test so a future refactor can't regress it)."""
+    model_dir = tmp_path / "models"
+    (model_dir / "org--m1").mkdir(parents=True)
+    secret_outside = tmp_path / "outside_secret.txt"
+    secret_outside.write_bytes(b"definitely don't")
+
+    assert (
+        file_server._resolve_safe(
+            str(model_dir), "org--m1", "../../outside_secret.txt"
+        )
+        is None
+    )
+
+
+# ---- multi-directory resolution --------------------------------------------
+
+
+async def test_falls_back_across_writable_and_read_only_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A model that lives in a read-only mirror should still be servable."""
+    writable = tmp_path / "writable"
+    read_only = tmp_path / "readonly"
+    writable.mkdir()
+    read_only.mkdir()
+    monkeypatch.setattr(file_server, "EXO_MODELS_DIRS", (writable,))
+    monkeypatch.setattr(file_server, "EXO_MODELS_READ_ONLY_DIRS", (read_only,))
+
+    payload = b"from read-only mirror"
+    _write_model_file(read_only, "test-org/m1", "f.bin", payload)
+
+    app = web.Application()
+    app.router.add_get("/{path:.*}", file_server._handle_model_file)
+    async with (
+        TestClient(TestServer(app)) as test_client,
+        test_client.get("/test-org/m1/f.bin") as resp,
+    ):
+        assert resp.status == 200
+        assert await resp.read() == payload
+
+
+async def test_deduplicates_overlapping_dir_lists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same path appearing in both writable and read-only must not be visited
+    twice (otherwise the same file would be returned for the wrong reason)."""
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    monkeypatch.setattr(file_server, "EXO_MODELS_DIRS", (shared,))
+    monkeypatch.setattr(file_server, "EXO_MODELS_READ_ONLY_DIRS", (shared,))
+
+    dirs = file_server._all_model_dirs()
+    assert len(dirs) == 1
+    assert dirs[0] == str(shared.resolve())
+
+
+# ---- Range header robustness -----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        (None, None),
+        ("", None),
+        ("bytes=", None),
+        ("bytes=-", None),
+        ("bytes=-100", None),  # suffix-form not supported (yet) — None means "ignore"
+        ("bytes=abc-", None),  # non-numeric — must NOT raise
+        ("bytes=10.5-", None),  # float — must NOT raise
+        ("bytes=10-20,30-40", None),  # multi-range not supported
+        ("invalid", None),  # missing "bytes=" unit
+        ("items=10-", None),  # wrong unit
+        ("bytes=0-", 0),
+        ("bytes=10-", 10),
+        ("bytes=999999999999999-", 999999999999999),
+    ],
+)
+def test_parse_range_start(header: str | None, expected: int | None) -> None:
+    """``_parse_range_start`` must never raise on malformed input — a 500
+    here would be a trivial DoS for any peer who can hit the server. It
+    returns ``None`` for unparseable / unsupported headers so the caller
+    falls through to a normal full-file response."""
+    assert file_server._parse_range_start(header) == expected
+
+
+# ---- HTTP-protocol-level security tests ------------------------------------
+# These bypass aiohttp's URL-normalizing client by sending raw HTTP requests
+# over a socket. The path-traversal attack vector has historically been
+# masked by client-side ``..`` collapsing, so we exercise it at the byte
+# level to be sure the server's defense actually fires.
+
+
+async def _raw_http_get(port: int, request_line: bytes, headers: bytes = b"") -> bytes:
+    """Open a socket, send a literal HTTP/1.1 request, return the raw response."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect(("127.0.0.1", port))
+    s.send(request_line + b"\r\n" + headers + b"\r\n")
+    await asyncio.sleep(0.2)  # give the server a tick to write the response
+    s.settimeout(1.0)
+    data = b""
+    try:
+        while True:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+    except TimeoutError:
+        pass
+    s.close()
+    return data
+
+
+@pytest_asyncio.fixture
+async def raw_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[tuple[int, Path]]:
+    """Start a real file_server on an ephemeral port. Yields ``(port, model_dir)``."""
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    monkeypatch.setattr(file_server, "EXO_MODELS_DIRS", (model_dir,))
+    monkeypatch.setattr(file_server, "EXO_MODELS_READ_ONLY_DIRS", ())
+
+    app = web.Application()
+    app.router.add_get("/{path:.*}", file_server._handle_model_file)
+    runner = web.AppRunner(app, access_log=None)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port: int = site._server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+    try:
+        yield port, model_dir
+    finally:
+        await runner.cleanup()
+
+
+async def test_lateral_traversal_blocked_at_protocol_level(
+    raw_server: tuple[int, Path],
+) -> None:
+    """Send the actual ``..`` bytes over the wire — no client-side
+    normalization. A buggy server would 200 with the rogue file's contents."""
+    port, model_dir = raw_server
+    (model_dir / "org--m1").mkdir()
+    (model_dir / "org--m1" / "real.bin").write_bytes(b"REAL")
+    (model_dir / "org--m1-ROGUE").mkdir()
+    (model_dir / "org--m1-ROGUE" / "secret.txt").write_bytes(b"DO-NOT-LEAK")
+
+    resp = await _raw_http_get(
+        port,
+        b"GET /org/m1/../org--m1-ROGUE/secret.txt HTTP/1.1\r\nHost: x",
+    )
+    assert resp.startswith(b"HTTP/1.1 404"), resp[:80]
+    assert b"DO-NOT-LEAK" not in resp
+
+
+async def test_escape_to_filesystem_root_blocked_at_protocol_level(
+    raw_server: tuple[int, Path], tmp_path: Path
+) -> None:
+    """A traversal that escapes the model_dir entirely must also fail."""
+    port, model_dir = raw_server
+    (model_dir / "org--m1").mkdir()
+    outside = tmp_path / "outside_secret.txt"
+    outside.write_bytes(b"OUTSIDE-SECRET")
+
+    resp = await _raw_http_get(
+        port,
+        b"GET /org/m1/../../outside_secret.txt HTTP/1.1\r\nHost: x",
+    )
+    assert resp.startswith(b"HTTP/1.1 404"), resp[:80]
+    assert b"OUTSIDE-SECRET" not in resp
+
+
+async def test_malformed_range_does_not_500(
+    raw_server: tuple[int, Path],
+) -> None:
+    """A junk Range header must not crash the handler. Pre-fix this was a
+    trivial DoS — ``Range: bytes=abc-`` raised ValueError out of
+    ``int(...)`` and aiohttp returned 500."""
+    port, model_dir = raw_server
+    (model_dir / "org--m1").mkdir()
+    (model_dir / "org--m1" / "real.bin").write_bytes(b"REAL")
+
+    resp = await _raw_http_get(
+        port,
+        b"GET /org/m1/real.bin HTTP/1.1\r\nHost: x",
+        b"Range: bytes=abc-\r\n",
+    )
+    # Either 200 (header ignored — current behavior) or 416 (rejected)
+    # is fine; a 500 is not.
+    status = resp.split(b" ", 2)[1]
+    assert status in (b"200", b"416"), resp[:80]
+
+
+async def test_error_response_does_not_echo_request_path(
+    raw_server: tuple[int, Path],
+) -> None:
+    """The 404 body for a missing file must not reflect the requested path
+    back. Even though Content-Type is text/plain (so this isn't an XSS by
+    itself), reflecting attacker-controlled input is bad practice and would
+    chain badly with any client that ever rendered the response as HTML."""
+    port, _ = raw_server
+    sentinel = b"<script>alert(1)</script>"
+    resp = await _raw_http_get(
+        port,
+        b"GET /" + sentinel + b"/m1/file.bin HTTP/1.1\r\nHost: x",
+    )
+    assert resp.startswith(b"HTTP/1.1 404"), resp[:80]
+    body = resp.split(b"\r\n\r\n", 1)[1] if b"\r\n\r\n" in resp else b""
+    assert sentinel not in body, body
+
+
+# ---- X-File-SHA256 header --------------------------------------------------
+
+
+async def test_serves_x_file_sha256_when_sidecar_present(
+    client: tuple[Any, Path],
+) -> None:
+    """A ``<file>.sha256`` sidecar makes the file_server emit
+    ``X-File-SHA256`` so the receiver can verify the bytes after curl
+    finishes. The sidecar is the source of truth — we never recompute the
+    hash on the request path because that would block for tens of seconds
+    on multi-GB safetensors."""
+    payload = b"deadbeef" * 100
+    digest = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    target = client[1] / "test-org--m1" / "f.bin"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(payload)
+    target.with_suffix(".bin.sha256").write_text(digest + "\n")
+
+    async with client[0].get("/test-org/m1/f.bin") as resp:
+        assert resp.status == 200
+        assert resp.headers.get("X-File-SHA256") == digest
+        assert await resp.read() == payload
+
+
+async def test_omits_x_file_sha256_when_sidecar_absent(
+    client: tuple[Any, Path],
+) -> None:
+    """No sidecar → no header. The receiver treats this as "skip
+    verification" and proceeds (logged at debug)."""
+    _write_model_file(client[1], "test-org/m1", "f.bin", b"x")
+    async with client[0].get("/test-org/m1/f.bin") as resp:
+        assert resp.status == 200
+        assert "X-File-SHA256" not in resp.headers
+
+
+async def test_rejects_malformed_sidecar(
+    client: tuple[Any, Path],
+) -> None:
+    """A sidecar with non-hex contents (or wrong length) must be ignored
+    rather than echoed as if it were a real digest. Otherwise a corrupt
+    sidecar on the source would propagate junk hashes to peers, who would
+    then fail verification despite the bytes being fine."""
+    target = client[1] / "test-org--m1" / "f.bin"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"x")
+    # Length wrong + non-hex content
+    target.with_suffix(".bin.sha256").write_text("not a digest at all")
+
+    async with client[0].get("/test-org/m1/f.bin") as resp:
+        assert resp.status == 200
+        assert "X-File-SHA256" not in resp.headers
+
+
+# ---- concurrency cap -------------------------------------------------------
+
+
+async def test_excess_concurrent_requests_get_503(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the semaphore is at its cap, additional requests get 503 with
+    Retry-After rather than queueing forever.
+
+    We monkey-patch ``_serve`` to await an event we control, so we can
+    deterministically pin one request inside the semaphore and observe
+    the second getting rejected. (Reading from a real file races with
+    aiohttp's internal buffering and isn't reliable as a pinning
+    mechanism.)"""
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    monkeypatch.setattr(file_server, "EXO_MODELS_DIRS", (model_dir,))
+    monkeypatch.setattr(file_server, "EXO_MODELS_READ_ONLY_DIRS", ())
+    monkeypatch.setattr(file_server, "_serve_semaphore", asyncio.Semaphore(1))
+
+    release = asyncio.Event()
+
+    async def held_serve(_: web.Request) -> web.Response:
+        await release.wait()
+        return web.Response(status=200, body=b"done")
+
+    monkeypatch.setattr(file_server, "_serve", held_serve)
+
+    app = web.Application()
+    app.router.add_get("/{path:.*}", file_server._handle_model_file)
+
+    async with TestClient(TestServer(app)) as test_client:
+        # Start the first request — it'll block inside held_serve, holding
+        # the semaphore.
+        first_task = asyncio.create_task(test_client.get("/test-org/m1/f.bin"))
+        # Yield to the event loop so the first request actually enters _serve.
+        await asyncio.sleep(0.05)
+        # Second request — semaphore is locked, must come back 503.
+        async with test_client.get("/test-org/m1/f.bin") as second:
+            assert second.status == 503
+            assert second.headers.get("Retry-After") == "1"
+        # Release the held first request and confirm it completes normally.
+        release.set()
+        first_resp = await first_task
+        assert first_resp.status == 200
+        await first_resp.release()
+
+
+async def test_semaphore_releases_on_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If a serve raises (e.g. for a missing file → 404), the semaphore
+    permit must still be released so subsequent requests aren't blocked
+    forever. ``async with semaphore`` guarantees this; we lock the cap at 1
+    and verify that 100 sequential 404s don't deadlock."""
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    monkeypatch.setattr(file_server, "EXO_MODELS_DIRS", (model_dir,))
+    monkeypatch.setattr(file_server, "EXO_MODELS_READ_ONLY_DIRS", ())
+    monkeypatch.setattr(file_server, "_serve_semaphore", asyncio.Semaphore(1))
+
+    app = web.Application()
+    app.router.add_get("/{path:.*}", file_server._handle_model_file)
+
+    async with TestClient(TestServer(app)) as test_client:
+        for _ in range(100):
+            async with test_client.get("/test-org/m1/missing.bin") as resp:
+                assert resp.status == 404

--- a/src/exo/download/tests/test_p2p_download.py
+++ b/src/exo/download/tests/test_p2p_download.py
@@ -1,0 +1,360 @@
+# pyright: reportPrivateUsage = false, reportAny = false
+
+"""End-to-end test: file_server (producer) ↔ _download_file_from_peer (consumer).
+
+Spins up a real ``file_server`` on an ephemeral port and drives the curl-based
+``_download_file_from_peer`` against it. Skipped if curl is not on $PATH.
+"""
+
+import asyncio
+import hashlib
+import shutil
+import socket
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+
+from exo.download import file_server
+from exo.download.download_utils import (
+    _download_file_from_peer,
+    _parse_x_file_sha256,
+    _sha256_sidecar_path,
+)
+from exo.shared.models.model_cards import ModelId
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("curl") is None,
+    reason="curl is not installed; P2P download tests need the curl binary",
+)
+
+
+def _free_port() -> int:
+    """Bind a socket to port 0, read back the OS-assigned port, release it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest_asyncio.fixture
+async def p2p_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[tuple[str, Path]]:
+    """Start a file_server on a free port serving a tmp model directory.
+
+    Yields ``(repo_url, server_model_dir)`` so the test can write source
+    files into ``server_model_dir`` and pass ``repo_url`` to the downloader.
+    """
+    server_model_dir = tmp_path / "server_models"
+    server_model_dir.mkdir()
+    monkeypatch.setattr(file_server, "EXO_MODELS_DIRS", (server_model_dir,))
+    monkeypatch.setattr(file_server, "EXO_MODELS_READ_ONLY_DIRS", ())
+
+    port = _free_port()
+    app = web.Application()
+    app.router.add_get("/{path:.*}", file_server._handle_model_file)
+    runner = web.AppRunner(app, access_log=None)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", port)
+    await site.start()
+    try:
+        yield f"http://127.0.0.1:{port}", server_model_dir
+    finally:
+        await runner.cleanup()
+
+
+def _seed_source_file(
+    server_model_dir: Path, model_id: str, path: str, content: bytes
+) -> None:
+    normalized = model_id.replace("/", "--")
+    target = server_model_dir / normalized / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+
+
+def _seed_source_file_with_sidecar(
+    server_model_dir: Path,
+    model_id: str,
+    path: str,
+    content: bytes,
+    sidecar_override: str | None = None,
+) -> None:
+    """Seed a file plus its ``<file>.sha256`` sidecar so the file_server will
+    advertise ``X-File-SHA256`` for it. Pass ``sidecar_override`` to write
+    a deliberately-wrong hash for mismatch tests."""
+    _seed_source_file(server_model_dir, model_id, path, content)
+    normalized = model_id.replace("/", "--")
+    target = server_model_dir / normalized / path
+    digest = sidecar_override or hashlib.sha256(content).hexdigest()
+    _sha256_sidecar_path(target).write_text(digest + "\n")
+
+
+# ---- happy path ------------------------------------------------------------
+
+
+async def test_round_trip_serves_and_downloads(
+    p2p_server: tuple[str, Path], tmp_path: Path
+) -> None:
+    repo_url, server_model_dir = p2p_server
+    model_id = ModelId("test-org/round-trip")
+    payload = b"x" * (256 * 1024)  # 256 KiB
+
+    _seed_source_file(server_model_dir, str(model_id), "weights.bin", payload)
+
+    client_target_dir = tmp_path / "client_models"
+    client_target_dir.mkdir()
+
+    final = await _download_file_from_peer(
+        repo_url=repo_url,
+        model_id=model_id,
+        path="weights.bin",
+        target_dir=client_target_dir,
+    )
+
+    assert final == client_target_dir / "weights.bin"
+    assert final.read_bytes() == payload
+    # The .partial file was renamed away on success.
+    assert not (client_target_dir / "weights.bin.partial").exists()
+
+
+async def test_progress_callback_invoked(
+    p2p_server: tuple[str, Path], tmp_path: Path
+) -> None:
+    """``_download_file_from_peer`` invokes ``on_progress(curr, total, done)``
+    at least once on success (with done=True for the final call)."""
+    repo_url, server_model_dir = p2p_server
+    model_id = ModelId("test-org/progress")
+    payload = b"y" * 4096
+
+    _seed_source_file(server_model_dir, str(model_id), "f.bin", payload)
+
+    client_target_dir = tmp_path / "client_models"
+    client_target_dir.mkdir()
+
+    calls: list[tuple[int, int, bool]] = []
+
+    def _record(curr: int, total: int, done: bool) -> None:
+        calls.append((curr, total, done))
+
+    await _download_file_from_peer(
+        repo_url=repo_url,
+        model_id=model_id,
+        path="f.bin",
+        target_dir=client_target_dir,
+        on_progress=_record,
+        total_bytes=len(payload),
+    )
+
+    assert any(c[2] for c in calls), "expected at least one done=True progress call"
+    final = next(c for c in reversed(calls) if c[2])
+    assert final[0] == len(payload)
+
+
+async def test_resume_from_partial(
+    p2p_server: tuple[str, Path], tmp_path: Path
+) -> None:
+    """If a ``.partial`` file already has bytes from a previous attempt,
+    curl's ``-C -`` resumes from where it left off rather than restarting."""
+    repo_url, server_model_dir = p2p_server
+    model_id = ModelId("test-org/resume")
+    payload = b"R" * 8192
+
+    _seed_source_file(server_model_dir, str(model_id), "f.bin", payload)
+
+    client_target_dir = tmp_path / "client_models"
+    client_target_dir.mkdir()
+
+    # Pre-seed the .partial file with the first half — simulating a
+    # previously interrupted download.
+    partial = client_target_dir / "f.bin.partial"
+    partial.write_bytes(payload[: len(payload) // 2])
+
+    final = await _download_file_from_peer(
+        repo_url=repo_url,
+        model_id=model_id,
+        path="f.bin",
+        target_dir=client_target_dir,
+    )
+
+    assert final.read_bytes() == payload
+
+
+# ---- error paths -----------------------------------------------------------
+
+
+async def test_curl_raises_runtime_error_on_404(
+    p2p_server: tuple[str, Path], tmp_path: Path
+) -> None:
+    repo_url, _ = p2p_server
+    model_id = ModelId("test-org/missing")
+
+    client_target_dir = tmp_path / "client_models"
+    client_target_dir.mkdir()
+
+    with pytest.raises(RuntimeError, match="curl failed"):
+        await _download_file_from_peer(
+            repo_url=repo_url,
+            model_id=model_id,
+            path="never-existed.bin",
+            target_dir=client_target_dir,
+        )
+
+
+async def test_curl_raises_runtime_error_on_unreachable_host(
+    tmp_path: Path,
+) -> None:
+    """If the file server is not running (or the URL is wrong), the
+    subprocess exits non-zero and we surface that as a RuntimeError."""
+    model_id = ModelId("test-org/unreach")
+    client_target_dir = tmp_path / "client_models"
+    client_target_dir.mkdir()
+
+    # Bind a port to grab a number, then close it — the address should be
+    # unbound by the time curl tries to dial.
+    port = _free_port()
+
+    with pytest.raises(RuntimeError, match="curl failed"):
+        await asyncio.wait_for(
+            _download_file_from_peer(
+                repo_url=f"http://127.0.0.1:{port}",
+                model_id=model_id,
+                path="any.bin",
+                target_dir=client_target_dir,
+            ),
+            timeout=10.0,
+        )
+
+
+# ---- hash verification ----------------------------------------------------
+
+
+async def test_hash_header_emitted_when_sidecar_exists(
+    p2p_server: tuple[str, Path], tmp_path: Path
+) -> None:
+    """When the source has a ``.sha256`` sidecar, the receiver verifies the
+    downloaded bytes against it — and persists its own sidecar so it can in
+    turn serve to other peers with the same hash header."""
+    repo_url, server_model_dir = p2p_server
+    model_id = ModelId("test-org/with-hash")
+    payload = b"verify-me" * 4096
+    _seed_source_file_with_sidecar(
+        server_model_dir, str(model_id), "f.bin", payload
+    )
+
+    client_target_dir = tmp_path / "client_models"
+    client_target_dir.mkdir()
+    final = await _download_file_from_peer(
+        repo_url=repo_url,
+        model_id=model_id,
+        path="f.bin",
+        target_dir=client_target_dir,
+    )
+    assert final.read_bytes() == payload
+    # Receiver re-emitted the hash sidecar.
+    receiver_sidecar = _sha256_sidecar_path(final)
+    assert receiver_sidecar.exists()
+    assert receiver_sidecar.read_text().strip() == hashlib.sha256(payload).hexdigest()
+
+
+async def test_hash_mismatch_aborts_and_raises(
+    p2p_server: tuple[str, Path], tmp_path: Path
+) -> None:
+    """If the peer's reported X-File-SHA256 doesn't match the bytes we
+    received, the download must fail (so the outer retry loop can re-fetch),
+    the partial file must be removed, and no final file may be left in
+    target_dir for the caller to mistakenly trust."""
+    repo_url, server_model_dir = p2p_server
+    model_id = ModelId("test-org/bad-hash")
+    payload = b"these-are-the-real-bytes" * 1000
+    wrong_hash = "0" * 64  # plausible-looking SHA256 hex, won't match payload
+    _seed_source_file_with_sidecar(
+        server_model_dir,
+        str(model_id),
+        "f.bin",
+        payload,
+        sidecar_override=wrong_hash,
+    )
+
+    client_target_dir = tmp_path / "client_models"
+    client_target_dir.mkdir()
+
+    with pytest.raises(RuntimeError, match="P2P hash mismatch"):
+        await _download_file_from_peer(
+            repo_url=repo_url,
+            model_id=model_id,
+            path="f.bin",
+            target_dir=client_target_dir,
+        )
+    # The final file must NOT exist — we don't rename .partial → final on
+    # mismatch, and we delete the .partial.
+    assert not (client_target_dir / "f.bin").exists()
+    assert not (client_target_dir / "f.bin.partial").exists()
+
+
+async def test_no_hash_header_skips_verification(
+    p2p_server: tuple[str, Path], tmp_path: Path
+) -> None:
+    """If the peer doesn't have a sidecar (e.g. the source's own download
+    happened before we shipped sidecar-writing), the file_server omits the
+    header entirely. The receiver logs a debug note and proceeds — this is
+    backward-compatible with peers running an older build."""
+    repo_url, server_model_dir = p2p_server
+    model_id = ModelId("test-org/no-hash")
+    payload = b"no-sidecar-here" * 2000
+    # NB: NOT using _seed_source_file_with_sidecar — no sidecar gets written.
+    _seed_source_file(server_model_dir, str(model_id), "f.bin", payload)
+
+    client_target_dir = tmp_path / "client_models"
+    client_target_dir.mkdir()
+    final = await _download_file_from_peer(
+        repo_url=repo_url,
+        model_id=model_id,
+        path="f.bin",
+        target_dir=client_target_dir,
+    )
+    assert final.read_bytes() == payload
+    # No sidecar on receiver either, since the peer didn't advertise one.
+    assert not _sha256_sidecar_path(final).exists()
+
+
+# ---- _parse_x_file_sha256 unit tests --------------------------------------
+
+
+def test_parse_x_file_sha256_picks_last_match() -> None:
+    """If a curl ``-D`` dump contains more than one set of response headers
+    (e.g. a redirect chain), we want the *final* response's hash, not an
+    intermediate one. Walk the dump in order and let the last value win."""
+    digest_a = "a" * 64
+    digest_b = "b" * 64
+    headers_text = (
+        "HTTP/1.1 301 Moved\r\n"
+        f"X-File-SHA256: {digest_a}\r\n"
+        "\r\n"
+        "HTTP/1.1 200 OK\r\n"
+        f"X-File-SHA256: {digest_b}\r\n"
+        "\r\n"
+    )
+    assert _parse_x_file_sha256(headers_text) == digest_b
+
+
+def test_parse_x_file_sha256_rejects_non_hex_value() -> None:
+    """Defense in depth: the server-side reader also rejects non-hex values,
+    but if a malformed header somehow makes it onto the wire we must not
+    pass it on as a "valid" expected hash."""
+    headers_text = "HTTP/1.1 200 OK\r\nX-File-SHA256: definitely-not-a-hex-digest\r\n\r\n"
+    assert _parse_x_file_sha256(headers_text) is None
+
+
+def test_parse_x_file_sha256_returns_none_when_absent() -> None:
+    headers_text = "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\n\r\n"
+    assert _parse_x_file_sha256(headers_text) is None
+
+
+def test_parse_x_file_sha256_case_insensitive_header_name() -> None:
+    """HTTP header names are case-insensitive per RFC 7230. We accept any
+    casing in the curl dump."""
+    digest = "f" * 64
+    headers_text = f"HTTP/1.1 200 OK\r\nx-FILE-sha256: {digest}\r\n\r\n"
+    assert _parse_x_file_sha256(headers_text) == digest

--- a/src/exo/download/tests/test_peer_discovery.py
+++ b/src/exo/download/tests/test_peer_discovery.py
@@ -1,0 +1,302 @@
+"""Tests for peer-discovery URL selection.
+
+Each test case constructs a small synthetic state (a couple of peers, a
+download status snapshot, a network-info map) and asserts that
+`find_peer_repo_url` either returns the expected URL or `None`.
+"""
+
+from collections.abc import Mapping, Sequence
+
+from exo.download.peer_discovery import find_peer_repo_url
+from exo.shared.constants import EXO_FILE_SERVER_PORT
+from exo.shared.models.model_cards import ModelCard, ModelId, ModelTask
+from exo.shared.types.common import NodeId
+from exo.shared.types.memory import Memory
+from exo.shared.types.profiling import NetworkInterfaceInfo, NodeNetworkInfo
+from exo.shared.types.worker.downloads import (
+    DownloadCompleted,
+    DownloadOngoing,
+    DownloadPending,
+    DownloadProgress,
+    DownloadProgressData,
+)
+from exo.shared.types.worker.shards import PipelineShardMetadata, ShardMetadata
+
+NODE_SELF = NodeId("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+NODE_PEER_A = NodeId("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+NODE_PEER_B = NodeId("cccccccc-cccc-4ccc-8ccc-cccccccccccc")
+MODEL_ID = ModelId("test-org/test-model")
+OTHER_MODEL_ID = ModelId("test-org/other-model")
+
+
+def _shard(model_id: ModelId = MODEL_ID) -> ShardMetadata:
+    return PipelineShardMetadata(
+        model_card=ModelCard(
+            model_id=model_id,
+            storage_size=Memory.from_mb(100),
+            n_layers=1,
+            hidden_size=1,
+            supports_tensor=False,
+            tasks=[ModelTask.TextGeneration],
+        ),
+        device_rank=0,
+        world_size=1,
+        start_layer=0,
+        end_layer=1,
+        n_layers=1,
+    )
+
+
+def _completed(node_id: NodeId, model_id: ModelId = MODEL_ID) -> DownloadCompleted:
+    return DownloadCompleted(
+        node_id=node_id,
+        shard_metadata=_shard(model_id),
+        total=Memory.from_mb(100),
+        model_directory="",
+    )
+
+
+def _ongoing(node_id: NodeId) -> DownloadOngoing:
+    return DownloadOngoing(
+        node_id=node_id,
+        shard_metadata=_shard(),
+        model_directory="",
+        download_progress=DownloadProgressData(
+            total=Memory.from_mb(100),
+            downloaded=Memory.from_mb(50),
+            downloaded_this_session=Memory.from_mb(50),
+            completed_files=1,
+            total_files=2,
+            speed=0,
+            eta_ms=0,
+            files={},
+        ),
+    )
+
+
+def _pending(node_id: NodeId) -> DownloadPending:
+    return DownloadPending(
+        node_id=node_id,
+        shard_metadata=_shard(),
+        model_directory="",
+    )
+
+
+def _net(*ifaces: tuple[str, str]) -> NodeNetworkInfo:
+    return NodeNetworkInfo(
+        interfaces=[
+            NetworkInterfaceInfo(
+                name=f"if{idx}", ip_address=ip, interface_type=iface_type  # type: ignore[arg-type]
+            )
+            for idx, (ip, iface_type) in enumerate(ifaces)
+        ]
+    )
+
+
+def _state(
+    downloads: Mapping[NodeId, Sequence[DownloadProgress]],
+    network: Mapping[NodeId, NodeNetworkInfo],
+) -> tuple[
+    Mapping[NodeId, Sequence[DownloadProgress]],
+    Mapping[NodeId, NodeNetworkInfo],
+]:
+    return downloads, network
+
+
+# ---- "no peer found" cases --------------------------------------------------
+
+
+def test_returns_none_when_no_peers() -> None:
+    downloads, net = _state({NODE_SELF: []}, {})
+    assert find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net) is None
+
+
+def test_skips_self() -> None:
+    """Even if the requester has the model completed, it must not be returned
+    as its own peer."""
+    downloads, net = _state(
+        {NODE_SELF: [_completed(NODE_SELF)]},
+        {NODE_SELF: _net(("10.0.0.1", "ethernet"))},
+    )
+    assert find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net) is None
+
+
+def test_skips_peer_with_only_ongoing_download() -> None:
+    """A peer that is *currently downloading* the model is not yet a source."""
+    downloads, net = _state(
+        {NODE_PEER_A: [_ongoing(NODE_PEER_A)]},
+        {NODE_PEER_A: _net(("10.0.0.2", "ethernet"))},
+    )
+    assert find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net) is None
+
+
+def test_skips_peer_with_only_pending_download() -> None:
+    downloads, net = _state(
+        {NODE_PEER_A: [_pending(NODE_PEER_A)]},
+        {NODE_PEER_A: _net(("10.0.0.2", "ethernet"))},
+    )
+    assert find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net) is None
+
+
+def test_skips_peer_with_completed_other_model() -> None:
+    downloads, net = _state(
+        {NODE_PEER_A: [_completed(NODE_PEER_A, OTHER_MODEL_ID)]},
+        {NODE_PEER_A: _net(("10.0.0.2", "ethernet"))},
+    )
+    assert find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net) is None
+
+
+def test_skips_peer_with_no_network_info() -> None:
+    downloads, net = _state(
+        {NODE_PEER_A: [_completed(NODE_PEER_A)]},
+        {},  # no network info entry for the peer
+    )
+    assert find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net) is None
+
+
+def test_skips_peer_with_empty_interfaces() -> None:
+    downloads, net = _state(
+        {NODE_PEER_A: [_completed(NODE_PEER_A)]},
+        {NODE_PEER_A: NodeNetworkInfo(interfaces=[])},
+    )
+    assert find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net) is None
+
+
+def test_skips_peer_with_only_unroutable_addresses() -> None:
+    """IPv6, loopback, and link-local IPv4 are all unroutable for our purposes."""
+    downloads, net = _state(
+        {NODE_PEER_A: [_completed(NODE_PEER_A)]},
+        {
+            NODE_PEER_A: _net(
+                ("fe80::1", "ethernet"),
+                ("::1", "ethernet"),
+                ("127.0.0.1", "ethernet"),
+                ("169.254.1.1", "ethernet"),
+            )
+        },
+    )
+    assert find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net) is None
+
+
+# ---- "peer found" cases -----------------------------------------------------
+
+
+def test_returns_url_for_completed_peer() -> None:
+    downloads, net = _state(
+        {NODE_PEER_A: [_completed(NODE_PEER_A)]},
+        {NODE_PEER_A: _net(("10.0.0.2", "ethernet"))},
+    )
+    url = find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net)
+    assert url == f"http://10.0.0.2:{EXO_FILE_SERVER_PORT}"
+
+
+def test_thunderbolt_beats_ethernet() -> None:
+    """Both interfaces are routable; thunderbolt wins."""
+    downloads, net = _state(
+        {NODE_PEER_A: [_completed(NODE_PEER_A)]},
+        {
+            NODE_PEER_A: _net(
+                ("10.0.0.2", "ethernet"),
+                ("169.254.81.1", "ethernet"),  # gets skipped (link-local)
+                ("10.0.1.2", "thunderbolt"),
+            )
+        },
+    )
+    url = find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net)
+    assert url == f"http://10.0.1.2:{EXO_FILE_SERVER_PORT}"
+
+
+def test_maybe_ethernet_beats_confirmed_ethernet() -> None:
+    """In the adurham M4 cluster, TB-bridges show up as `maybe_ethernet`,
+    so we deliberately rank them above confirmed `ethernet`."""
+    downloads, net = _state(
+        {NODE_PEER_A: [_completed(NODE_PEER_A)]},
+        {
+            NODE_PEER_A: _net(
+                ("10.0.0.2", "ethernet"),
+                ("10.0.5.2", "maybe_ethernet"),
+            )
+        },
+    )
+    url = find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net)
+    assert url == f"http://10.0.5.2:{EXO_FILE_SERVER_PORT}"
+
+
+def test_unknown_interface_type_is_lower_priority_than_ethernet() -> None:
+    downloads, net = _state(
+        {NODE_PEER_A: [_completed(NODE_PEER_A)]},
+        {
+            NODE_PEER_A: _net(
+                ("10.0.9.2", "wifi"),  # not in the priority table
+                ("10.0.0.2", "ethernet"),
+            )
+        },
+    )
+    url = find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net)
+    assert url == f"http://10.0.0.2:{EXO_FILE_SERVER_PORT}"
+
+
+def test_skips_ipv6_picks_ipv4() -> None:
+    downloads, net = _state(
+        {NODE_PEER_A: [_completed(NODE_PEER_A)]},
+        {
+            NODE_PEER_A: _net(
+                ("fd00::1", "thunderbolt"),  # IPv6 — skipped
+                ("10.0.1.2", "ethernet"),
+            )
+        },
+    )
+    url = find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net)
+    assert url == f"http://10.0.1.2:{EXO_FILE_SERVER_PORT}"
+
+
+def test_first_completed_peer_wins() -> None:
+    """When multiple peers have the model, the first one we encounter in
+    download_status iteration order is selected (Python dict iteration is
+    insertion-ordered, so this is deterministic for a given input)."""
+    downloads, net = _state(
+        {
+            NODE_PEER_A: [_completed(NODE_PEER_A)],
+            NODE_PEER_B: [_completed(NODE_PEER_B)],
+        },
+        {
+            NODE_PEER_A: _net(("10.0.0.2", "ethernet")),
+            NODE_PEER_B: _net(("10.0.0.3", "thunderbolt")),
+        },
+    )
+    url = find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net)
+    # NODE_PEER_A came first, so we don't search further even though
+    # NODE_PEER_B has a faster interface.
+    assert url == f"http://10.0.0.2:{EXO_FILE_SERVER_PORT}"
+
+
+def test_falls_through_to_second_peer_when_first_unreachable() -> None:
+    """If the first completed peer has no routable IP, fall through to the next."""
+    downloads, net = _state(
+        {
+            NODE_PEER_A: [_completed(NODE_PEER_A)],
+            NODE_PEER_B: [_completed(NODE_PEER_B)],
+        },
+        {
+            NODE_PEER_A: _net(("127.0.0.1", "ethernet")),  # unroutable
+            NODE_PEER_B: _net(("10.0.0.3", "ethernet")),
+        },
+    )
+    url = find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net)
+    assert url == f"http://10.0.0.3:{EXO_FILE_SERVER_PORT}"
+
+
+def test_completed_among_other_states_still_wins() -> None:
+    """A peer can be in DownloadCompleted for one model and DownloadOngoing
+    for another — we should still pick it for the completed one."""
+    downloads, net = _state(
+        {
+            NODE_PEER_A: [
+                _ongoing(NODE_PEER_A),  # different model, in progress
+                _completed(NODE_PEER_A, MODEL_ID),  # the one we want
+            ]
+        },
+        {NODE_PEER_A: _net(("10.0.0.2", "ethernet"))},
+    )
+    url = find_peer_repo_url(NODE_SELF, str(MODEL_ID), downloads, net)
+    assert url == f"http://10.0.0.2:{EXO_FILE_SERVER_PORT}"

--- a/src/exo/download/tests/test_re_download.py
+++ b/src/exo/download/tests/test_re_download.py
@@ -66,6 +66,7 @@ class FakeShardDownloader(ShardDownloader):
         self,
         shard: ShardMetadata,
         config_only: bool = False,  # noqa: ARG002
+        repo_url: str | None = None,  # noqa: ARG002
     ) -> Path:
         # Simulate a completed download by firing the progress callback
         progress = RepoDownloadProgress(

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -13,6 +13,7 @@ from pydantic import PositiveInt
 import exo.routing.topics as topics
 from exo.api.main import API
 from exo.download.coordinator import DownloadCoordinator
+from exo.download.file_server import run_file_server
 from exo.download.impl_shard_downloader import exo_shard_downloader
 from exo.master.main import Master
 from exo.routing.event_router import EventRouter
@@ -158,6 +159,7 @@ class Node:
                 tg.start_soon(self.master.run)
             if self.api:
                 tg.start_soon(self.api.run)
+            tg.start_soon(run_file_server)
             tg.start_soon(self._elect_loop)
 
     def shutdown(self):

--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -35,6 +35,7 @@ from exo.shared.types.worker.downloads import (
     DownloadCompleted,
     DownloadFailed,
     DownloadOngoing,
+    DownloadPaused,
     DownloadPending,
     DownloadProgress,
 )
@@ -82,7 +83,7 @@ def _get_node_download_fraction(
                     if total > 0
                     else 0.0
                 )
-            case DownloadPending():
+            case DownloadPending() | DownloadPaused():
                 total = progress.total.in_bytes
                 return progress.downloaded.in_bytes / total if total > 0 else 0.0
             case DownloadFailed():

--- a/src/exo/shared/constants.py
+++ b/src/exo/shared/constants.py
@@ -99,3 +99,20 @@ EXO_TRACING_ENABLED = os.getenv("EXO_TRACING_ENABLED", "false").lower() == "true
 EXO_MAX_CONCURRENT_REQUESTS = int(os.getenv("EXO_MAX_CONCURRENT_REQUESTS", "8"))
 
 EXO_MAX_INSTANCE_RETRIES = 5
+
+EXO_FILE_SERVER_PORT = int(os.getenv("EXO_FILE_SERVER_PORT", "52416"))
+# Interface the P2P file server binds to. Default 0.0.0.0 because peer IPs
+# are discovered dynamically and not known at bind time. Set to "127.0.0.1"
+# to disable P2P serving on this node, or to a specific interface IP to
+# narrow exposure. See docs/p2p-model-distribution.md for the security stance.
+EXO_FILE_SERVER_BIND_HOST = os.getenv("EXO_FILE_SERVER_BIND_HOST", "0.0.0.0")
+# Cap on concurrent in-flight serves from the P2P file server. A misbehaving
+# peer can otherwise spawn enough parallel curl-fetches to saturate the
+# server. Default 64 = 16 files/peer × 4 peers, matching the receiver's
+# Semaphore in download_utils._download_file_from_peer's caller. Over-cap
+# requests get a 503 with Retry-After; the receiver's outer retry loop
+# (download_file_with_retry) re-invokes curl which then auto-resumes via
+# `-C -` so no bytes are wasted.
+EXO_FILE_SERVER_MAX_CONCURRENCY = int(
+    os.getenv("EXO_FILE_SERVER_MAX_CONCURRENCY", "64")
+)

--- a/src/exo/shared/types/commands.py
+++ b/src/exo/shared/types/commands.py
@@ -69,6 +69,7 @@ class RequestEventLog(BaseCommand):
 class StartDownload(BaseCommand):
     target_node_id: NodeId
     shard_metadata: ShardMetadata
+    repo_url: str | None = None
 
 
 class DeleteDownload(BaseCommand):

--- a/src/exo/shared/types/tasks.py
+++ b/src/exo/shared/types/tasks.py
@@ -42,6 +42,7 @@ class CreateRunner(BaseTask):  # emitted by Worker
 
 class DownloadModel(BaseTask):  # emitted by Worker
     shard_metadata: ShardMetadata
+    repo_url: str | None = None
 
 
 class LoadModel(BaseTask):  # emitted by Worker

--- a/src/exo/shared/types/worker/downloads.py
+++ b/src/exo/shared/types/worker/downloads.py
@@ -47,8 +47,17 @@ class DownloadOngoing(BaseDownloadProgress):
     download_progress: DownloadProgressData
 
 
+class DownloadPaused(BaseDownloadProgress):
+    downloaded: Memory = Memory()
+    total: Memory = Memory()
+
+
 DownloadProgress = (
-    DownloadPending | DownloadCompleted | DownloadFailed | DownloadOngoing
+    DownloadPending
+    | DownloadCompleted
+    | DownloadFailed
+    | DownloadOngoing
+    | DownloadPaused
 )
 
 

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -193,6 +193,7 @@ class Worker:
                 self.image_cache,
                 self._instance_backoff,
                 self._download_backoff,
+                self.state.node_network,
             )
             if task is None:
                 continue
@@ -225,7 +226,7 @@ class Worker:
                             task_id=task.task_id, task_status=TaskStatus.Complete
                         )
                     )
-                case DownloadModel(shard_metadata=shard):
+                case DownloadModel(shard_metadata=shard, repo_url=repo_url):
                     model_id = shard.model_card.model_id
                     self._download_backoff.record_attempt(model_id)
 
@@ -252,12 +253,15 @@ class Worker:
                             )
                         )
                     else:
+                        if repo_url:
+                            logger.info(f"P2P download available for {model_id} from {repo_url}")
                         await self.download_command_sender.send(
                             ForwarderDownloadCommand(
                                 origin=self._system_id,
                                 command=StartDownload(
                                     target_node_id=self.node_id,
                                     shard_metadata=shard,
+                                    repo_url=repo_url,
                                 ),
                             )
                         )

--- a/src/exo/worker/plan.py
+++ b/src/exo/worker/plan.py
@@ -2,8 +2,10 @@
 
 from collections.abc import Mapping, Sequence
 
+from exo.download.peer_discovery import find_peer_repo_url
 from exo.shared.types.chunks import InputImageChunk
 from exo.shared.types.common import CommandId, ModelId, NodeId
+from exo.shared.types.profiling import NodeNetworkInfo
 from exo.shared.types.tasks import (
     CancelTask,
     ConnectToGroup,
@@ -24,6 +26,7 @@ from exo.shared.types.worker.downloads import (
     DownloadCompleted,
     DownloadFailed,
     DownloadOngoing,
+    DownloadPaused,
     DownloadProgress,
 )
 from exo.shared.types.worker.instances import BoundInstance, Instance, InstanceId
@@ -56,6 +59,7 @@ def plan(
     image_cache: Mapping[Base64ImageHash, Base64Image],
     instance_backoff: KeyedBackoff[InstanceId],
     download_backoff: KeyedBackoff[ModelId],
+    node_network: Mapping[NodeId, NodeNetworkInfo] | None = None,
 ) -> Task | None:
     # Python short circuiting OR logic should evaluate these sequentially.
     return (
@@ -63,7 +67,7 @@ def plan(
         or _kill_runner(runners, all_runners, instances)
         or _create_runner(node_id, runners, all_runners, instances, instance_backoff)
         or _model_needs_download(
-            node_id, runners, global_download_status, download_backoff
+            node_id, runners, global_download_status, download_backoff, node_network or {}
         )
         or _init_distributed_backend(runners, all_runners)
         or _load_model(runners, all_runners, global_download_status)
@@ -141,6 +145,7 @@ def _model_needs_download(
     runners: Mapping[RunnerId, RunnerSupervisor],
     global_download_status: Mapping[NodeId, Sequence[DownloadProgress]],
     download_backoff: KeyedBackoff[ModelId],
+    node_network: Mapping[NodeId, NodeNetworkInfo],
 ) -> DownloadModel | None:
     local_downloads = global_download_status.get(node_id, [])
     download_status = {
@@ -155,15 +160,19 @@ def _model_needs_download(
                 model_id not in download_status
                 or not isinstance(
                     download_status[model_id],
-                    (DownloadOngoing, DownloadCompleted, DownloadFailed),
+                    (DownloadOngoing, DownloadCompleted, DownloadFailed, DownloadPaused),
                 )
             )
             and download_backoff.should_proceed(model_id)
         ):
+            repo_url = find_peer_repo_url(
+                node_id, model_id, global_download_status, node_network
+            )
             # We don't invalidate download_status randomly in case a file gets deleted on disk
             return DownloadModel(
                 instance_id=runner.bound_instance.instance.instance_id,
                 shard_metadata=runner.bound_instance.bound_shard,
+                repo_url=repo_url,
             )
 
 


### PR DESCRIPTION
## Summary

When more than one node in a cluster needs the same model, this lets nodes that already hold the weights serve them to peers over the local network instead of every node fetching independently from HuggingFace. On a Thunderbolt-meshed cluster, a 200 GB model is pulled from the internet exactly once and then fans out at link-local speed.

The PR is two commits, both reviewable independently:

1. **`feat: peer-to-peer model distribution`** — the file server, peer discovery, curl-based fetch with hash verification, and the concurrency cap.
2. **`refactor: rename download cancel→pause and surface DownloadPaused state`** — splits the existing "cancel" download state into a real `DownloadPaused` so the worker plan loop doesn't auto-restart paused downloads. Adds `POST /download/pause` alongside `/download/cancel` (the latter is kept for backwards compat).

## How it works

- New `src/exo/download/file_server.py` exposes a small aiohttp server on `EXO_FILE_SERVER_PORT` (default `52416`) that streams files from any directory listed in `EXO_MODELS_DIRS` / `EXO_MODELS_READ_ONLY_DIRS`. Supports HTTP Range for resumable downloads.
- New `src/exo/download/peer_discovery.py` walks the global `download_status` for any peer in `DownloadCompleted` and picks the best routable IPv4 address from that peer's `NodeNetworkInfo`, ranking `thunderbolt > maybe_ethernet > ethernet > everything else` and skipping IPv6, loopback, link-local.
- `StartDownload` / `DownloadModel` carry an optional `repo_url`. When set, the shard downloader skips HF and uses curl (`-C -` for resume, `-f` for fail-fast, `-D <file>` to capture response headers) to pull from the peer. Per-file parallelism is bumped to 16 concurrent files for the peer path since the bottleneck is local NIC throughput, not HF rate limits.

## Security stance

Documented in detail in `docs/p2p-model-distribution.md`. Headlines:

- **Path-traversal defense.** Resolved file paths are pinned to the *specific* `<model_dir>/<normalized>/` subdirectory — `..`-traversal that would escape into a sibling model under the same root is rejected with 404 (an earlier `is_relative_to(model_dir)`-only check missed this). Tested at the HTTP-protocol level with raw sockets so client-side URL normalization can't hide a regression.
- **Range header robustness.** Malformed `Range` headers (`bytes=abc-`, multi-range, suffix-form, etc.) are silently ignored rather than crashing the handler. Pre-fix this was a one-line DoS — `int("abc")` raised `ValueError` and aiohttp returned 500.
- **Hash verification.** When the source has a `<file>.sha256` sidecar (written by the existing HF integrity-check path after it verifies HF's etag), the file server emits `X-File-SHA256`. The receiver captures the header in the same curl round-trip via `-D`, hashes the downloaded bytes, refuses to rename `.partial → final` on mismatch, and the outer retry loop re-fetches. On success the receiver writes its own sidecar so it can in turn pass verified hashes to other peers. Catches transmission corruption and disk-side decay; trust boundary remains "every node in the cluster is trusted."
- **Concurrency cap.** `EXO_FILE_SERVER_MAX_CONCURRENCY` (default 64). Excess in-flight serves get `503 Retry-After: 1` and the receiver's existing retry loop handles it (curl re-runs and `-C -` resumes — no bytes wasted).
- **Configurable bind host.** `EXO_FILE_SERVER_BIND_HOST` (default `0.0.0.0`). Set to `127.0.0.1` to disable P2P serving on a node, or to a specific interface IP to narrow exposure.
- **Error responses do not echo request paths.** A 404 says `Not found`, not `File not found: <user-controlled-input>`.
- **No reverse-proxy assumption.** Inter-cluster traffic is the use case; rate-limiting at the reverse-proxy layer doesn't fit the topology.

## Tests

61 new tests, all passing alongside the existing 360. Notable:

- `test_peer_discovery.py` — 16 cases covering interface priority, routability filtering, multi-peer fallthrough.
- `test_file_server.py` — 32 cases including 4 raw-socket protocol-level tests that exercise path traversal and malformed Range without aiohttp client-side URL normalization.
- `test_p2p_download.py` — 13 end-to-end cases through a real ephemeral file_server, including hash mismatch handling, sidecar absence (backward compat), and `_parse_x_file_sha256` redirect-chain handling.

## Test plan

- [ ] CI green (basedpyright, ruff, pytest)
- [ ] Reviewer sanity-check: `docs/p2p-model-distribution.md` accurately describes the security stance
- [ ] Reviewer sanity-check: hash-verification flow makes sense given the existing `download_file_with_retry` retry semantics
- [ ] Optional manual test: 2-node cluster, place an instance of a model neither node has, confirm node A pulls from HF and node B pulls from node A

## Related

Fork-side issue tracking from when this was scoped: `docs/upstream-prs.md` (private) — this is the "P2P model distribution" entry.