### PR TITLE
Reconcile worker instance backoff from State

### DIFF
--- a/src/exo/utils/keyed_backoff.py
+++ b/src/exo/utils/keyed_backoff.py
@@ -29,6 +29,10 @@ class KeyedBackoff[K]:
         """Return the number of recorded attempts for a key."""
         return self._attempts.get(key, 0)
 
+    def tracked_keys(self) -> set[K]:
+        """Return keys that currently have recorded backoff state."""
+        return set(self._attempts) | set(self._last_time)
+
     def reset(self, key: K) -> None:
         """Reset backoff state for a key (e.g., on success)."""
         self._attempts.pop(key, None)

--- a/src/exo/utils/tests/test_keyed_backoff.py
+++ b/src/exo/utils/tests/test_keyed_backoff.py
@@ -1,0 +1,13 @@
+from exo.utils.keyed_backoff import KeyedBackoff
+
+
+def test_tracked_keys_reports_and_resets_backoff_state() -> None:
+    backoff = KeyedBackoff[str]()
+
+    backoff.record_attempt("instance-a")
+
+    assert backoff.tracked_keys() == {"instance-a"}
+
+    backoff.reset("instance-a")
+
+    assert backoff.tracked_keys() == set()

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -30,7 +30,6 @@ from exo.shared.types.common import CommandId, NodeId, SessionId, SystemId
 from exo.shared.types.events import (
     Event,
     IndexedEvent,
-    InstanceDeleted,
     NodeDownloadProgress,
     NodeGatheredInfo,
     TaskCreated,
@@ -141,6 +140,7 @@ class Worker:
         self._tg.start_soon(self._forward_info, info_recv)
         self._tg.start_soon(self.plan_step)
         self._tg.start_soon(self._event_applier)
+        self._tg.start_soon(self._reconcile_instance_backoff)
         self._tg.start_soon(self._reconcile_custom_cards)
         self._tg.start_soon(self._poll_connection_updates)
 
@@ -190,12 +190,18 @@ class Worker:
                     continue
                 # 2. for each event, apply it to the state
                 self.state = apply(self.state, event=event)
-                event = event.event
-
-                if isinstance(event, InstanceDeleted):
-                    self._instance_backoff.reset(event.instance_id)
-
                 self._sync_input_views_from_state()
+
+    async def _reconcile_instance_backoff(self) -> None:
+        while True:
+            await anyio.sleep(1)
+            self._reconcile_instance_backoff_once()
+
+    def _reconcile_instance_backoff_once(self) -> None:
+        live_instances = set(self.state.instances)
+        for instance_id in self._instance_backoff.tracked_keys():
+            if instance_id not in live_instances:
+                self._instance_backoff.reset(instance_id)
 
     async def _reconcile_custom_cards(self) -> None:
         while True:

--- a/src/exo/worker/tests/unittests/test_worker_instance_backoff.py
+++ b/src/exo/worker/tests/unittests/test_worker_instance_backoff.py
@@ -1,0 +1,36 @@
+# pyright: reportPrivateUsage=false
+
+from exo.shared.types.common import ModelId, NodeId
+from exo.shared.types.state import State
+from exo.shared.types.worker.instances import InstanceId, MlxRingInstance
+from exo.shared.types.worker.runners import ShardAssignments
+from exo.utils.keyed_backoff import KeyedBackoff
+from exo.worker.main import Worker
+
+
+def _make_instance(instance_id: InstanceId) -> MlxRingInstance:
+    return MlxRingInstance(
+        instance_id=instance_id,
+        shard_assignments=ShardAssignments(
+            model_id=ModelId("test-model"),
+            node_to_runner={},
+            runner_to_shard={},
+        ),
+        hosts_by_node={NodeId("node-1"): []},
+        ephemeral_port=1,
+    )
+
+
+def test_worker_reconciles_instance_backoff_from_state() -> None:
+    live_instance_id = InstanceId("inst-live")
+    deleted_instance_id = InstanceId("inst-deleted")
+    worker = object.__new__(Worker)
+    worker.state = State(instances={live_instance_id: _make_instance(live_instance_id)})
+    worker._instance_backoff = KeyedBackoff[InstanceId]()
+    worker._instance_backoff.record_attempt(live_instance_id)
+    worker._instance_backoff.record_attempt(deleted_instance_id)
+
+    worker._reconcile_instance_backoff_once()
+
+    assert worker._instance_backoff.attempts(live_instance_id) == 1
+    assert worker._instance_backoff.attempts(deleted_instance_id) == 0


### PR DESCRIPTION
## Why

The worker still reset instance backoff by reacting directly to `InstanceDeleted`. With snapshot bootstrap, that deletion may already be reflected in State and the original event may not replay. The backoff cleanup should therefore reconcile from State.

## How

- Add `KeyedBackoff.tracked_keys()` so callers can inspect local backoff state without reaching into private fields.
- Remove the worker `InstanceDeleted` event side effect.
- Add a worker reconciliation loop that resets instance backoff for keys no longer present in `state.instances`.
- Add focused tests for `tracked_keys()` and worker backoff reconciliation.

## Tests

- `uv run pytest src/exo/utils/tests/test_keyed_backoff.py src/exo/worker/tests/unittests/test_worker_instance_backoff.py`
- `uv run pytest`
- `uv run ruff check src/exo/utils/keyed_backoff.py src/exo/utils/tests/test_keyed_backoff.py src/exo/worker/main.py src/exo/worker/tests/unittests/test_worker_instance_backoff.py`
- `uv run basedpyright`
- `nix fmt`
