### PR TITLE
Add State schema version for snapshots

### DIFF
--- a/src/exo/shared/tests/test_state_serialization.py
+++ b/src/exo/shared/tests/test_state_serialization.py
@@ -25,6 +25,7 @@ def test_state_serialization_roundtrip() -> None:
     json_repr = state.model_dump_json()
     restored_state = State.model_validate_json(json_repr)
 
+    assert restored_state.schema_version == state.schema_version
     assert (
         state.topology.to_snapshot().nodes
         == restored_state.topology.to_snapshot().nodes

--- a/src/exo/shared/types/state.py
+++ b/src/exo/shared/types/state.py
@@ -42,6 +42,9 @@ class State(FrozenModel):
         strict=True,
         arbitrary_types_allowed=True,
     )
+    # Bump when a State change makes older snapshots unsafe to restore.
+    schema_version: int = Field(default=1, ge=1)
+
     instances: Mapping[InstanceId, Instance] = {}
     runners: Mapping[RunnerId, RunnerStatus] = {}
     downloads: Mapping[NodeId, Sequence[DownloadProgress]] = {}


### PR DESCRIPTION
## Why

Snapshot restore needs a cheap compatibility check before accepting serialized state. Without an explicit schema version, a node could try to restore a snapshot whose JSON shape no longer matches the reducer/runtime expectations.

## How

- Add `State.schema_version`, defaulting to `1`.
- Preserve it through the existing State JSON round-trip test.

This PR does not implement snapshot transfer. It only adds the state metadata that the snapshot receiver/server will use in the following PRs.

## Tests

- `uv run pytest src/exo/shared/tests/test_state_serialization.py`
- `uv run ruff check src/exo/shared/types/state.py src/exo/shared/tests/test_state_serialization.py`
- `uv run basedpyright`
- `nix fmt`
