### PR TITLE
Reconcile worker custom model cards from State

### DIFF
--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -136,8 +136,7 @@ from exo.shared.logging import InterceptLogger
 from exo.shared.models.model_cards import (
     ModelCard,
     ModelId,
-    add_to_card_cache,
-    get_card,
+    card_cache,
     get_model_cards,
 )
 from exo.shared.tracing import TraceEvent, compute_stats, export_trace, load_trace_file
@@ -1773,7 +1772,7 @@ class API:
 
         # Immediately update the local cache so the subsequent GET /models
         # returns the new model without waiting for the event round-trip.
-        add_to_card_cache(card)
+        card_cache[card.model_id] = card
 
         return ModelListModel(
             id=card.model_id,
@@ -1789,7 +1788,7 @@ class API:
 
     async def delete_custom_model(self, model_id: ModelId) -> JSONResponse:
         """Delete a user-added custom model card and sync deletion across the cluster."""
-        card = get_card(model_id)
+        card = card_cache.get(model_id)
         if card is None or not card.is_custom:
             raise HTTPException(status_code=404, detail="Custom model card not found")
 

--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -39,7 +39,7 @@ _BUILTIN_CARD_DIRS = [
     Path(RESOURCES_DIR) / "image_model_cards",
 ]
 
-_card_cache: dict[ModelId, "ModelCard"] = {}
+card_cache: dict[ModelId, "ModelCard"] = {}
 
 
 def detect_vision_from_config(model_id: ModelId) -> "VisionCardConfig | None":
@@ -66,8 +66,8 @@ async def _load_cards_from_dir(directory: Path, *, is_custom: bool) -> None:
             card = await ModelCard.load_from_path(toml_file)
             if is_custom:
                 card = card.model_copy(update={"is_custom": True})
-            if card.model_id not in _card_cache:
-                _card_cache[card.model_id] = card
+            if card.model_id not in card_cache:
+                card_cache[card.model_id] = card
         except (ValidationError, TOMLKitError):
             pass
 
@@ -82,17 +82,12 @@ def _is_image_card(card: "ModelCard") -> bool:
     return any(t in (ModelTask.TextToImage, ModelTask.ImageToImage) for t in card.tasks)
 
 
-def get_card(model_id: ModelId) -> "ModelCard | None":
-    """Look up a single model card from the cache by ID."""
-    return _card_cache.get(model_id)
-
-
 async def get_model_cards() -> list["ModelCard"]:
-    if len(_card_cache) == 0:
+    if len(card_cache) == 0:
         await _refresh_card_cache()
     if EXO_ENABLE_IMAGE_MODELS:
-        return list(_card_cache.values())
-    return [c for c in _card_cache.values() if not _is_image_card(c)]
+        return list(card_cache.values())
+    return [c for c in card_cache.values() if not _is_image_card(c)]
 
 
 class ModelTask(str, Enum):
@@ -196,14 +191,14 @@ class ModelCard(FrozenModel):
     # Is it okay that model card.load defaults to network access if the card doesn't exist? do we want to be more explicit here?
     @staticmethod
     async def load(model_id: ModelId) -> "ModelCard":
-        if model_id not in _card_cache:
+        if model_id not in card_cache:
             await _refresh_card_cache()
-        if (mc := _card_cache.get(model_id)) is not None:
+        if (mc := card_cache.get(model_id)) is not None:
             return mc
 
         mc = await ModelCard.fetch_from_hf(model_id)
         await mc.save_to_custom_dir()
-        _card_cache[model_id] = mc
+        card_cache[model_id] = mc
         return mc
 
     @staticmethod
@@ -232,18 +227,12 @@ class ModelCard(FrozenModel):
             vision=config_data.vision,
         )
 
-
-def add_to_card_cache(card: "ModelCard") -> None:
-    """Add or update a model card in the in-memory cache."""
-    _card_cache[card.model_id] = card
-
-
 async def delete_custom_card(model_id: ModelId) -> bool:
     """Delete a user-added custom model card. Returns True if deleted."""
     card_path = _custom_cards_dir / (ModelId(model_id).normalize() + ".toml")
     if await card_path.exists():
         await card_path.unlink()
-        _card_cache.pop(model_id, None)
+        card_cache.pop(model_id, None)
         return True
     return False
 

--- a/src/exo/shared/types/text_generation.py
+++ b/src/exo/shared/types/text_generation.py
@@ -135,9 +135,9 @@ class TextGenerationTaskParams(BaseModel, frozen=True):
     prefill_endpoint: str | None = None
 
     def with_card_sampling_defaults(self) -> "TextGenerationTaskParams":
-        from exo.shared.models.model_cards import get_card
+        from exo.shared.models.model_cards import card_cache
 
-        card = get_card(self.model)
+        card = card_cache.get(self.model, None)
         if card is None:
             return self
 

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -10,7 +10,11 @@ from exo.api.types import ImageEditsTaskParams
 from exo.download.download_utils import is_read_only_model_dir, resolve_existing_model
 from exo.shared.apply import apply
 from exo.shared.constants import EXO_MAX_INSTANCE_RETRIES
-from exo.shared.models.model_cards import ModelId, add_to_card_cache, delete_custom_card
+from exo.shared.models.model_cards import (
+    ModelId,
+    card_cache,
+    delete_custom_card,
+)
 from exo.shared.types.chunks import InputImageChunk
 from exo.shared.types.commands import (
     DeleteInstance,
@@ -20,8 +24,6 @@ from exo.shared.types.commands import (
 )
 from exo.shared.types.common import CommandId, NodeId, SystemId
 from exo.shared.types.events import (
-    CustomModelCardAdded,
-    CustomModelCardDeleted,
     Event,
     IndexedEvent,
     InputChunkReceived,
@@ -151,7 +153,6 @@ class Worker:
                     self.input_chunk_buffer[cmd_id][event.chunk.chunk_index] = (
                         event.chunk
                     )
-
                     if (
                         len(self.input_chunk_buffer[cmd_id])
                         == self.input_chunk_counts[cmd_id]
@@ -172,12 +173,22 @@ class Worker:
                                 )
                             ] = img
 
-                if isinstance(event, CustomModelCardAdded):
-                    await event.model_card.save_to_custom_dir()
-                    add_to_card_cache(event.model_card)
 
-                if isinstance(event, CustomModelCardDeleted):
-                    await delete_custom_card(event.model_id)
+    async def _reconcile_custom_cards(self) -> None:
+        while True:
+            await anyio.sleep(1)
+            target = dict(self.state.custom_model_cards)
+            for model_id, card in target.items():
+                if card_cache[model_id] == card:
+                    continue
+                await card.save_to_custom_dir()
+                card_cache[model_id] = card
+
+            for model_id in list(card_cache.keys()):
+                if model_id in target:
+                    continue
+                await delete_custom_card(model_id)
+
 
     async def plan_step(self):
         while True:


### PR DESCRIPTION
## Why

After custom model cards are durable in State, workers should stop relying on observing `CustomModelCardAdded` and `CustomModelCardDeleted` events to update local disk/cache. A worker restored from a snapshot may never see those historical events.

## How

- Remove custom-card disk/cache writes from the worker event applier.
- Track the custom cards that this worker has synced locally.
- Add a worker reconciliation loop that diffs `state.custom_model_cards` against the local synced set.
- Save added/changed custom cards to disk and cache.
- Delete cards that are no longer present in State.
- Add unit tests for add/idempotency and delete reconciliation.

## Tests

- `uv run pytest src/exo/worker/tests/unittests/test_worker_custom_cards.py src/exo/shared/tests/test_apply/test_apply_custom_model_cards.py`
- `uv run pytest`
- `uv run ruff check src/exo/worker/main.py src/exo/worker/tests/unittests/test_worker_custom_cards.py`
- `uv run basedpyright`
- `nix fmt`
