### PR TITLE
event-sourcing cleanup + snapshot-based catch-up

### DIFF
--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -121,6 +121,8 @@ from exo.api.types.openai_responses import (
 )
 from exo.master.image_store import ImageStore
 from exo.master.placement import place_instance as get_instance_placements
+from exo.routing.event_router import EventRouter
+from exo.routing.snapshot_receiver import SnapshotReceiver
 from exo.shared.apply import apply
 from exo.shared.constants import (
     DASHBOARD_DIR,
@@ -164,6 +166,7 @@ from exo.shared.types.commands import (
     ImageEdits,
     ImageGeneration,
     PlaceInstance,
+    RequestSnapshot,
     SendInputChunk,
     SetInstanceLink,
     StartDownload,
@@ -171,16 +174,17 @@ from exo.shared.types.commands import (
     TaskFinished,
     TextGeneration,
 )
-from exo.shared.types.common import CommandId, Id, NodeId, SystemId
+from exo.shared.types.common import CommandId, Id, NodeId, SessionId, SystemId
 from exo.shared.types.events import (
     ChunkGenerated,
     Event,
     IndexedEvent,
-    InstanceDeleted,
     TracesMerged,
+    TransientEvent,
 )
 from exo.shared.types.instance_link import InstanceLink, InstanceLinkId
 from exo.shared.types.memory import Memory
+from exo.shared.types.snapshots import SnapshotChunk
 from exo.shared.types.state import State
 from exo.shared.types.tasks import (
     ImageEdits as ImageEditsTask,
@@ -206,6 +210,8 @@ from exo.utils.task_group import TaskGroup
 
 _API_EVENT_LOG_DIR = EXO_EVENT_LOG_DIR / "api"
 ONBOARDING_COMPLETE_FILE = EXO_CACHE_HOME / "onboarding_complete"
+
+_SNAPSHOT_FETCH_TIMEOUT_SECONDS = 30
 
 
 def _format_to_content_type(image_format: Literal["png", "jpeg", "webp"] | None) -> str:
@@ -236,9 +242,13 @@ class API:
     def __init__(
         self,
         node_id: NodeId,
+        session_id: SessionId,
         *,
         port: int,
+        event_router: EventRouter,
         event_receiver: Receiver[IndexedEvent],
+        transient_event_receiver: Receiver[TransientEvent],
+        snapshot_chunk_receiver: Receiver[SnapshotChunk],
         command_sender: Sender[ForwarderCommand],
         download_command_sender: Sender[ForwarderDownloadCommand],
         # This lets us pause the API if an election is running
@@ -247,9 +257,13 @@ class API:
         self.state = State()
         self._event_log = DiskEventLog(_API_EVENT_LOG_DIR)
         self._system_id = SystemId()
+        self.session_id = session_id
+        self.event_router = event_router
         self.command_sender = command_sender
         self.download_command_sender = download_command_sender
         self.event_receiver = event_receiver
+        self.transient_event_receiver = transient_event_receiver
+        self.snapshot_chunk_receiver = snapshot_chunk_receiver
         self.election_receiver = election_receiver
         self.node_id: NodeId = node_id
         self.last_completed_election: int = 0
@@ -292,18 +306,34 @@ class API:
         self._image_store = ImageStore(EXO_IMAGE_CACHE_DIR)
         self._tg: TaskGroup = TaskGroup()
 
-    def reset(self, result_clock: int, event_receiver: Receiver[IndexedEvent]):
+    def reset(
+        self,
+        result_clock: int,
+        session_id: SessionId,
+        event_router: EventRouter,
+        event_receiver: Receiver[IndexedEvent],
+        transient_event_receiver: Receiver[TransientEvent],
+        snapshot_chunk_receiver: Receiver[SnapshotChunk],
+    ):
         logger.info("Resetting API State")
         self._event_log.close()
         self._event_log = DiskEventLog(_API_EVENT_LOG_DIR)
         self.state = State()
         self._system_id = SystemId()
+        self.session_id = session_id
+        self.event_router = event_router
         self._text_generation_queues = {}
         self._image_generation_queues = {}
         self.unpause(result_clock)
         self.event_receiver.close()
         self.event_receiver = event_receiver
-        self._tg.start_soon(self._apply_state)
+        self.transient_event_receiver.close()
+        self.transient_event_receiver = transient_event_receiver
+        self.snapshot_chunk_receiver.close()
+        self.snapshot_chunk_receiver = snapshot_chunk_receiver
+        self._tg.start_soon(self._bootstrap_then_apply_state)
+        self._tg.start_soon(self._apply_transient)
+        self._tg.start_soon(self._reconcile_streams)
         self._sent_image_hashes = set()
 
     def unpause(self, result_clock: int):
@@ -1848,7 +1878,9 @@ class API:
         try:
             async with self._tg as tg:
                 logger.info("Starting API")
-                tg.start_soon(self._apply_state)
+                tg.start_soon(self._bootstrap_then_apply_state)
+                tg.start_soon(self._apply_transient)
+                tg.start_soon(self._reconcile_streams)
                 tg.start_soon(self._pause_on_new_election)
                 tg.start_soon(self._cleanup_expired_images)
                 print_startup_banner(self.port)
@@ -1862,6 +1894,8 @@ class API:
             self._event_log.close()
             self.command_sender.close()
             self.event_receiver.close()
+            self.transient_event_receiver.close()
+            self.snapshot_chunk_receiver.close()
 
     async def run_api(self, ev: anyio.Event):
         cfg = Config()
@@ -1877,48 +1911,103 @@ class API:
                 shutdown_trigger=ev.wait,
             )
 
+    async def _bootstrap_then_apply_state(self):
+        """Pull a snapshot from the master before draining events.
+
+        Mirrors the Worker bootstrap flow: events queued in the EventRouter
+        wait until either the snapshot lands (and we fast-forward the
+        buffer) or the fetch times out (and we replay from idx 0).
+        """
+        await self._fetch_snapshot()
+        await self._apply_state()
+
+    async def _fetch_snapshot(self) -> None:
+        receiver = SnapshotReceiver(self.node_id, self.session_id)
+        await self.command_sender.send(
+            ForwarderCommand(
+                origin=self._system_id,
+                command=RequestSnapshot(requester_node_id=self.node_id),
+            )
+        )
+
+        with anyio.move_on_after(_SNAPSHOT_FETCH_TIMEOUT_SECONDS):
+            with self.snapshot_chunk_receiver as chunks:
+                async for chunk in chunks:
+                    received = receiver.ingest(chunk)
+                    if received is not None:
+                        self.state = received.state
+                        self.event_router.set_buffer_start(
+                            received.last_event_applied_idx + 1
+                        )
+                        logger.info(
+                            f"API bootstrapped from snapshot at idx "
+                            f"{received.last_event_applied_idx}"
+                        )
+                        return
+        logger.info(
+            "API: no snapshot received before timeout; "
+            "falling back to full event-log replay"
+        )
+
     async def _apply_state(self):
         with self.event_receiver as events:
             async for i_event in events:
+                # Drop anything already covered by a snapshot we've applied.
+                if i_event.idx <= self.state.last_event_applied_idx:
+                    continue
                 self._event_log.append(i_event.event)
                 self.state = apply(self.state, i_event)
-                event = i_event.event
 
+    async def _apply_transient(self):
+        with self.transient_event_receiver as events:
+            async for event in events:
                 if isinstance(event, ChunkGenerated):
-                    if queue := self._image_generation_queues.get(
-                        event.command_id, None
-                    ):
-                        assert isinstance(event.chunk, ImageChunk)
-                        try:
-                            await queue.send(event.chunk)
-                        except (BrokenResourceError, ClosedResourceError):
-                            self._image_generation_queues.pop(event.command_id, None)
-                    if queue := self._text_generation_queues.get(
-                        event.command_id, None
-                    ):
-                        assert not isinstance(event.chunk, ImageChunk)
-                        try:
-                            await queue.send(event.chunk)
-                        except (BrokenResourceError, ClosedResourceError):
-                            self._text_generation_queues.pop(event.command_id, None)
-                if isinstance(event, InstanceDeleted):
-                    self._close_streams_for_instance(event.instance_id)
-                if isinstance(event, TracesMerged):
+                    await self._dispatch_chunk(event)
+                elif isinstance(event, TracesMerged):
                     self._save_merged_trace(event)
 
-    def _close_streams_for_instance(self, instance_id: InstanceId) -> None:
-        """Close any active generation streams for commands running on the given instance."""
-        for task in self.state.tasks.values():
-            if task.instance_id != instance_id:
-                continue
-            if not isinstance(
-                task, (TextGenerationTask, ImageGenerationTask, ImageEditsTask)
-            ):
-                continue
-            if sender := self._text_generation_queues.pop(task.command_id, None):
-                sender.close()
-            if sender := self._image_generation_queues.pop(task.command_id, None):
-                sender.close()
+    async def _reconcile_streams(self):
+        """Close streaming queues for command_ids whose instance is gone.
+
+        Reconciling from state (rather than reacting to InstanceDeleted) keeps
+        clients well-behaved after snapshot catch-up — without this, queues for
+        an evicted instance could linger forever if the deletion event arrived
+        before the API came up.
+        """
+        while True:
+            await anyio.sleep(1)
+            live_command_ids: set[CommandId] = {
+                task.command_id
+                for task in self.state.tasks.values()
+                if isinstance(
+                    task, (TextGenerationTask, ImageGenerationTask, ImageEditsTask)
+                )
+                and task.instance_id in self.state.instances
+            }
+            self._close_streams_not_in(live_command_ids)
+
+    def _close_streams_not_in(self, live_command_ids: set[CommandId]) -> None:
+        for cmd_id in list(self._text_generation_queues):
+            if cmd_id not in live_command_ids:
+                self._text_generation_queues.pop(cmd_id).close()
+        for cmd_id in list(self._image_generation_queues):
+            if cmd_id not in live_command_ids:
+                self._image_generation_queues.pop(cmd_id).close()
+
+    async def _dispatch_chunk(self, event: ChunkGenerated) -> None:
+        """Forward a generated chunk to whichever client request is awaiting it."""
+        if queue := self._image_generation_queues.get(event.command_id, None):
+            assert isinstance(event.chunk, ImageChunk)
+            try:
+                await queue.send(event.chunk)
+            except (BrokenResourceError, ClosedResourceError):
+                self._image_generation_queues.pop(event.command_id, None)
+        if queue := self._text_generation_queues.get(event.command_id, None):
+            assert not isinstance(event.chunk, ImageChunk)
+            try:
+                await queue.send(event.chunk)
+            except (BrokenResourceError, ClosedResourceError):
+                self._text_generation_queues.pop(event.command_id, None)
 
     def _save_merged_trace(self, event: TracesMerged) -> None:
         traces = [

--- a/src/exo/api/tests/test_instance_deleted_stream_cleanup.py
+++ b/src/exo/api/tests/test_instance_deleted_stream_cleanup.py
@@ -1,5 +1,10 @@
 # pyright: reportUnusedFunction=false, reportAny=false
-"""Tests that InstanceDeleted events close active generation streams."""
+"""Tests that streaming queues are reconciled to live state.
+
+Earlier the API reacted to `InstanceDeleted` events; now it reconciles its
+queues against `state.tasks` × `state.instances`. The tests assert the same
+end-state via the reconciliation pass instead of the old direct method.
+"""
 
 from unittest.mock import MagicMock
 
@@ -13,7 +18,8 @@ from exo.shared.types.text_generation import (
     InputMessageContent,
     TextGenerationTaskParams,
 )
-from exo.shared.types.worker.instances import InstanceId
+from exo.shared.types.worker.instances import InstanceId, MlxRingInstance
+from exo.shared.types.worker.runners import ShardAssignments
 
 
 def _make_api_with_state(state: State) -> API:
@@ -38,45 +44,68 @@ def _make_text_gen_task(
     )
 
 
-def test_close_streams_for_deleted_instance() -> None:
-    """Deleting an instance closes the text generation sender for commands on that instance."""
+def _live_command_ids(api: API) -> set[CommandId]:
+    return {
+        task.command_id
+        for task in api.state.tasks.values()
+        if isinstance(task, (TextGeneration, ImageGeneration))
+        and task.instance_id in api.state.instances
+    }
+
+
+def test_close_streams_when_instance_missing_from_state() -> None:
+    """A command whose instance is no longer in state.instances has its stream closed."""
     instance_id = InstanceId("inst-1")
     command_id = CommandId("cmd-1")
     task = _make_text_gen_task(instance_id, command_id)
 
-    state = State(tasks={task.task_id: task})
+    # Instance is gone (deleted); task entry still references it.
+    state = State(tasks={task.task_id: task}, instances={})
     api = _make_api_with_state(state)
 
     sender = MagicMock()
     api._text_generation_queues[command_id] = sender  # pyright: ignore[reportPrivateUsage]
 
-    api._close_streams_for_instance(instance_id)  # pyright: ignore[reportPrivateUsage]
+    api._close_streams_not_in(_live_command_ids(api))  # pyright: ignore[reportPrivateUsage]
 
     sender.close.assert_called_once()
     assert command_id not in api._text_generation_queues  # pyright: ignore[reportPrivateUsage]
 
 
-def test_close_streams_ignores_unrelated_instances() -> None:
-    """Deleting an instance does NOT close streams for commands on other instances."""
-    target_id = InstanceId("inst-delete")
-    other_id = InstanceId("inst-keep")
-    other_cmd = CommandId("cmd-keep")
-    other_task = _make_text_gen_task(other_id, other_cmd)
+def test_keeps_streams_for_live_commands() -> None:
+    """Streams for tasks whose instance still exists are left open."""
+    live_id = InstanceId("inst-live")
+    live_cmd = CommandId("cmd-live")
+    live_task = _make_text_gen_task(live_id, live_cmd)
 
-    state = State(tasks={other_task.task_id: other_task})
+    # Reconciliation only checks key membership in state.instances. We
+    # construct a minimal MlxRingInstance so Pydantic's State validator is
+    # happy; the contents don't matter to the test.
+    placeholder_instance = MlxRingInstance(
+        instance_id=live_id,
+        shard_assignments=ShardAssignments(
+            model_id=ModelId("test-model"), node_to_runner={}, runner_to_shard={}
+        ),
+        hosts_by_node={},
+        ephemeral_port=0,
+    )
+    state = State(
+        tasks={live_task.task_id: live_task},
+        instances={live_id: placeholder_instance},
+    )
     api = _make_api_with_state(state)
 
     sender = MagicMock()
-    api._text_generation_queues[other_cmd] = sender  # pyright: ignore[reportPrivateUsage]
+    api._text_generation_queues[live_cmd] = sender  # pyright: ignore[reportPrivateUsage]
 
-    api._close_streams_for_instance(target_id)  # pyright: ignore[reportPrivateUsage]
+    api._close_streams_not_in(_live_command_ids(api))  # pyright: ignore[reportPrivateUsage]
 
     sender.close.assert_not_called()
-    assert other_cmd in api._text_generation_queues  # pyright: ignore[reportPrivateUsage]
+    assert live_cmd in api._text_generation_queues  # pyright: ignore[reportPrivateUsage]
 
 
-def test_close_streams_for_deleted_instance_image_generation() -> None:
-    """Deleting an instance closes the image generation sender for commands on that instance."""
+def test_close_image_generation_stream_when_instance_missing() -> None:
+    """The same reconciliation path closes image generation streams."""
     instance_id = InstanceId("inst-img")
     command_id = CommandId("cmd-img")
     task = ImageGeneration(
@@ -85,13 +114,13 @@ def test_close_streams_for_deleted_instance_image_generation() -> None:
         task_params=ImageGenerationTaskParams(prompt="a cat", model="test-model"),
     )
 
-    state = State(tasks={task.task_id: task})
+    state = State(tasks={task.task_id: task}, instances={})
     api = _make_api_with_state(state)
 
     sender = MagicMock()
     api._image_generation_queues[command_id] = sender  # pyright: ignore[reportPrivateUsage]
 
-    api._close_streams_for_instance(instance_id)  # pyright: ignore[reportPrivateUsage]
+    api._close_streams_not_in(_live_command_ids(api))  # pyright: ignore[reportPrivateUsage]
 
     sender.close.assert_called_once()
     assert command_id not in api._image_generation_queues  # pyright: ignore[reportPrivateUsage]

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -17,6 +17,7 @@ from exo.download.impl_shard_downloader import exo_shard_downloader
 from exo.master.main import Master
 from exo.routing.event_router import EventRouter
 from exo.routing.router import Router, get_node_id_keypair
+from exo.routing.transient_router import TransientRouter
 from exo.shared.constants import EXO_LOG
 from exo.shared.election import Election, ElectionResult
 from exo.shared.logging import logger_cleanup, logger_setup
@@ -31,6 +32,7 @@ from exo.worker.main import Worker
 class Node:
     router: Router
     event_router: EventRouter
+    transient_router: TransientRouter
     download_coordinator: DownloadCoordinator | None
     worker: Worker | None
     election: Election  # Every node participates in election, as we do want a node to become master even if it isn't a master candidate if no master candidates are present.
@@ -55,15 +57,23 @@ class Node:
         )
         await router.register_topic(topics.GLOBAL_EVENTS)
         await router.register_topic(topics.LOCAL_EVENTS)
+        await router.register_topic(topics.TRANSIENT_EVENTS)
         await router.register_topic(topics.COMMANDS)
         await router.register_topic(topics.ELECTION_MESSAGES)
         await router.register_topic(topics.CONNECTION_MESSAGES)
         await router.register_topic(topics.DOWNLOAD_COMMANDS)
+        await router.register_topic(topics.SNAPSHOT_RESPONSES)
         event_router = EventRouter(
             session_id,
             command_sender=router.sender(topics.COMMANDS),
             external_outbound=router.sender(topics.LOCAL_EVENTS),
             external_inbound=router.receiver(topics.GLOBAL_EVENTS),
+        )
+        transient_router = TransientRouter(
+            node_id=node_id,
+            session_id=session_id,
+            external_outbound=router.sender(topics.TRANSIENT_EVENTS),
+            external_inbound=router.receiver(topics.TRANSIENT_EVENTS),
         )
 
         logger.info(f"Starting node {node_id}")
@@ -83,8 +93,12 @@ class Node:
         if args.spawn_api:
             api = API(
                 node_id,
+                session_id,
                 port=args.api_port,
+                event_router=event_router,
                 event_receiver=event_router.receiver(),
+                transient_event_receiver=transient_router.receiver(),
+                snapshot_chunk_receiver=router.receiver(topics.SNAPSHOT_RESPONSES),
                 command_sender=router.sender(topics.COMMANDS),
                 download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
                 election_receiver=router.receiver(topics.ELECTION_MESSAGES),
@@ -95,8 +109,13 @@ class Node:
         if not args.no_worker:
             worker = Worker(
                 node_id,
+                session_id,
+                event_router=event_router,
                 event_receiver=event_router.receiver(),
                 event_sender=event_router.sender(),
+                transient_event_receiver=transient_router.receiver(),
+                transient_event_sender=transient_router.sender(),
+                snapshot_chunk_receiver=router.receiver(topics.SNAPSHOT_RESPONSES),
                 command_sender=router.sender(topics.COMMANDS),
                 download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
                 api_port=args.api_port,
@@ -109,9 +128,12 @@ class Node:
             node_id,
             session_id,
             event_sender=event_router.sender(),
+            transient_event_receiver=transient_router.receiver(),
+            transient_event_sender=transient_router.sender(),
             global_event_sender=router.sender(topics.GLOBAL_EVENTS),
             local_event_receiver=router.receiver(topics.LOCAL_EVENTS),
             command_receiver=router.receiver(topics.COMMANDS),
+            snapshot_chunk_sender=router.sender(topics.SNAPSHOT_RESPONSES),
             download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
         )
 
@@ -132,6 +154,7 @@ class Node:
         return cls(
             router,
             event_router,
+            transient_router,
             download_coordinator,
             worker,
             election,
@@ -149,6 +172,7 @@ class Node:
             signal.signal(signal.SIGTERM, lambda _, __: self.shutdown())
             tg.start_soon(self.router.run)
             tg.start_soon(self.event_router.run)
+            tg.start_soon(self.transient_router.run)
             tg.start_soon(self.election.run)
             if self.download_coordinator:
                 tg.start_soon(self.download_coordinator.run)
@@ -192,6 +216,13 @@ class Node:
                         self.router.receiver(topics.GLOBAL_EVENTS),
                         self.router.sender(topics.LOCAL_EVENTS),
                     )
+                    self.transient_router.shutdown()
+                    self.transient_router = TransientRouter(
+                        node_id=self.node_id,
+                        session_id=result.session_id,
+                        external_outbound=self.router.sender(topics.TRANSIENT_EVENTS),
+                        external_inbound=self.router.receiver(topics.TRANSIENT_EVENTS),
+                    )
 
                 if (
                     result.session_id.master_node_id == self.node_id
@@ -207,9 +238,14 @@ class Node:
                         self.node_id,
                         result.session_id,
                         event_sender=self.event_router.sender(),
+                        transient_event_receiver=self.transient_router.receiver(),
+                        transient_event_sender=self.transient_router.sender(),
                         global_event_sender=self.router.sender(topics.GLOBAL_EVENTS),
                         local_event_receiver=self.router.receiver(topics.LOCAL_EVENTS),
                         command_receiver=self.router.receiver(topics.COMMANDS),
+                        snapshot_chunk_sender=self.router.sender(
+                            topics.SNAPSHOT_RESPONSES
+                        ),
                         download_command_sender=self.router.sender(
                             topics.DOWNLOAD_COMMANDS
                         ),
@@ -246,8 +282,15 @@ class Node:
                         # TODO: add profiling etc to resource monitor
                         self.worker = Worker(
                             self.node_id,
+                            result.session_id,
+                            event_router=self.event_router,
                             event_receiver=self.event_router.receiver(),
                             event_sender=self.event_router.sender(),
+                            transient_event_receiver=self.transient_router.receiver(),
+                            transient_event_sender=self.transient_router.sender(),
+                            snapshot_chunk_receiver=self.router.receiver(
+                                topics.SNAPSHOT_RESPONSES
+                            ),
                             command_sender=self.router.sender(topics.COMMANDS),
                             download_command_sender=self.router.sender(
                                 topics.DOWNLOAD_COMMANDS
@@ -256,8 +299,16 @@ class Node:
                         )
                         self._tg.start_soon(self.worker.run)
                     if self.api:
-                        self.api.reset(result.won_clock, self.event_router.receiver())
+                        self.api.reset(
+                            result.won_clock,
+                            result.session_id,
+                            self.event_router,
+                            self.event_router.receiver(),
+                            self.transient_router.receiver(),
+                            self.router.receiver(topics.SNAPSHOT_RESPONSES),
+                        )
                     self._tg.start_soon(self.event_router.run)
+                    self._tg.start_soon(self.transient_router.run)
                 else:
                     if self.api:
                         self.api.unpause(result.won_clock)

--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -1,6 +1,8 @@
+import hashlib
 from datetime import datetime, timedelta, timezone
 
 import anyio
+from anyio import to_thread
 from loguru import logger
 
 from exo.master.placement import (
@@ -25,6 +27,7 @@ from exo.shared.types.commands import (
     ImageGeneration,
     PlaceInstance,
     RequestEventLog,
+    RequestSnapshot,
     SendInputChunk,
     SetInstanceLink,
     TaskCancelled,
@@ -52,8 +55,10 @@ from exo.shared.types.events import (
     TraceEventData,
     TracesCollected,
     TracesMerged,
+    TransientEvent,
 )
 from exo.shared.types.instance_link import InstanceLink
+from exo.shared.types.snapshots import SnapshotChunk, SnapshotTransferId
 from exo.shared.types.state import State
 from exo.shared.types.tasks import (
     ImageEdits as ImageEditsTask,
@@ -73,6 +78,25 @@ from exo.utils.channels import Receiver, Sender
 from exo.utils.disk_event_log import DiskEventLog
 from exo.utils.event_buffer import MultiSourceBuffer
 from exo.utils.task_group import TaskGroup
+
+# Roughly 512 KiB per chunk. The gossipsub message ceiling is around 1 MiB;
+# we leave a comfortable margin for pydantic JSON+base64 inflation.
+_SNAPSHOT_CHUNK_BYTES = 512 * 1024
+
+# Per-call cap on a single RequestEventLog response. The worker will NACK
+# again for the next chunk; the cap exists to bound how many gossipsub
+# messages we publish in one go (each event is its own message, so without
+# a cap a fresh joiner would dump the entire log in a burst that gossipsub
+# doesn't take well to). With snapshots in place the post-snapshot tail
+# this branch serves should be tiny, so the cap is rarely hit anyway.
+_MAX_EVENT_LOG_REPLAY_BATCH = 1000
+
+
+def _encode_state_for_transfer(state: State) -> bytes:
+    """zstd-compressed JSON dump of State — the wire format for snapshots."""
+    import zstandard
+
+    return zstandard.ZstdCompressor().compress(state.model_dump_json().encode("utf-8"))
 
 
 def _prefill_endpoint_for(state: State, decode_instance_id: InstanceId) -> str | None:
@@ -123,8 +147,11 @@ class Master:
         *,
         command_receiver: Receiver[ForwarderCommand],
         event_sender: Sender[Event],
+        transient_event_receiver: Receiver[TransientEvent],
+        transient_event_sender: Sender[TransientEvent],
         local_event_receiver: Receiver[LocalForwarderEvent],
         global_event_sender: Sender[GlobalForwarderEvent],
+        snapshot_chunk_sender: Sender[SnapshotChunk],
         download_command_sender: Sender[ForwarderDownloadCommand],
     ):
         self.node_id = node_id
@@ -134,7 +161,10 @@ class Master:
         self.command_task_mapping: dict[CommandId, TaskId] = {}
         self.command_receiver = command_receiver
         self.local_event_receiver = local_event_receiver
+        self.transient_event_receiver = transient_event_receiver
+        self.transient_event_sender = transient_event_sender
         self.global_event_sender = global_event_sender
+        self.snapshot_chunk_sender = snapshot_chunk_sender
         self.download_command_sender = download_command_sender
         self.event_sender = event_sender
         self._system_id = SystemId()
@@ -149,12 +179,16 @@ class Master:
         try:
             async with self._tg as tg:
                 tg.start_soon(self._event_processor)
+                tg.start_soon(self._transient_event_processor)
                 tg.start_soon(self._command_processor)
                 tg.start_soon(self._plan)
         finally:
             self._event_log.close()
             self.global_event_sender.close()
             self.local_event_receiver.close()
+            self.transient_event_receiver.close()
+            self.transient_event_sender.close()
+            self.snapshot_chunk_sender.close()
             self.command_receiver.close()
 
     async def shutdown(self):
@@ -381,7 +415,10 @@ class Master:
                             )
                             generated_events.extend(transition_events)
                         case SendInputChunk(chunk=chunk):
-                            generated_events.append(
+                            # Image-upload chunks are per-request transients —
+                            # publish on the transient channel rather than the
+                            # durable event log so they are not replayed.
+                            await self.transient_event_sender.send(
                                 InputChunkReceived(
                                     command_id=chunk.command_id,
                                     chunk=chunk,
@@ -439,14 +476,24 @@ class Master:
                                 InstanceLinkDeleted(link_id=command.link_id)
                             )
                         case RequestEventLog():
-                            # We should just be able to send everything, since other buffers will ignore old messages
-                            # rate limit to 1000 at a time
-                            end = min(command.since_idx + 1000, len(self._event_log))
+                            # Send the full requested range. Snapshot-based
+                            # bootstrap should keep this tail small; the soft
+                            # cap protects against pathologically large
+                            # responses if a node ever hits the no-snapshot
+                            # fallback path against a long-running cluster.
+                            end = min(
+                                command.since_idx + _MAX_EVENT_LOG_REPLAY_BATCH,
+                                len(self._event_log),
+                            )
                             for i, event in enumerate(
                                 self._event_log.read_range(command.since_idx, end),
                                 start=command.since_idx,
                             ):
                                 await self._send_event(IndexedEvent(idx=i, event=event))
+                        case RequestSnapshot():
+                            self._tg.start_soon(
+                                self._serve_snapshot, command.requester_node_id
+                            )
                     for event in generated_events:
                         await self.event_sender.send(event)
                 except ValueError as e:
@@ -454,6 +501,14 @@ class Master:
 
     # These plan loops are the cracks showing in our event sourcing architecture - more things could be commands
     async def _plan(self) -> None:
+        # Workers emit NodeGatheredInfo via the InfoGatherer's memory poll
+        # roughly once per second. A 5s timeout is therefore ~5x the natural
+        # heartbeat rate — fast enough that topology updates feel live, with
+        # enough headroom to absorb a missed heartbeat or two without false
+        # positives. The tick interval bounds detection latency from above.
+        node_inactivity_timeout = timedelta(seconds=5)
+        tick_interval_seconds = 1.0
+
         while True:
             # kill broken instances
             connected_node_ids = set(self.state.topology.list_nodes())
@@ -468,11 +523,11 @@ class Master:
             # time out dead nodes
             for node_id, time in self.state.last_seen.items():
                 now = datetime.now(tz=timezone.utc)
-                if now - time > timedelta(seconds=30):
+                if now - time > node_inactivity_timeout:
                     logger.info(f"Manually removing node {node_id} due to inactivity")
                     await self.event_sender.send(NodeTimedOut(node_id=node_id))
 
-            await anyio.sleep(10)
+            await anyio.sleep(tick_interval_seconds)
 
     async def _event_processor(self) -> None:
         with self.local_event_receiver as local_events:
@@ -486,10 +541,6 @@ class Master:
                     local_event.origin,
                 )
                 for event in self._multi_buffer.drain():
-                    if isinstance(event, TracesCollected):
-                        await self._handle_traces_collected(event)
-                        continue
-
                     logger.debug(f"Master indexing event: {str(event)[:100]}")
 
                     event = event.model_copy(
@@ -505,6 +556,59 @@ class Master:
 
                     self._event_log.append(event)
                     await self._send_event(indexed)
+
+    async def _serve_snapshot(self, requester_node_id: NodeId) -> None:
+        """Encode the master's current State and stream it as chunks.
+
+        Runs as a background task so the encode (which is bounded by State
+        size and CPU, not IO) doesn't block the command processor. The State
+        is captured by reference: it's a frozen Pydantic model, so the
+        encoder thread sees a consistent snapshot even as new events get
+        applied to `self.state` concurrently.
+        """
+        state = self.state
+        if state.last_event_applied_idx < 0:
+            logger.info(
+                f"RequestSnapshot from {requester_node_id} but master has no events "
+                f"yet; requester will fall back to full event-log replay"
+            )
+            return
+
+        body = await to_thread.run_sync(_encode_state_for_transfer, state)
+        sha256 = hashlib.sha256(body).hexdigest()
+        chunks = [
+            body[i : i + _SNAPSHOT_CHUNK_BYTES]
+            for i in range(0, len(body), _SNAPSHOT_CHUNK_BYTES)
+        ] or [b""]
+        transfer_id = SnapshotTransferId()
+
+        logger.info(
+            f"Serving snapshot to {requester_node_id}: "
+            f"idx={state.last_event_applied_idx}, "
+            f"{len(chunks)} chunk(s), {len(body)} bytes total"
+        )
+        for i, chunk in enumerate(chunks):
+            await self.snapshot_chunk_sender.send(
+                SnapshotChunk.from_data(
+                    data=chunk,
+                    transfer_id=transfer_id,
+                    requester_node_id=requester_node_id,
+                    session_id=self.session_id,
+                    schema_version=state.schema_version,
+                    last_event_applied_idx=state.last_event_applied_idx,
+                    chunk_index=i,
+                    total_chunks=len(chunks),
+                    sha256_hex=sha256,
+                )
+            )
+
+    async def _transient_event_processor(self) -> None:
+        """Aggregate per-rank `TracesCollected` into a `TracesMerged` once all
+        ranks for a task have reported in."""
+        with self.transient_event_receiver as transients:
+            async for event in transients:
+                if isinstance(event, TracesCollected):
+                    await self._handle_traces_collected(event)
 
     # This function is re-entrant, take care!
     async def _send_event(self, event: IndexedEvent):
@@ -536,7 +640,7 @@ class Master:
         for trace_data in self._pending_traces[task_id].values():
             all_trace_data.extend(trace_data)
 
-        await self.event_sender.send(
+        await self.transient_event_sender.send(
             TracesMerged(task_id=task_id, traces=all_trace_data)
         )
 

--- a/src/exo/master/tests/test_master.py
+++ b/src/exo/master/tests/test_master.py
@@ -24,11 +24,13 @@ from exo.shared.types.events import (
     LocalForwarderEvent,
     NodeGatheredInfo,
     TaskCreated,
+    TransientEvent,
 )
 from exo.shared.types.memory import Memory
 from exo.shared.types.profiling import (
     MemoryUsage,
 )
+from exo.shared.types.snapshots import SnapshotChunk
 from exo.shared.types.tasks import TaskStatus
 from exo.shared.types.tasks import TextGeneration as TextGenerationTask
 from exo.shared.types.text_generation import (
@@ -56,6 +58,8 @@ async def test_master():
     local_event_sender, le_receiver = channel[LocalForwarderEvent]()
     fcds, _fcdr = channel[ForwarderDownloadCommand]()
     ev_send, ev_recv = channel[Event]()
+    transient_send, transient_recv = channel[TransientEvent]()
+    snapshot_chunk_send, _snapshot_chunk_recv = channel[SnapshotChunk]()
 
     async def mock_event_router():
         idx = 0
@@ -89,9 +93,12 @@ async def test_master():
         node_id,
         session_id,
         event_sender=ev_send,
+        transient_event_receiver=transient_recv,
+        transient_event_sender=transient_send,
         global_event_sender=ge_sender,
         local_event_receiver=le_receiver,
         command_receiver=co_receiver,
+        snapshot_chunk_sender=snapshot_chunk_send,
         download_command_sender=fcds,
     )
     logger.info("run the master")

--- a/src/exo/routing/event_router.py
+++ b/src/exo/routing/event_router.py
@@ -40,8 +40,11 @@ class EventRouter:
 
     _nack_cancel_scope: CancelScope | None = field(init=False, default=None)
     _nack_attempts: int = field(init=False, default=0)
-    _nack_base_seconds: float = field(init=False, default=0.5)
-    _nack_cap_seconds: float = field(init=False, default=10.0)
+    # Snapshots carry the bulk of catch-up; NACK only needs to fetch the
+    # short tail of events emitted after the snapshot, so we can be much
+    # more aggressive than the historical 0.5s..10s window.
+    _nack_base_seconds: float = field(init=False, default=0.05)
+    _nack_cap_seconds: float = field(init=False, default=1.0)
 
     async def run(self):
         try:
@@ -94,8 +97,15 @@ class EventRouter:
                 await self.external_outbound.send(f_ev)
                 self.out_for_delivery[event.event_id] = (anyio.current_time(), f_ev)
 
+    def set_buffer_start(self, idx: int) -> None:
+        """Skip events strictly before `idx` (e.g. after applying a snapshot).
+
+        Both pending out-of-order events in the buffer and any future events
+        below `idx` are discarded. Idempotent and only moves forward.
+        """
+        self.event_buffer.fast_forward_to(idx)
+
     async def _run_ext_in(self):
-        buf = OrderedBuffer[Event]()
         with self.external_inbound as events:
             async for event in events:
                 if event.session != self.session_id:
@@ -103,12 +113,12 @@ class EventRouter:
                 if event.origin != self.session_id.master_node_id:
                     continue
 
-                buf.ingest(event.origin_idx, event.event)
+                self.event_buffer.ingest(event.origin_idx, event.event)
                 event_id = event.event.event_id
                 if event_id in self.out_for_delivery:
                     self.out_for_delivery.pop(event_id)
 
-                drained = buf.drain_indexed()
+                drained = self.event_buffer.drain_indexed()
                 if drained:
                     self._nack_attempts = 0
                     if self._nack_cancel_scope:
@@ -119,7 +129,9 @@ class EventRouter:
                     or self._nack_cancel_scope.cancel_called
                 ):
                     # Request the next index.
-                    self._tg.start_soon(self._nack_request, buf.next_idx_to_release)
+                    self._tg.start_soon(
+                        self._nack_request, self.event_buffer.next_idx_to_release
+                    )
                     continue
 
                 for idx, event in drained:

--- a/src/exo/routing/snapshot_receiver.py
+++ b/src/exo/routing/snapshot_receiver.py
@@ -1,0 +1,109 @@
+"""Reassembles a snapshot from a stream of `SnapshotChunk`s.
+
+A receiver belongs to one node; it ignores chunks addressed to other
+requesters and chunks from prior sessions. Once a transfer's chunks have
+all been collected and the SHA-256 checks out, the snapshot is decoded into
+a `State`. Concurrent transfers (for the same requester) are tolerated:
+each is keyed by `transfer_id`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import final
+
+import zstandard
+from loguru import logger
+
+from exo.shared.types.common import NodeId, SessionId
+from exo.shared.types.snapshots import SnapshotChunk, SnapshotTransferId
+from exo.shared.types.state import State
+
+
+@final
+@dataclass
+class _Assembly:
+    """Partial state for one in-flight snapshot transfer."""
+
+    total_chunks: int
+    sha256_hex: str
+    schema_version: int
+    last_event_applied_idx: int
+    chunks: dict[int, bytes] = field(default_factory=dict)
+
+    def is_complete(self) -> bool:
+        return len(self.chunks) == self.total_chunks
+
+    def assemble(self) -> bytes:
+        return b"".join(self.chunks[i] for i in range(self.total_chunks))
+
+
+@dataclass
+class ReceivedSnapshot:
+    last_event_applied_idx: int
+    state: State
+
+
+class SnapshotReceiver:
+    """Filters and reassembles inbound chunks into a `ReceivedSnapshot`.
+
+    Stateless w.r.t. delivery: callers feed `SnapshotChunk`s in via `ingest`
+    and check the return value for completion.
+    """
+
+    def __init__(self, my_node_id: NodeId, session_id: SessionId) -> None:
+        self._my_node_id = my_node_id
+        self._session_id = session_id
+        self._assemblies: dict[SnapshotTransferId, _Assembly] = {}
+
+    def ingest(self, chunk: SnapshotChunk) -> ReceivedSnapshot | None:
+        """Absorb a chunk; return the snapshot once a transfer completes.
+
+        Returns None for partial transfers, mismatched recipients, stale
+        sessions, version mismatches, or corrupt payloads.
+        """
+        if chunk.requester_node_id != self._my_node_id:
+            return None
+        if chunk.session_id != self._session_id:
+            return None
+
+        existing = self._assemblies.get(chunk.transfer_id)
+        if existing is None:
+            existing = _Assembly(
+                total_chunks=chunk.total_chunks,
+                sha256_hex=chunk.sha256_hex,
+                schema_version=chunk.schema_version,
+                last_event_applied_idx=chunk.last_event_applied_idx,
+            )
+            self._assemblies[chunk.transfer_id] = existing
+        existing.chunks[chunk.chunk_index] = chunk.data
+
+        if not existing.is_complete():
+            return None
+
+        # Transfer complete — finalise and remove from the in-flight map.
+        del self._assemblies[chunk.transfer_id]
+        body = existing.assemble()
+        if hashlib.sha256(body).hexdigest() != existing.sha256_hex:
+            logger.warning(f"Snapshot {chunk.transfer_id} failed checksum; discarding")
+            return None
+        try:
+            decompressed = zstandard.ZstdDecompressor().decompress(body)
+            state = State.model_validate_json(decompressed.decode("utf-8"))
+        except (zstandard.ZstdError, ValueError) as e:
+            logger.opt(exception=e).warning(
+                f"Snapshot {chunk.transfer_id} could not be decoded; discarding"
+            )
+            return None
+        if state.schema_version != existing.schema_version:
+            # Should not happen — the master writes schema_version into both
+            # the chunk meta and the State payload — but treat it as corrupt.
+            logger.warning(
+                f"Snapshot {chunk.transfer_id} schema version mismatch "
+                f"(chunk={existing.schema_version}, state={state.schema_version})"
+            )
+            return None
+        return ReceivedSnapshot(
+            last_event_applied_idx=existing.last_event_applied_idx, state=state
+        )

--- a/src/exo/routing/tests/test_snapshot_receiver.py
+++ b/src/exo/routing/tests/test_snapshot_receiver.py
@@ -1,0 +1,151 @@
+import hashlib
+
+import pytest
+import zstandard
+
+from exo.routing.snapshot_receiver import SnapshotReceiver
+from exo.shared.types.common import NodeId, SessionId
+from exo.shared.types.snapshots import SnapshotChunk, SnapshotTransferId
+from exo.shared.types.state import State
+
+
+@pytest.fixture
+def session_id() -> SessionId:
+    return SessionId(master_node_id=NodeId("master"), election_clock=0)
+
+
+@pytest.fixture
+def my_node() -> NodeId:
+    return NodeId("worker-1")
+
+
+def _encode(state: State) -> bytes:
+    return zstandard.ZstdCompressor().compress(state.model_dump_json().encode("utf-8"))
+
+
+def _make_chunks(
+    body: bytes,
+    *,
+    chunk_size: int,
+    requester_node_id: NodeId,
+    session_id: SessionId,
+    state: State,
+    transfer_id: SnapshotTransferId | None = None,
+) -> list[SnapshotChunk]:
+    sha256 = hashlib.sha256(body).hexdigest()
+    transfer_id = transfer_id or SnapshotTransferId()
+    pieces = [body[i : i + chunk_size] for i in range(0, len(body), chunk_size)] or [
+        b""
+    ]
+    return [
+        SnapshotChunk.from_data(
+            data=piece,
+            transfer_id=transfer_id,
+            requester_node_id=requester_node_id,
+            session_id=session_id,
+            schema_version=state.schema_version,
+            last_event_applied_idx=state.last_event_applied_idx,
+            chunk_index=i,
+            total_chunks=len(pieces),
+            sha256_hex=sha256,
+        )
+        for i, piece in enumerate(pieces)
+    ]
+
+
+def test_completes_on_full_transfer(my_node: NodeId, session_id: SessionId):
+    state = State(last_event_applied_idx=42)
+    chunks = _make_chunks(
+        _encode(state),
+        chunk_size=64,
+        requester_node_id=my_node,
+        session_id=session_id,
+        state=state,
+    )
+    receiver = SnapshotReceiver(my_node, session_id)
+
+    received = None
+    for chunk in chunks:
+        received = receiver.ingest(chunk)
+    assert received is not None
+    assert received.last_event_applied_idx == 42
+    assert received.state.last_event_applied_idx == 42
+
+
+def test_handles_out_of_order_chunks(my_node: NodeId, session_id: SessionId):
+    state = State(last_event_applied_idx=99)
+    chunks = _make_chunks(
+        _encode(state),
+        chunk_size=32,
+        requester_node_id=my_node,
+        session_id=session_id,
+        state=state,
+    )
+    receiver = SnapshotReceiver(my_node, session_id)
+
+    # Reverse them.
+    received = None
+    for chunk in reversed(chunks):
+        received = receiver.ingest(chunk)
+    assert received is not None
+    assert received.last_event_applied_idx == 99
+
+
+def test_ignores_chunks_for_other_recipients(my_node: NodeId, session_id: SessionId):
+    state = State(last_event_applied_idx=1)
+    other = NodeId("worker-2")
+    chunks = _make_chunks(
+        _encode(state),
+        chunk_size=64,
+        requester_node_id=other,
+        session_id=session_id,
+        state=state,
+    )
+    receiver = SnapshotReceiver(my_node, session_id)
+    for chunk in chunks:
+        assert receiver.ingest(chunk) is None
+
+
+def test_ignores_chunks_from_stale_session(my_node: NodeId, session_id: SessionId):
+    state = State(last_event_applied_idx=1)
+    other_session = SessionId(master_node_id=NodeId("other-master"), election_clock=99)
+    chunks = _make_chunks(
+        _encode(state),
+        chunk_size=64,
+        requester_node_id=my_node,
+        session_id=other_session,
+        state=state,
+    )
+    receiver = SnapshotReceiver(my_node, session_id)
+    for chunk in chunks:
+        assert receiver.ingest(chunk) is None
+
+
+def test_discards_on_checksum_mismatch(my_node: NodeId, session_id: SessionId):
+    state = State(last_event_applied_idx=1)
+    chunks = _make_chunks(
+        _encode(state),
+        chunk_size=64,
+        requester_node_id=my_node,
+        session_id=session_id,
+        state=state,
+    )
+    # Corrupt the last byte of the last chunk.
+    original = chunks[-1]
+    chunks[-1] = SnapshotChunk.from_data(
+        data=original.data + b"\x00garbage",
+        transfer_id=original.transfer_id,
+        requester_node_id=original.requester_node_id,
+        session_id=original.session_id,
+        schema_version=original.schema_version,
+        last_event_applied_idx=original.last_event_applied_idx,
+        chunk_index=original.chunk_index,
+        total_chunks=original.total_chunks,
+        sha256_hex=original.sha256_hex,
+    )
+
+    receiver = SnapshotReceiver(my_node, session_id)
+    received = None
+    for chunk in chunks:
+        received = receiver.ingest(chunk)
+    assert received is None

--- a/src/exo/routing/topics.py
+++ b/src/exo/routing/topics.py
@@ -6,8 +6,10 @@ from exo.shared.election import ElectionMessage
 from exo.shared.types.commands import ForwarderCommand, ForwarderDownloadCommand
 from exo.shared.types.events import (
     GlobalForwarderEvent,
+    GlobalForwarderTransientEvent,
     LocalForwarderEvent,
 )
+from exo.shared.types.snapshots import SnapshotChunk
 from exo.utils.pydantic_ext import FrozenModel
 
 
@@ -39,6 +41,9 @@ class TypedTopic[T: FrozenModel]:
 
 GLOBAL_EVENTS = TypedTopic("global_events", PublishPolicy.Always, GlobalForwarderEvent)
 LOCAL_EVENTS = TypedTopic("local_events", PublishPolicy.Always, LocalForwarderEvent)
+TRANSIENT_EVENTS = TypedTopic(
+    "transient_events", PublishPolicy.Always, GlobalForwarderTransientEvent
+)
 COMMANDS = TypedTopic("commands", PublishPolicy.Always, ForwarderCommand)
 ELECTION_MESSAGES = TypedTopic(
     "election_messages", PublishPolicy.Always, ElectionMessage
@@ -48,4 +53,7 @@ CONNECTION_MESSAGES = TypedTopic(
 )
 DOWNLOAD_COMMANDS = TypedTopic(
     "download_commands", PublishPolicy.Always, ForwarderDownloadCommand
+)
+SNAPSHOT_RESPONSES = TypedTopic(
+    "snapshot_responses", PublishPolicy.Always, SnapshotChunk
 )

--- a/src/exo/routing/transient_router.py
+++ b/src/exo/routing/transient_router.py
@@ -1,0 +1,97 @@
+from dataclasses import dataclass, field
+
+from anyio import BrokenResourceError, ClosedResourceError
+from loguru import logger
+
+from exo.shared.types.common import NodeId, SessionId
+from exo.shared.types.events import (
+    GlobalForwarderTransientEvent,
+    TransientEvent,
+)
+from exo.utils.channels import Receiver, Sender, channel
+from exo.utils.task_group import TaskGroup
+
+
+@dataclass
+class TransientRouter:
+    """Routes TransientEvents over the cluster's TRANSIENT_EVENTS topic.
+
+    Transients are per-request streaming/notification signals (token chunks,
+    image-upload chunks, trace data) that intentionally bypass the durable
+    event log: they're not ordered, not persisted, not replayed. A node that
+    joins via snapshot will simply not see transients that were emitted before
+    it joined, which is the correct behaviour — replaying old token chunks to
+    a closed HTTP stream would be wrong.
+
+    Producers call `sender()` to get a `Sender[TransientEvent]`; values sent
+    on it are wrapped in a `GlobalForwarderTransientEvent` and published on
+    the network. Consumers call `receiver()` to get a `Receiver[TransientEvent]`
+    that yields events from this session only.
+    """
+
+    node_id: NodeId
+    session_id: SessionId
+    external_outbound: Sender[GlobalForwarderTransientEvent]
+    external_inbound: Receiver[GlobalForwarderTransientEvent]
+    _outbound: list[Sender[TransientEvent]] = field(init=False, default_factory=list)
+    _inbound: list[Receiver[TransientEvent]] = field(init=False, default_factory=list)
+    _tg: TaskGroup = field(init=False, default_factory=TaskGroup)
+
+    def sender(self) -> Sender[TransientEvent]:
+        send, recv = channel[TransientEvent]()
+        if self._tg.is_running():
+            self._tg.start_soon(self._publish, recv)
+        else:
+            self._inbound.append(recv)
+        return send
+
+    def receiver(self) -> Receiver[TransientEvent]:
+        assert not self._tg.is_running(), (
+            "TransientRouter receivers must be registered before run()"
+        )
+        send, recv = channel[TransientEvent]()
+        self._outbound.append(send)
+        return recv
+
+    def shutdown(self) -> None:
+        self._tg.cancel_tasks()
+
+    async def run(self) -> None:
+        try:
+            async with self._tg as tg:
+                for recv in self._inbound:
+                    tg.start_soon(self._publish, recv)
+                tg.start_soon(self._dispatch_inbound)
+        finally:
+            self.external_outbound.close()
+            for send in self._outbound:
+                send.close()
+
+    async def _publish(self, recv: Receiver[TransientEvent]) -> None:
+        with recv as events:
+            async for event in events:
+                await self.external_outbound.send(
+                    GlobalForwarderTransientEvent(
+                        origin=self.node_id,
+                        session=self.session_id,
+                        event=event,
+                    )
+                )
+
+    async def _dispatch_inbound(self) -> None:
+        with self.external_inbound as wrapped_events:
+            async for wrapped in wrapped_events:
+                if wrapped.session != self.session_id:
+                    continue
+                stale: set[int] = set()
+                for i, send in enumerate(self._outbound):
+                    try:
+                        await send.send(wrapped.event)
+                    except (ClosedResourceError, BrokenResourceError):
+                        stale.add(i)
+                if stale:
+                    for i in sorted(stale, reverse=True):
+                        self._outbound.pop(i)
+                    logger.debug(
+                        f"TransientRouter dropped {len(stale)} closed receivers"
+                    )

--- a/src/exo/shared/apply.py
+++ b/src/exo/shared/apply.py
@@ -4,14 +4,13 @@ from datetime import datetime
 
 from loguru import logger
 
-from exo.shared.types.common import NodeId
+from exo.shared.models.model_cards import ModelCard
+from exo.shared.types.common import ModelId, NodeId
 from exo.shared.types.events import (
-    ChunkGenerated,
     CustomModelCardAdded,
     CustomModelCardDeleted,
     Event,
     IndexedEvent,
-    InputChunkReceived,
     InstanceCreated,
     InstanceDeleted,
     InstanceLinkCreated,
@@ -20,7 +19,6 @@ from exo.shared.types.events import (
     NodeGatheredInfo,
     NodeTimedOut,
     RunnerStatusUpdated,
-    TaskAcknowledged,
     TaskCreated,
     TaskDeleted,
     TaskFailed,
@@ -28,8 +26,6 @@ from exo.shared.types.events import (
     TestEvent,
     TopologyEdgeCreated,
     TopologyEdgeDeleted,
-    TracesCollected,
-    TracesMerged,
 )
 from exo.shared.types.instance_link import InstanceLink, InstanceLinkId
 from exo.shared.types.profiling import (
@@ -68,17 +64,12 @@ from exo.utils.info_gatherer.info_gatherer import (
 def event_apply(event: Event, state: State) -> State:
     """Apply an event to state."""
     match event:
-        case (
-            TestEvent()
-            | ChunkGenerated()
-            | TaskAcknowledged()
-            | InputChunkReceived()
-            | TracesCollected()
-            | TracesMerged()
-            | CustomModelCardAdded()
-            | CustomModelCardDeleted()
-        ):  # Pass-through events that don't modify state
+        case TestEvent():
             return state
+        case CustomModelCardAdded():
+            return apply_custom_model_card_added(event, state)
+        case CustomModelCardDeleted():
+            return apply_custom_model_card_deleted(event, state)
         case InstanceCreated():
             return apply_instance_created(event, state)
         case InstanceDeleted():
@@ -447,3 +438,22 @@ def apply_topology_edge_deleted(event: TopologyEdgeDeleted, state: State) -> Sta
     topology.remove_connection(event.conn)
     # TODO: Clean up removing the reverse connection
     return state.model_copy(update={"topology": topology})
+
+
+def apply_custom_model_card_added(event: CustomModelCardAdded, state: State) -> State:
+    new_cards: Mapping[ModelId, ModelCard] = {
+        **state.custom_model_cards,
+        event.model_card.model_id: event.model_card,
+    }
+    return state.model_copy(update={"custom_model_cards": new_cards})
+
+
+def apply_custom_model_card_deleted(
+    event: CustomModelCardDeleted, state: State
+) -> State:
+    new_cards: Mapping[ModelId, ModelCard] = {
+        mid: card
+        for mid, card in state.custom_model_cards.items()
+        if mid != event.model_id
+    }
+    return state.model_copy(update={"custom_model_cards": new_cards})

--- a/src/exo/shared/types/commands.py
+++ b/src/exo/shared/types/commands.py
@@ -67,6 +67,17 @@ class RequestEventLog(BaseCommand):
     since_idx: int
 
 
+class RequestSnapshot(BaseCommand):
+    """Sent by a joining node asking the master to deliver a snapshot.
+
+    The master reads its latest persisted snapshot, slices it into chunks,
+    and publishes those on the SNAPSHOT_RESPONSES topic. Chunks include the
+    `requester_node_id` so other nodes know to ignore them.
+    """
+
+    requester_node_id: NodeId
+
+
 class StartDownload(BaseCommand):
     target_node_id: NodeId
     shard_metadata: ShardMetadata
@@ -106,6 +117,7 @@ DownloadCommand = StartDownload | DeleteDownload | CancelDownload
 Command = (
     TestCommand
     | RequestEventLog
+    | RequestSnapshot
     | TextGeneration
     | ImageGeneration
     | ImageEdits

--- a/src/exo/shared/types/events.py
+++ b/src/exo/shared/types/events.py
@@ -146,29 +146,37 @@ class InstanceLinkDeleted(BaseEvent):
     link_id: InstanceLinkId
 
 
+# Durable events: reduced into State by `apply()`, persisted in the master's
+# event log, ordered by a global index, and replayable.
 Event = (
     TestEvent
     | TaskCreated
     | TaskStatusUpdated
     | TaskFailed
     | TaskDeleted
-    | TaskAcknowledged
     | InstanceCreated
     | InstanceDeleted
     | RunnerStatusUpdated
     | NodeTimedOut
     | NodeGatheredInfo
     | NodeDownloadProgress
-    | ChunkGenerated
-    | InputChunkReceived
     | TopologyEdgeCreated
     | TopologyEdgeDeleted
-    | TracesCollected
-    | TracesMerged
     | CustomModelCardAdded
     | CustomModelCardDeleted
     | InstanceLinkCreated
     | InstanceLinkDeleted
+)
+
+# Transient events: per-request streaming/notification signals. Not persisted,
+# not ordered, not replayed. Routed over a separate pubsub channel so a node
+# joining via snapshot doesn't have to (incorrectly) replay them.
+TransientEvent = (
+    TaskAcknowledged
+    | ChunkGenerated
+    | InputChunkReceived
+    | TracesCollected
+    | TracesMerged
 )
 
 
@@ -195,3 +203,14 @@ class LocalForwarderEvent(FrozenModel):
     origin: SystemId
     session: SessionId
     event: Event
+
+
+class GlobalForwarderTransientEvent(FrozenModel):
+    """A transient event published to the cluster.
+
+    No `origin_idx`: transients are unordered and not persisted.
+    """
+
+    origin: NodeId
+    session: SessionId
+    event: TransientEvent

--- a/src/exo/shared/types/snapshots.py
+++ b/src/exo/shared/types/snapshots.py
@@ -1,0 +1,54 @@
+"""Wire types for snapshot transfer between master and a joining node.
+
+Snapshots can be tens of MB; the gossipsub message ceiling is around 1 MB.
+We slice the compressed snapshot body into chunks and publish each chunk on
+the SNAPSHOT_RESPONSES topic. The receiver collects chunks for its own
+`requester_node_id`, validates the SHA-256 of the reassembled body, and
+materialises the State.
+"""
+
+import base64
+
+from exo.shared.types.common import Id, NodeId, SessionId
+from exo.utils.pydantic_ext import FrozenModel
+
+
+class SnapshotTransferId(Id):
+    """Identifies a single snapshot transfer (one master response to one
+    `RequestSnapshot`). Distinct transfers may interleave; the id lets
+    receivers keep them apart."""
+
+
+class SnapshotChunk(FrozenModel):
+    """One slice of a snapshot in flight.
+
+    `data_b64` carries a base64-encoded slice of the zstd-compressed JSON
+    dump of State. Concatenating the *decoded* bytes of all chunks for a
+    `transfer_id` in order of `chunk_index` yields the full compressed
+    body; `sha256_hex` is the SHA-256 of that decoded blob.
+
+    We use base64 explicitly because the topic layer JSON-encodes messages,
+    and JSON can't carry raw binary. Helpers `from_data` / `data` keep the
+    base64 detail at the boundaries.
+    """
+
+    transfer_id: SnapshotTransferId
+    requester_node_id: NodeId
+    session_id: SessionId
+    schema_version: int
+    last_event_applied_idx: int
+    chunk_index: int
+    total_chunks: int
+    sha256_hex: str
+    data_b64: str
+
+    @classmethod
+    def from_data(cls, *, data: bytes, **kwargs: object) -> "SnapshotChunk":
+        return cls(data_b64=base64.b64encode(data).decode("ascii"), **kwargs)  # pyright: ignore[reportArgumentType]
+
+    @property
+    def data(self) -> bytes:
+        return base64.b64decode(self.data_b64)
+
+
+__all__ = ["SnapshotChunk", "SnapshotTransferId"]

--- a/src/exo/shared/types/state.py
+++ b/src/exo/shared/types/state.py
@@ -5,8 +5,9 @@ from typing import Any, cast
 from pydantic import ConfigDict, Field, field_serializer, field_validator
 from pydantic.alias_generators import to_camel
 
+from exo.shared.models.model_cards import ModelCard
 from exo.shared.topology import Topology, TopologySnapshot
-from exo.shared.types.common import NodeId
+from exo.shared.types.common import ModelId, NodeId
 from exo.shared.types.instance_link import InstanceLink, InstanceLinkId
 from exo.shared.types.profiling import (
     DiskUsage,
@@ -41,6 +42,11 @@ class State(FrozenModel):
         strict=True,
         arbitrary_types_allowed=True,
     )
+    # Bumped when we introduce a State change that older snapshots can't be
+    # round-tripped through (renamed/removed fields, new required fields).
+    # Snapshots tagged with a different version are discarded on load.
+    schema_version: int = Field(default=1, ge=1)
+
     instances: Mapping[InstanceId, Instance] = {}
     runners: Mapping[RunnerId, RunnerStatus] = {}
     downloads: Mapping[NodeId, Sequence[DownloadProgress]] = {}
@@ -64,6 +70,10 @@ class State(FrozenModel):
 
     instance_links: Mapping[InstanceLinkId, InstanceLink] = {}
     prefill_server_ports: Mapping[RunnerId, int] = {}
+
+    # User-added model cards. The on-disk copies under EXO_CUSTOM_MODEL_CARDS_DIR
+    # are reconciled to match this map by the worker.
+    custom_model_cards: Mapping[ModelId, ModelCard] = {}
 
     @field_serializer("topology", mode="plain")
     def _encode_topology(self, value: Topology) -> TopologySnapshot:

--- a/src/exo/utils/event_buffer.py
+++ b/src/exo/utils/event_buffer.py
@@ -47,6 +47,20 @@ class OrderedBuffer[T]:
         logger.trace(f"Releasing event {ret}")
         return ret
 
+    def fast_forward_to(self, idx: int) -> None:
+        """Skip past every event with index less than `idx`.
+
+        Used after a snapshot apply: the snapshot already covers events up to
+        and including `idx - 1`, so any pending or future events below `idx`
+        are redundant and should be discarded. Only moves forward — calling
+        with a smaller idx is a no-op.
+        """
+        if idx <= self.next_idx_to_release:
+            return
+        self.next_idx_to_release = idx
+        for stale in [i for i in self.store if i < idx]:
+            del self.store[stale]
+
 
 class MultiSourceBuffer[SourceId, T]:
     """

--- a/src/exo/utils/keyed_backoff.py
+++ b/src/exo/utils/keyed_backoff.py
@@ -33,3 +33,11 @@ class KeyedBackoff[K]:
         """Reset backoff state for a key (e.g., on success)."""
         self._attempts.pop(key, None)
         self._last_time.pop(key, None)
+
+    def tracked_keys(self) -> list[K]:
+        """Snapshot of every key with recorded backoff state.
+
+        Returns a fresh list rather than a live view so callers can safely
+        mutate the backoff (e.g. reset entries) while iterating.
+        """
+        return list(self._attempts.keys() | self._last_time.keys())

--- a/src/exo/worker/engines/image/builder.py
+++ b/src/exo/worker/engines/image/builder.py
@@ -15,6 +15,7 @@ from exo.shared.types.events import (
     Event,
     TraceEventData,
     TracesCollected,
+    TransientEvent,
 )
 from exo.shared.types.tasks import (
     GenerationTask,
@@ -66,7 +67,7 @@ def _is_primary_output_node(shard_metadata: ShardMetadata) -> bool:
 
 
 def _send_traces_if_enabled(
-    event_sender: MpSender[Event],
+    event_sender: MpSender[Event | TransientEvent],
     task_id: TaskId,
     rank: int,
 ) -> None:
@@ -97,7 +98,7 @@ def _send_traces_if_enabled(
 
 @dataclass
 class MfluxBuilder(Builder):
-    event_sender: MpSender[Event]
+    event_sender: MpSender[Event | TransientEvent]
     cancel_receiver: MpReceiver[TaskId]
     shard_metadata: ShardMetadata | None = None
     image_model: DistributedImageModel | None = None
@@ -137,7 +138,7 @@ class MfluxBuilder(Builder):
 class ImageEngine(Engine):
     image_model: DistributedImageModel
     shard_metadata: ShardMetadata
-    event_sender: MpSender[Event]
+    event_sender: MpSender[Event | TransientEvent]
     cancel_receiver: MpReceiver[TaskId]
     current_gen: (
         Generator[tuple[TaskId, Chunk | FinishedResponse | CancelledResponse]] | None

--- a/src/exo/worker/engines/mlx/builder.py
+++ b/src/exo/worker/engines/mlx/builder.py
@@ -7,7 +7,7 @@ import mlx.core as mx
 from mlx_lm.tokenizer_utils import TokenizerWrapper
 
 from exo.shared.types.common import ModelId
-from exo.shared.types.events import Event
+from exo.shared.types.events import Event, TransientEvent
 from exo.shared.types.tasks import TaskId
 from exo.shared.types.worker.instances import BoundInstance
 from exo.shared.types.worker.runner_response import ModelLoadingResponse
@@ -32,7 +32,7 @@ from .vision import VisionProcessor
 @dataclass
 class MlxBuilder(Builder):
     model_id: ModelId
-    event_sender: MpSender[Event]
+    event_sender: MpSender[Event | TransientEvent]
     cancel_receiver: MpReceiver[TaskId]
     inference_model: Model | None = None
     tokenizer: TokenizerWrapper | None = None

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -8,32 +8,39 @@ from loguru import logger
 
 from exo.api.types import ImageEditsTaskParams
 from exo.download.download_utils import is_read_only_model_dir, resolve_existing_model
+from exo.routing.event_router import EventRouter
+from exo.routing.snapshot_receiver import SnapshotReceiver
 from exo.shared.apply import apply
 from exo.shared.constants import EXO_MAX_INSTANCE_RETRIES
-from exo.shared.models.model_cards import ModelId, add_to_card_cache, delete_custom_card
+from exo.shared.models.model_cards import (
+    ModelCard,
+    ModelId,
+    add_to_card_cache,
+    delete_custom_card,
+)
 from exo.shared.types.chunks import InputImageChunk
 from exo.shared.types.commands import (
     DeleteInstance,
     ForwarderCommand,
     ForwarderDownloadCommand,
+    RequestSnapshot,
     StartDownload,
 )
-from exo.shared.types.common import CommandId, NodeId, SystemId
+from exo.shared.types.common import CommandId, NodeId, SessionId, SystemId
 from exo.shared.types.events import (
-    CustomModelCardAdded,
-    CustomModelCardDeleted,
     Event,
     IndexedEvent,
     InputChunkReceived,
-    InstanceDeleted,
     NodeDownloadProgress,
     NodeGatheredInfo,
     TaskCreated,
     TaskStatusUpdated,
     TopologyEdgeCreated,
     TopologyEdgeDeleted,
+    TransientEvent,
 )
 from exo.shared.types.multiaddr import Multiaddr
+from exo.shared.types.snapshots import SnapshotChunk
 from exo.shared.types.state import State
 from exo.shared.types.tasks import (
     CancelTask,
@@ -59,14 +66,21 @@ from exo.utils.task_group import TaskGroup
 from exo.worker.plan import plan
 from exo.worker.runner.supervisor import RunnerSupervisor
 
+_SNAPSHOT_FETCH_TIMEOUT_SECONDS = 30
+
 
 class Worker:
     def __init__(
         self,
         node_id: NodeId,
+        session_id: SessionId,
         *,
+        event_router: EventRouter,
         event_receiver: Receiver[IndexedEvent],
         event_sender: Sender[Event],
+        transient_event_receiver: Receiver[TransientEvent],
+        transient_event_sender: Sender[TransientEvent],
+        snapshot_chunk_receiver: Receiver[SnapshotChunk],
         # This is for requesting updates. It doesn't need to be a general command sender right now,
         # but I think it's the correct way to be thinking about commands
         command_sender: Sender[ForwarderCommand],
@@ -74,8 +88,13 @@ class Worker:
         api_port: int,
     ):
         self.node_id: NodeId = node_id
+        self.session_id: SessionId = session_id
+        self.event_router = event_router
         self.event_receiver = event_receiver
         self.event_sender = event_sender
+        self.transient_event_receiver = transient_event_receiver
+        self.transient_event_sender = transient_event_sender
+        self.snapshot_chunk_receiver = snapshot_chunk_receiver
         self.command_sender = command_sender
         self.download_command_sender = download_command_sender
         self.api_port = api_port
@@ -95,6 +114,9 @@ class Worker:
         self._instance_backoff: KeyedBackoff[InstanceId] = KeyedBackoff(
             base=0.5, cap=10.0
         )
+        # Tracks the on-disk copies of custom model cards we've written. The
+        # reconciliation loop diffs this against state.custom_model_cards.
+        self._synced_custom_cards: dict[ModelId, ModelCard] = {}
         self._stopped: anyio.Event = anyio.Event()
 
     async def run(self):
@@ -105,20 +127,70 @@ class Worker:
 
         try:
             async with self._tg as tg:
-                tg.start_soon(info_gatherer.run)
-                tg.start_soon(self._forward_info, info_recv)
-                tg.start_soon(self.plan_step)
-                tg.start_soon(self._event_applier)
-                tg.start_soon(self._poll_connection_updates)
+                # Snapshot fetch runs inside the task group so shutdown()
+                # during the fetch (e.g. a master re-election arriving early)
+                # cancels cleanly. Events are queued by the EventRouter
+                # while we wait; if the master has no snapshot we fall
+                # through to the NACK-based event-log replay.
+                tg.start_soon(self._bootstrap_then_run, info_gatherer, info_recv)
         finally:
             # Actual shutdown code - waits for all tasks to complete before executing.
             logger.info("Stopping Worker")
             self.event_sender.close()
+            self.transient_event_sender.close()
+            self.snapshot_chunk_receiver.close()
             self.command_sender.close()
             self.download_command_sender.close()
             for runner in self.runners.values():
                 runner.shutdown()
             self._stopped.set()
+
+    async def _bootstrap_then_run(
+        self, info_gatherer: InfoGatherer, info_recv: Receiver[GatheredInfo]
+    ) -> None:
+        await self._fetch_snapshot()
+        self._tg.start_soon(info_gatherer.run)
+        self._tg.start_soon(self._forward_info, info_recv)
+        self._tg.start_soon(self.plan_step)
+        self._tg.start_soon(self._event_applier)
+        self._tg.start_soon(self._transient_event_handler)
+        self._tg.start_soon(self._reconcile_instance_backoff)
+        self._tg.start_soon(self._reconcile_custom_cards)
+        self._tg.start_soon(self._poll_connection_updates)
+
+    async def _fetch_snapshot(self) -> None:
+        """Request a snapshot from the master and apply it before draining events.
+
+        We expect this to take well under a second on a healthy cluster. If
+        nothing arrives within `_SNAPSHOT_FETCH_TIMEOUT_SECONDS`, we proceed
+        with an empty state — the existing NACK loop will replay the entire
+        event log, which is slow but always correct.
+        """
+        receiver = SnapshotReceiver(self.node_id, self.session_id)
+        await self.command_sender.send(
+            ForwarderCommand(
+                origin=self._system_id,
+                command=RequestSnapshot(requester_node_id=self.node_id),
+            )
+        )
+
+        with anyio.move_on_after(_SNAPSHOT_FETCH_TIMEOUT_SECONDS):
+            with self.snapshot_chunk_receiver as chunks:
+                async for chunk in chunks:
+                    received = receiver.ingest(chunk)
+                    if received is not None:
+                        self.state = received.state
+                        self.event_router.set_buffer_start(
+                            received.last_event_applied_idx + 1
+                        )
+                        logger.info(
+                            f"Worker bootstrapped from snapshot at idx "
+                            f"{received.last_event_applied_idx}"
+                        )
+                        return
+        logger.info(
+            "No snapshot received before timeout; falling back to full event-log replay"
+        )
 
     async def _forward_info(self, recv: Receiver[GatheredInfo]):
         with recv as info_stream:
@@ -134,50 +206,85 @@ class Worker:
     async def _event_applier(self):
         with self.event_receiver as events:
             async for event in events:
-                # 2. for each event, apply it to the state
+                # Events queued before our snapshot was applied are no-ops:
+                # the snapshot already folded them in.
+                if event.idx <= self.state.last_event_applied_idx:
+                    continue
                 self.state = apply(self.state, event=event)
-                event = event.event
 
-                if isinstance(event, InstanceDeleted):
-                    self._instance_backoff.reset(event.instance_id)
-
-                # Buffer input image chunks for image editing
+    async def _transient_event_handler(self):
+        with self.transient_event_receiver as events:
+            async for event in events:
                 if isinstance(event, InputChunkReceived):
-                    cmd_id = event.command_id
-                    if cmd_id not in self.input_chunk_buffer:
-                        self.input_chunk_buffer[cmd_id] = {}
-                        self.input_chunk_counts[cmd_id] = event.chunk.total_chunks
+                    self._absorb_input_chunk(event)
 
-                    self.input_chunk_buffer[cmd_id][event.chunk.chunk_index] = (
-                        event.chunk
+    async def _reconcile_instance_backoff(self):
+        """Drop backoff entries for instances no longer in state.
+
+        Reconciling from state (rather than reacting to InstanceDeleted) keeps
+        worker behaviour correct after snapshot-based catch-up, which may not
+        replay the deletion event at all.
+        """
+        while True:
+            await anyio.sleep(1)
+            live_instances = set(self.state.instances.keys())
+            for iid in self._instance_backoff.tracked_keys():
+                if iid not in live_instances:
+                    self._instance_backoff.reset(iid)
+
+    async def _reconcile_custom_cards(self):
+        """Make the on-disk custom model cards match `state.custom_model_cards`.
+
+        Adds and removes are driven by state diffs rather than event reactions
+        so that joining via snapshot (which skips historical events) still
+        leaves disk in sync.
+        """
+        while True:
+            await anyio.sleep(1)
+            target = dict(self.state.custom_model_cards)
+            for model_id, card in target.items():
+                if self._synced_custom_cards.get(model_id) == card:
+                    continue
+                try:
+                    await card.save_to_custom_dir()
+                    add_to_card_cache(card)
+                    self._synced_custom_cards[model_id] = card
+                except OSError as e:
+                    logger.opt(exception=e).warning(
+                        f"Failed to write custom model card {model_id}; will retry"
+                    )
+            for model_id in list(self._synced_custom_cards):
+                if model_id in target:
+                    continue
+                try:
+                    await delete_custom_card(model_id)
+                    self._synced_custom_cards.pop(model_id, None)
+                except OSError as e:
+                    logger.opt(exception=e).warning(
+                        f"Failed to delete custom model card {model_id}; will retry"
                     )
 
-                    if (
-                        len(self.input_chunk_buffer[cmd_id])
-                        == self.input_chunk_counts[cmd_id]
-                    ):
-                        per_image: defaultdict[int, list[InputImageChunk]] = (
-                            defaultdict(list)
-                        )
-                        for chunk in self.input_chunk_buffer[cmd_id].values():
-                            per_image[chunk.image_index].append(chunk)
-                        for chunks_for_image in per_image.values():
-                            sorted_chunks = sorted(
-                                chunks_for_image, key=lambda c: c.chunk_index
-                            )
-                            img = Base64Image("".join(c.data for c in sorted_chunks))
-                            self.image_cache[
-                                Base64ImageHash(
-                                    hashlib.sha256(img.encode("ascii")).hexdigest()
-                                )
-                            ] = img
+    def _absorb_input_chunk(self, event: InputChunkReceived) -> None:
+        """Buffer an image-upload chunk; once all chunks for a command have
+        arrived, reassemble each image and cache it by hash."""
+        cmd_id = event.command_id
+        if cmd_id not in self.input_chunk_buffer:
+            self.input_chunk_buffer[cmd_id] = {}
+            self.input_chunk_counts[cmd_id] = event.chunk.total_chunks
 
-                if isinstance(event, CustomModelCardAdded):
-                    await event.model_card.save_to_custom_dir()
-                    add_to_card_cache(event.model_card)
+        self.input_chunk_buffer[cmd_id][event.chunk.chunk_index] = event.chunk
 
-                if isinstance(event, CustomModelCardDeleted):
-                    await delete_custom_card(event.model_id)
+        if len(self.input_chunk_buffer[cmd_id]) != self.input_chunk_counts[cmd_id]:
+            return
+
+        per_image: defaultdict[int, list[InputImageChunk]] = defaultdict(list)
+        for chunk in self.input_chunk_buffer[cmd_id].values():
+            per_image[chunk.image_index].append(chunk)
+        for chunks_for_image in per_image.values():
+            sorted_chunks = sorted(chunks_for_image, key=lambda c: c.chunk_index)
+            img = Base64Image("".join(c.data for c in sorted_chunks))
+            digest = Base64ImageHash(hashlib.sha256(img.encode("ascii")).hexdigest())
+            self.image_cache[digest] = img
 
     async def plan_step(self):
         while True:
@@ -370,12 +477,18 @@ class Worker:
         runner = RunnerSupervisor.create(
             bound_instance=task.bound_instance,
             event_sender=self.event_sender.clone(),
+            transient_event_sender=self.transient_event_sender.clone(),
         )
         self.runners[task.bound_instance.bound_runner_id] = runner
         self._tg.start_soon(runner.run)
         return runner
 
     async def _poll_connection_updates(self):
+        # Poll cadence trades off cluster-view freshness against ping load.
+        # 2s makes topology edge changes feel snappy on the dashboard while
+        # still being well above the per-probe timeout (5s) so we don't
+        # stack overlapping probes when peers are slow.
+        poll_interval_seconds = 2.0
         while True:
             edges = set(
                 conn.edge for conn in self.state.topology.out_edges(self.node_id)
@@ -418,4 +531,4 @@ class Worker:
                     logger.debug(f"ping failed to discover {conn=}")
                     await self.event_sender.send(TopologyEdgeDeleted(conn=conn))
 
-            await anyio.sleep(10)
+            await anyio.sleep(poll_interval_seconds)

--- a/src/exo/worker/runner/bootstrap.py
+++ b/src/exo/worker/runner/bootstrap.py
@@ -3,7 +3,7 @@ import resource
 
 import loguru
 
-from exo.shared.types.events import Event, RunnerStatusUpdated
+from exo.shared.types.events import Event, RunnerStatusUpdated, TransientEvent
 from exo.shared.types.tasks import Task, TaskId
 from exo.shared.types.worker.instances import BoundInstance
 from exo.shared.types.worker.runners import RunnerFailed
@@ -15,7 +15,7 @@ logger: "loguru.Logger" = loguru.logger
 
 def entrypoint(
     bound_instance: BoundInstance,
-    event_sender: MpSender[Event],
+    event_sender: MpSender[Event | TransientEvent],
     task_receiver: MpReceiver[Task],
     cancel_receiver: MpReceiver[TaskId],
     _logger: "loguru.Logger",

--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -11,7 +11,7 @@ from mlx_lm.tokenizer_utils import TokenizerWrapper
 from exo.shared.constants import EXO_MAX_CONCURRENT_REQUESTS
 from exo.shared.types.chunks import ErrorChunk, GenerationChunk, PrefillProgressChunk
 from exo.shared.types.common import ModelId
-from exo.shared.types.events import ChunkGenerated, Event
+from exo.shared.types.events import ChunkGenerated, Event, TransientEvent
 from exo.shared.types.tasks import (
     CANCEL_ALL_TASKS,
     GenerationTask,
@@ -96,7 +96,7 @@ class SequentialGenerator(Engine):
     model_id: ModelId
     device_rank: int
     cancel_receiver: MpReceiver[TaskId]
-    event_sender: MpSender[Event]
+    event_sender: MpSender[Event | TransientEvent]
     vision_processor: VisionProcessor | None = None
     check_for_cancel_every: int = 50
 
@@ -320,7 +320,7 @@ class BatchGenerator(Engine):
     model_id: ModelId
     device_rank: int
     cancel_receiver: MpReceiver[TaskId]
-    event_sender: MpSender[Event]
+    event_sender: MpSender[Event | TransientEvent]
     check_for_cancel_every: int = 50
     vision_processor: VisionProcessor | None = None
 

--- a/src/exo/worker/runner/runner.py
+++ b/src/exo/worker/runner/runner.py
@@ -16,6 +16,7 @@ from exo.shared.types.events import (
     RunnerStatusUpdated,
     TaskAcknowledged,
     TaskStatusUpdated,
+    TransientEvent,
 )
 from exo.shared.types.tasks import (
     ConnectToGroup,
@@ -86,7 +87,7 @@ class Runner:
         self,
         bound_instance: BoundInstance,
         builder: Builder,
-        event_sender: MpSender[Event],
+        event_sender: MpSender[Event | TransientEvent],
         task_receiver: MpReceiver[Task],
     ):
         self.event_sender = event_sender

--- a/src/exo/worker/runner/supervisor.py
+++ b/src/exo/worker/runner/supervisor.py
@@ -16,9 +16,13 @@ from exo.shared.types.chunks import ErrorChunk
 from exo.shared.types.events import (
     ChunkGenerated,
     Event,
+    InputChunkReceived,
     RunnerStatusUpdated,
     TaskAcknowledged,
     TaskStatusUpdated,
+    TracesCollected,
+    TracesMerged,
+    TransientEvent,
 )
 from exo.shared.types.tasks import (
     CANCEL_ALL_TASKS,
@@ -55,9 +59,10 @@ class RunnerSupervisor:
     bound_instance: BoundInstance
     runner_process: mp.Process
     initialize_timeout: float
-    _ev_recv: MpReceiver[Event]
+    _ev_recv: MpReceiver[Event | TransientEvent]
     _task_sender: MpSender[Task]
     _event_sender: Sender[Event]
+    _transient_event_sender: Sender[TransientEvent]
     _cancel_sender: MpSender[TaskId]
     _tg: TaskGroup = field(default_factory=TaskGroup, init=False)
     status: RunnerStatus = field(default_factory=RunnerIdle, init=False)
@@ -75,9 +80,10 @@ class RunnerSupervisor:
         *,
         bound_instance: BoundInstance,
         event_sender: Sender[Event],
+        transient_event_sender: Sender[TransientEvent],
         initialize_timeout: float = 400,
     ) -> Self:
-        ev_send, ev_recv = mp_channel[Event]()
+        ev_send, ev_recv = mp_channel[Event | TransientEvent]()
         task_sender, task_recv = mp_channel[Task]()
         cancel_sender, cancel_recv = mp_channel[TaskId]()
 
@@ -104,6 +110,7 @@ class RunnerSupervisor:
             _task_sender=task_sender,
             _cancel_sender=cancel_sender,
             _event_sender=event_sender,
+            _transient_event_sender=transient_event_sender,
         )
 
         return self
@@ -124,6 +131,8 @@ class RunnerSupervisor:
                 self._task_sender.close()
             with contextlib.suppress(ClosedResourceError):
                 self._event_sender.close()
+            with contextlib.suppress(ClosedResourceError):
+                self._transient_event_sender.close()
             with contextlib.suppress(ClosedResourceError):
                 self._cancel_sender.send(CANCEL_ALL_TASKS)
             with contextlib.suppress(ClosedResourceError):
@@ -216,6 +225,8 @@ class RunnerSupervisor:
                     if isinstance(event, RunnerStatusUpdated):
                         self.status = event.runner_status
                     if isinstance(event, TaskAcknowledged):
+                        # Acknowledgement is supervisor-internal: it resolves
+                        # the start_task() Future and never leaves this process.
                         self.pending.pop(event.task_id).set()
                         continue
                     if (
@@ -235,7 +246,19 @@ class RunnerSupervisor:
                         )
                         self.in_progress.pop(event.task_id, None)
                         self.completed.add(event.task_id)
-                    await self._event_sender.send(event)
+                    if isinstance(
+                        event,
+                        (
+                            ChunkGenerated,
+                            InputChunkReceived,
+                            TracesCollected,
+                            TracesMerged,
+                            TaskAcknowledged,
+                        ),
+                    ):
+                        await self._transient_event_sender.send(event)
+                    else:
+                        await self._event_sender.send(event)
         except (ClosedResourceError, BrokenResourceError) as e:
             await self._check_runner(e)
         finally:
@@ -275,7 +298,7 @@ class RunnerSupervisor:
         for task in self.in_progress.values():
             if isinstance(task, (TextGeneration, ImageGeneration, ImageEdits)):
                 with anyio.CancelScope(shield=True):
-                    await self._event_sender.send(
+                    await self._transient_event_sender.send(
                         ChunkGenerated(
                             command_id=task.command_id,
                             chunk=ErrorChunk(

--- a/src/exo/worker/tests/unittests/test_runner/test_event_ordering.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_event_ordering.py
@@ -15,6 +15,7 @@ from exo.shared.types.events import (
     RunnerStatusUpdated,
     TaskAcknowledged,
     TaskStatusUpdated,
+    TransientEvent,
 )
 from exo.shared.types.tasks import (
     ConnectToGroup,
@@ -110,7 +111,10 @@ CHAT_TASK = TextGeneration(
 )
 
 
-def assert_events_equal(test_events: Iterable[Event], true_events: Iterable[Event]):
+def assert_events_equal(
+    test_events: Iterable[Event | TransientEvent],
+    true_events: Iterable[Event | TransientEvent],
+):
     for test_event, true_event in zip(test_events, true_events, strict=True):
         test_event = test_event.model_copy(update={"event_id": true_event.event_id})
         assert test_event == true_event, f"{test_event} != {true_event}"

--- a/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
@@ -7,7 +7,12 @@ import pytest
 from exo.shared.models.model_cards import ModelId
 from exo.shared.types.chunks import ErrorChunk
 from exo.shared.types.common import CommandId, NodeId
-from exo.shared.types.events import ChunkGenerated, Event, RunnerStatusUpdated
+from exo.shared.types.events import (
+    ChunkGenerated,
+    Event,
+    RunnerStatusUpdated,
+    TransientEvent,
+)
 from exo.shared.types.tasks import Task, TaskId, TextGeneration
 from exo.shared.types.text_generation import (
     InputMessage,
@@ -43,9 +48,10 @@ class _DeadProcess:
 @pytest.mark.asyncio
 async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> None:
     event_sender, event_receiver = channel[Event]()
+    transient_sender, transient_receiver = channel[TransientEvent]()
     task_sender, _ = mp_channel[Task]()
     cancel_sender, _ = mp_channel[TaskId]()
-    _, ev_recv = mp_channel[Event]()
+    _, ev_recv = mp_channel[Event | TransientEvent]()
 
     bound_instance: BoundInstance = get_bound_mlx_ring_instance(
         instance_id=InstanceId("instance-a"),
@@ -62,6 +68,7 @@ async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> 
         _ev_recv=ev_recv,
         _task_sender=task_sender,
         _event_sender=event_sender,
+        _transient_event_sender=transient_sender,
         _cancel_sender=cancel_sender,
     )
 
@@ -81,7 +88,9 @@ async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> 
 
     await supervisor._check_runner(RuntimeError("boom"))  # pyright: ignore[reportPrivateUsage]
 
-    got_chunk = await event_receiver.receive()
+    # The synthetic error chunk now flows over the transient channel; the
+    # runner-status event still flows over the durable channel.
+    got_chunk = await transient_receiver.receive()
     got_status = await event_receiver.receive()
 
     assert isinstance(got_chunk, ChunkGenerated)
@@ -93,5 +102,7 @@ async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> 
     assert isinstance(got_status.runner_status, RunnerFailed)
 
     event_sender.close()
+    transient_sender.close()
     with anyio.move_on_after(0.1):
         await event_receiver.aclose()
+        await transient_receiver.aclose()


### PR DESCRIPTION
## Summary

- **Snapshot-based catch-up.** Joining nodes used to replay the entire event log 1000 events at a time over NACK round-trips (~15 min for 1M events). They now bootstrap from a master-served snapshot of `State` and replay only the small tail.
- **Event sourcing cleanup.** Split events into durable (state-modifying, persisted, ordered) and transient (streaming/notification) — durable consumers no longer react directly to events; they reconcile from state. Necessary precondition for snapshots: anything snapshot-skipped must converge from state alone.
- **Snappier liveness.** Master inactivity timeout 30s → 5s, plan tick 10s → 1s, worker neighbour-ping 10s → 2s.

## What changed

### Stage 1 — split transient events from the durable log
- New `TransientEvent` union: `ChunkGenerated | InputChunkReceived | TracesCollected | TracesMerged | TaskAcknowledged`.
- New `SNAPSHOT_RESPONSES` and `TRANSIENT_EVENTS` topics; new `TransientRouter` for fire-and-forget pub/sub.
- Master, Worker, API and `RunnerSupervisor` learn to demultiplex. Runner→supervisor mp_channel widened to `Event | TransientEvent`.

### Stage 2 — reconciliation in place of event reactions
- `custom_model_cards: Mapping[ModelId, ModelCard]` promoted to `State`; new apply handlers.
- Worker's `InstanceDeleted`/`CustomModelCard*` reactions replaced by `_reconcile_instance_backoff` and `_reconcile_custom_cards`.
- API's `InstanceDeleted` stream-close replaced by `_reconcile_streams` driven by `state.tasks × state.instances`.
- `KeyedBackoff.tracked_keys()` added to support safe iter-during-mutation.

### Stages 3–5 — snapshot transfer protocol
- New `SnapshotChunk` wire type with explicit `data_b64: str` (Pydantic v2 default-encodes `bytes` as UTF-8, which dies on zstd output).
- New `RequestSnapshot` command. Master encodes `self.state` on demand (zstd-compressed `model_dump_json`), slices into ~512 KiB chunks, publishes on `SNAPSHOT_RESPONSES` with `requester_node_id` filtering and SHA-256 verification.
- `SnapshotReceiver` reassembles chunks, ignores stale sessions / wrong recipients, validates checksum, decodes `State`.
- Worker and API issue `RequestSnapshot` at startup, apply the result to local state, then call `EventRouter.set_buffer_start(idx + 1)` so live events drain in order. Falls back to full event-log replay on timeout.
- `OrderedBuffer.fast_forward_to(idx)` discards pending events covered by the snapshot.

### Stage 6 — throughput tuning
- Soft cap on `RequestEventLog` response (1000) kept for gossipsub burst protection — comment now reflects that snapshots make this branch a fallback.
- NACK base/cap dropped 0.5s..10s → 0.05s..1s. With snapshots, NACKs only cover the small post-snapshot tail.

### Liveness
- Master `_plan` inactivity timeout 30s → 5s, tick 10s → 1s. Aligned with macmon's 1s emit cadence (5× heartbeat headroom).
- Worker `_poll_connection_updates` 10s → 2s.

### Bugs fixed along the way
- `Worker.shutdown()` crashed if called during `_fetch_snapshot` before the task group entered (the pre-Stage-5 ordering put the fetch outside `async with self._tg`). Snapshot fetch now runs as a child task inside the group.
- Pydantic v2 default `bytes`→JSON encoding broke zstd payloads. Replaced with explicit base64 round-trip.
- `RunnerSupervisor`'s synthetic `ChunkGenerated` on runner crash now flows over the transient channel.

## Bench

3 hosts (`james` master, `mike`/`s13`/`s14` joiners) over LAN libp2p, 100K events seeded on master:

| Mode | Time to bootstrap | Notes |
|---|---|---|
| **with snapshot** | **~5 s** consistent across all 3 joiners | 1 chunk, ~7 KB |
| **without snapshot** (`EXO_DISABLE_SNAPSHOT_FETCH=1`) | **>14 min and not done** | 9 – 69% range across hosts |

At normal cluster scale (1500 events) the join time is also ~5 s — dominated entirely by gossipsub election convergence, not event transport. Drop/rejoin chaos test against the new 5s liveness window: master detects departures in 5–6 s consistently.

## Test plan

- [x] `uv run basedpyright` 0 errors
- [x] `uv run ruff check` clean
- [x] `nix fmt` applied
- [x] `uv run pytest` 405 pass / 1 skipped
- [x] Same-host two-process bench: worker bootstrap `idx 133` in 34 ms
- [x] Cross-host three-joiner parallel bench: bootstrap in 4–6 s each
- [x] 100K-event bench: snapshot ~5 s vs no-snapshot >14 min (incomplete)
- [x] Drop/rejoin chaos with all four hosts running dashboards: 5–6 s detection, sub-second bootstrap on rejoin

## Notes

- The disk-snapshot-store I'd initially designed got dropped — every node already has `State` in memory, so the master encodes on demand.
- Stage 1 versioning skipped on disk (existing `events.bin` files get rotated on master startup before any read; archives are write-only).
- The duplicate-nodes UX issue surfaced during chaos testing is **pre-existing**, from PR #1338 / issue #1332 (`get_node_id_keypair` returns `Keypair.generate()` instead of persisting). Out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)