### PR TITLE
Fix reliable Darwin mDNS discovery

### DIFF
--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -1,8 +1,11 @@
 import argparse
+import ipaddress
 import multiprocessing as mp
 import os
 import resource
 import signal
+import subprocess
+import sys
 from dataclasses import dataclass, field
 from typing import Self
 
@@ -41,6 +44,7 @@ class Node:
     node_id: NodeId
     offline: bool
     _api_port: int
+    _libp2p_port: int
     _tg: TaskGroup = field(init=False, default_factory=TaskGroup)
 
     @classmethod
@@ -141,6 +145,7 @@ class Node:
             node_id,
             args.offline,
             args.api_port,
+            args.libp2p_port,
         )
 
     async def run(self):
@@ -158,6 +163,12 @@ class Node:
                 tg.start_soon(self.master.run)
             if self.api:
                 tg.start_soon(self.api.run)
+            if sys.platform == "darwin" and self._libp2p_port != 0:
+                tg.start_soon(
+                    _darwin_mdns_broadcast_announcer,
+                    self.node_id,
+                    self._libp2p_port,
+                )
             tg.start_soon(self._elect_loop)
 
     def shutdown(self):
@@ -261,6 +272,77 @@ class Node:
                 else:
                     if self.api:
                         self.api.unpause(result.won_clock)
+
+
+def _darwin_en0_ip_address() -> str | None:
+    try:
+        return subprocess.check_output(
+            ["ipconfig", "getifaddr", "en0"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _darwin_en0_broadcast_address(ip_address: str) -> str | None:
+    try:
+        subnet_mask = subprocess.check_output(
+            ["ipconfig", "getoption", "en0", "subnet_mask"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        interface = ipaddress.IPv4Interface(f"{ip_address}/{subnet_mask}")
+        return str(interface.network.broadcast_address)
+    except (OSError, ValueError, subprocess.CalledProcessError):
+        return None
+
+
+async def _darwin_mdns_broadcast_announcer(
+    node_id: NodeId, libp2p_port: int
+) -> None:
+    ip_address = _darwin_en0_ip_address()
+    if not ip_address:
+        logger.debug("Darwin mDNS broadcast announcer disabled: no en0 IPv4 address")
+        return
+
+    broadcast_address = _darwin_en0_broadcast_address(ip_address)
+    logger.debug(
+        f"Darwin mDNS announcer advertising {node_id} at {ip_address}:{libp2p_port}"
+    )
+    command = [
+        sys.executable,
+        "-m",
+        "exo.routing.mdns_announcer",
+        "--node-id",
+        str(node_id),
+        "--ip-address",
+        ip_address,
+        "--libp2p-port",
+        str(libp2p_port),
+    ]
+    if broadcast_address is not None:
+        command.extend(["--broadcast-address", broadcast_address])
+    process = subprocess.Popen(
+        command,
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+    )
+    try:
+        while process.poll() is None:
+            await anyio.sleep(60)
+        logger.debug(
+            f"Darwin mDNS announcer subprocess exited with {process.returncode}"
+        )
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            with anyio.move_on_after(2):
+                while process.poll() is None:
+                    await anyio.sleep(0.1)
+            if process.poll() is None:
+                process.kill()
+                await anyio.sleep(0)
 
 
 def main():

--- a/src/exo/routing/mdns_announcer.py
+++ b/src/exo/routing/mdns_announcer.py
@@ -1,0 +1,97 @@
+import argparse
+import contextlib
+import random
+import socket
+import string
+import struct
+import sys
+import time
+from typing import final
+
+
+def _dns_qname(name: bytes) -> bytes:
+    return b"".join(bytes([len(part)]) + part for part in name.split(b".")) + b"\0"
+
+
+def _build_response_packet(node_id: str, ip_address: str, libp2p_port: int) -> bytes:
+    service_name = b"_p2p._udp.local"
+    peer_name = (
+        "".join(random.choice(string.ascii_letters + string.digits) for _ in range(32))
+        + "._p2p._udp.local"
+    ).encode()
+    txt_record = f"dnsaddr=/ip4/{ip_address}/tcp/{libp2p_port}/p2p/{node_id}".encode()
+
+    peer_qname = _dns_qname(peer_name)
+    packet = bytearray()
+    packet += struct.pack("!HHHHHH", 0, 0x8400, 0, 1, 0, 1)
+    packet += _dns_qname(service_name)
+    packet += struct.pack("!HHI", 12, 1, 120)
+    packet += struct.pack("!H", len(peer_qname))
+    packet += peer_qname
+    packet += peer_qname
+    packet += struct.pack("!HHI", 16, 1, 120)
+    packet += struct.pack("!H", len(txt_record) + 1)
+    packet += bytes([len(txt_record)])
+    packet += txt_record
+    return bytes(packet)
+
+
+@final
+class Args(argparse.Namespace):
+    node_id: str
+    ip_address: str
+    libp2p_port: int
+    broadcast_address: str | None
+    count: int
+
+    @staticmethod
+    def parse() -> "Args":
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--node-id", required=True)
+        parser.add_argument("--ip-address", required=True)
+        parser.add_argument("--libp2p-port", required=True, type=int)
+        parser.add_argument("--broadcast-address")
+        parser.add_argument("--count", default=0, type=int)
+        return parser.parse_args(namespace=Args())
+
+
+def main() -> None:
+    args = Args.parse()
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    with contextlib.suppress(OSError):
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+    sock.bind((args.ip_address, 0))
+
+    sent_count = 0
+    while True:
+        packet = _build_response_packet(
+            args.node_id, args.ip_address, args.libp2p_port
+        )
+        errors: list[str] = []
+        destinations: list[tuple[str, int]] = []
+        if args.broadcast_address is not None:
+            destinations.append((args.broadcast_address, 5353))
+        destinations.extend([("255.255.255.255", 5353), ("224.0.0.251", 5353)])
+        sent = False
+        for destination in destinations:
+            try:
+                sock.sendto(packet, destination)
+                sent = True
+            except OSError as err:
+                errors.append(f"{destination}: {err}")
+        if not sent:
+            print(
+                f"mDNS announcer send failed: {'; '.join(errors)}",
+                file=sys.stderr,
+                flush=True,
+            )
+        sent_count += 1
+        if args.count > 0 and sent_count >= args.count:
+            return
+        time.sleep(1.0 if sent_count < 60 else 10.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 
 import anyio
-from anyio import fail_after, to_thread
+from anyio import fail_after, move_on_after, to_thread
 from loguru import logger
 
 from exo.api.types import ImageEditsTaskParams
@@ -364,8 +364,16 @@ class Worker:
                     await self._start_runner_task(task)
 
     async def shutdown(self):
+        self.event_sender.close()
+        self.command_sender.close()
+        self.download_command_sender.close()
+        for runner in self.runners.values():
+            runner.shutdown()
         self._tg.cancel_tasks()
-        await self._stopped.wait()
+        with move_on_after(5) as scope:
+            await self._stopped.wait()
+        if scope.cancel_called:
+            logger.warning("Timed out waiting for Worker shutdown")
 
     async def _start_runner_task(self, task: Task):
         if (instance := self.state.instances.get(task.instance_id)) is not None:


### PR DESCRIPTION
## Root Cause

There were two separate issues behind the unreliable no-bootstrap startup on the four-machine macOS cluster.

1. **Darwin mDNS advertisement was not reliable from the background exo process.**

   On the affected machines, the normal libp2p mDNS path could fail to advertise in the daemonized/background context. In particular, multicast / limited broadcast paths were not reliable, while the interface's directed subnet broadcast address worked consistently.

2. **Discovery alone was not enough because election transitions could stall.**

   After peers connected and exchanged election traffic, a node could get stuck while demoting/rebuilding because `Worker.shutdown()` could wait indefinitely. That left the node connected at the libp2p layer but without reliably rebuilding worker/API/event-router state, so `/state` could remain incomplete.

## What Changed and Why

- Added a Darwin-only mDNS announcer in Python.

  `src/exo/routing/mdns_announcer.py` builds a libp2p-mdns-compatible DNS response containing:

  ```text
  dnsaddr=/ip4/<node-ip>/tcp/<libp2p-port>/p2p/<node-id>
  ```

  `src/exo/main.py` starts this announcer on macOS when exo has a fixed libp2p port. It discovers the `en0` address and subnet mask, computes the directed broadcast address, and advertises there first. This is what made no-bootstrap peer discovery reliable on the test machines.

- Kept the announcer active through startup.

  The announcer sends every second for the first 60 sends, then backs off to every 10 seconds. This covers cold starts where machines come up at slightly different times without relying on bootstrap peers.

- Made worker shutdown bounded and proactive.

  `src/exo/worker/main.py` now closes senders, shuts down runners, cancels background tasks, and waits for shutdown with a timeout. This prevents election demotion from blocking forever and lets the node rebuild its runtime state after topology/election changes.

## What This Is Not

- This PR does **not** vendor or patch Rust/libp2p code.
- An earlier version tried a Rust `libp2p-mdns` patch, but that was removed after verification showed the Python announcer plus bounded worker shutdown was sufficient.

## Validation

Local checks:

- `uv run basedpyright src/exo/main.py src/exo/routing/mdns_announcer.py src/exo/worker/main.py`
- `uv run ruff check src/exo/main.py src/exo/routing/mdns_announcer.py src/exo/worker/main.py`
- `uv run pytest`
- `uv run --reinstall-package exo-pyo3-bindings python -c "import exo_pyo3_bindings; print('rebuilt bindings')"`

Cluster verification:

- Final slim Python-only PR, no Rust vendoring: **10/10 cold-start cycles passed** across `james`, `mike`, `s13`, and `s14`.
- Each cycle killed previous listeners, started all four machines from scratch with `EXO_BOOTSTRAP_PEERS` unset, and verified every node's `/state` reported `topology.nodes == 4`.
- The final test used commit `49b2c5f2` from `alexcheema/reliable-mdns-discovery`.

## Notes

- PR is stacked on `alexcheema/profilers-dashboard` so the diff contains only this mDNS reliability fix.
