### PR TITLE
Add snapshot request and response routing types

### DIFF
--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -25,6 +25,7 @@ from exo.shared.types.commands import (
     ImageGeneration,
     PlaceInstance,
     RequestEventLog,
+    RequestSnapshot,
     SendInputChunk,
     SetInstanceLink,
     TaskCancelled,
@@ -447,6 +448,10 @@ class Master:
                                 start=command.since_idx,
                             ):
                                 await self._send_event(IndexedEvent(idx=i, event=event))
+                        case RequestSnapshot():
+                            logger.info(
+                                "Ignoring RequestSnapshot; snapshot serving is not wired yet"
+                            )
                     for event in generated_events:
                         await self.event_sender.send(event)
                 except ValueError as e:

--- a/src/exo/routing/tests/test_snapshot_routing_types.py
+++ b/src/exo/routing/tests/test_snapshot_routing_types.py
@@ -1,0 +1,37 @@
+from exo.routing import topics
+from exo.shared.types.commands import ForwarderCommand, RequestSnapshot
+from exo.shared.types.common import NodeId, SessionId, SystemId
+from exo.shared.types.snapshots import SnapshotChunk, SnapshotTransferId
+
+
+def test_request_snapshot_round_trips_through_forwarder_command() -> None:
+    command = ForwarderCommand(
+        origin=SystemId("system-1"),
+        command=RequestSnapshot(requester_node_id=NodeId("worker-1")),
+    )
+
+    restored = ForwarderCommand.model_validate_json(command.model_dump_json())
+
+    assert isinstance(restored.command, RequestSnapshot)
+    assert restored.command.requester_node_id == NodeId("worker-1")
+
+
+def test_snapshot_response_topic_round_trips_chunk() -> None:
+    chunk = SnapshotChunk.from_data(
+        data=b"snapshot-bytes",
+        transfer_id=SnapshotTransferId("transfer-1"),
+        requester_node_id=NodeId("worker-1"),
+        session_id=SessionId(master_node_id=NodeId("master"), election_clock=1),
+        schema_version=1,
+        last_event_applied_idx=42,
+        chunk_index=0,
+        total_chunks=1,
+        sha256_hex="unused",
+    )
+
+    restored = topics.SNAPSHOT_RESPONSES.deserialize(
+        topics.SNAPSHOT_RESPONSES.serialize(chunk)
+    )
+
+    assert restored == chunk
+    assert restored.data == b"snapshot-bytes"

--- a/src/exo/routing/topics.py
+++ b/src/exo/routing/topics.py
@@ -8,6 +8,7 @@ from exo.shared.types.events import (
     GlobalForwarderEvent,
     LocalForwarderEvent,
 )
+from exo.shared.types.snapshots import SnapshotChunk
 from exo.utils.pydantic_ext import FrozenModel
 
 
@@ -48,4 +49,7 @@ CONNECTION_MESSAGES = TypedTopic(
 )
 DOWNLOAD_COMMANDS = TypedTopic(
     "download_commands", PublishPolicy.Always, ForwarderDownloadCommand
+)
+SNAPSHOT_RESPONSES = TypedTopic(
+    "snapshot_responses", PublishPolicy.Always, SnapshotChunk
 )

--- a/src/exo/shared/types/commands.py
+++ b/src/exo/shared/types/commands.py
@@ -67,6 +67,12 @@ class RequestEventLog(BaseCommand):
     since_idx: int
 
 
+class RequestSnapshot(BaseCommand):
+    """Ask the current master to send a State snapshot to this node."""
+
+    requester_node_id: NodeId
+
+
 class StartDownload(BaseCommand):
     target_node_id: NodeId
     shard_metadata: ShardMetadata
@@ -106,6 +112,7 @@ DownloadCommand = StartDownload | DeleteDownload | CancelDownload
 Command = (
     TestCommand
     | RequestEventLog
+    | RequestSnapshot
     | TextGeneration
     | ImageGeneration
     | ImageEdits


### PR DESCRIPTION
## Why

Snapshot bootstrap needs two routing-level contracts before master serving or node bootstrap can be wired: a command for asking the master for a snapshot, and a topic for publishing snapshot chunks back to the requester.

## How

- Add `RequestSnapshot` to the command union.
- Register `SNAPSHOT_RESPONSES` as a typed topic carrying `SnapshotChunk`.
- Add explicit master handling for `RequestSnapshot` as a no-op diagnostic for now, so the exhaustive command match remains honest until snapshot serving lands in the next PR.
- Add round-trip tests for `RequestSnapshot` inside `ForwarderCommand` and `SnapshotChunk` through the new topic.

## Tests

- `uv run pytest src/exo/routing/tests/test_snapshot_routing_types.py src/exo/master/tests/test_master.py`
- `uv run pytest`
- `uv run ruff check src/exo/shared/types/commands.py src/exo/routing/topics.py src/exo/routing/tests/test_snapshot_routing_types.py src/exo/master/main.py`
- `uv run basedpyright`
- `nix fmt`
