### PR TITLE
Add transient event transport

### DIFF
--- a/src/exo/routing/tests/test_transient_router.py
+++ b/src/exo/routing/tests/test_transient_router.py
@@ -1,0 +1,69 @@
+import anyio
+import pytest
+
+from exo.routing import topics
+from exo.routing.transient_router import TransientRouter
+from exo.shared.types.common import NodeId, SessionId
+from exo.shared.types.events import (
+    GlobalForwarderTransientEvent,
+    TaskAcknowledged,
+)
+from exo.shared.types.tasks import TaskId
+from exo.utils.channels import channel
+
+
+def test_transient_topic_round_trips_wrapped_event() -> None:
+    wrapped = GlobalForwarderTransientEvent(
+        origin=NodeId("worker"),
+        session=SessionId(master_node_id=NodeId("master"), election_clock=1),
+        event=TaskAcknowledged(task_id=TaskId("task-1")),
+    )
+
+    restored = topics.TRANSIENT_EVENTS.deserialize(
+        topics.TRANSIENT_EVENTS.serialize(wrapped)
+    )
+
+    assert restored == wrapped
+
+
+@pytest.mark.asyncio
+async def test_transient_router_publishes_and_dispatches_session_events() -> None:
+    node_id = NodeId("worker")
+    session_id = SessionId(master_node_id=NodeId("master"), election_clock=1)
+    external_outbound_sender, external_outbound_receiver = channel[
+        GlobalForwarderTransientEvent
+    ]()
+    external_inbound_sender, external_inbound_receiver = channel[
+        GlobalForwarderTransientEvent
+    ]()
+    router = TransientRouter(
+        node_id=node_id,
+        session_id=session_id,
+        external_outbound=external_outbound_sender,
+        external_inbound=external_inbound_receiver,
+    )
+    local_sender = router.sender()
+    local_receiver = router.receiver()
+    event = TaskAcknowledged(task_id=TaskId("task-1"))
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(router.run)
+        await local_sender.send(event)
+
+        wrapped = await external_outbound_receiver.receive()
+        assert wrapped.origin == node_id
+        assert wrapped.session == session_id
+        assert wrapped.event == event
+
+        await external_inbound_sender.send(wrapped)
+        assert await local_receiver.receive() == event
+
+        stale_session = SessionId(master_node_id=NodeId("master"), election_clock=2)
+        await external_inbound_sender.send(
+            wrapped.model_copy(update={"session": stale_session})
+        )
+        await anyio.sleep(0)
+        assert local_receiver.collect() == []
+
+        router.shutdown()
+        tg.cancel_scope.cancel()

--- a/src/exo/routing/topics.py
+++ b/src/exo/routing/topics.py
@@ -6,6 +6,7 @@ from exo.shared.election import ElectionMessage
 from exo.shared.types.commands import ForwarderCommand, ForwarderDownloadCommand
 from exo.shared.types.events import (
     GlobalForwarderEvent,
+    GlobalForwarderTransientEvent,
     LocalForwarderEvent,
 )
 from exo.shared.types.snapshots import SnapshotChunk
@@ -40,6 +41,9 @@ class TypedTopic[T: FrozenModel]:
 
 GLOBAL_EVENTS = TypedTopic("global_events", PublishPolicy.Always, GlobalForwarderEvent)
 LOCAL_EVENTS = TypedTopic("local_events", PublishPolicy.Always, LocalForwarderEvent)
+TRANSIENT_EVENTS = TypedTopic(
+    "transient_events", PublishPolicy.Always, GlobalForwarderTransientEvent
+)
 COMMANDS = TypedTopic("commands", PublishPolicy.Always, ForwarderCommand)
 ELECTION_MESSAGES = TypedTopic(
     "election_messages", PublishPolicy.Always, ElectionMessage

--- a/src/exo/routing/transient_router.py
+++ b/src/exo/routing/transient_router.py
@@ -1,0 +1,84 @@
+from dataclasses import dataclass, field
+
+from anyio import BrokenResourceError, ClosedResourceError
+from loguru import logger
+
+from exo.shared.types.common import NodeId, SessionId
+from exo.shared.types.events import (
+    GlobalForwarderTransientEvent,
+    TransientEvent,
+)
+from exo.utils.channels import Receiver, Sender, channel
+from exo.utils.task_group import TaskGroup
+
+
+@dataclass
+class TransientRouter:
+    """Routes unordered, non-durable events over the transient-events topic."""
+
+    node_id: NodeId
+    session_id: SessionId
+    external_outbound: Sender[GlobalForwarderTransientEvent]
+    external_inbound: Receiver[GlobalForwarderTransientEvent]
+    _outbound: list[Sender[TransientEvent]] = field(init=False, default_factory=list)
+    _inbound: list[Receiver[TransientEvent]] = field(init=False, default_factory=list)
+    _tg: TaskGroup = field(init=False, default_factory=TaskGroup)
+
+    def sender(self) -> Sender[TransientEvent]:
+        send, recv = channel[TransientEvent]()
+        if self._tg.is_running():
+            self._tg.start_soon(self._publish, recv)
+        else:
+            self._inbound.append(recv)
+        return send
+
+    def receiver(self) -> Receiver[TransientEvent]:
+        assert not self._tg.is_running(), (
+            "TransientRouter receivers must be registered before run()"
+        )
+        send, recv = channel[TransientEvent]()
+        self._outbound.append(send)
+        return recv
+
+    def shutdown(self) -> None:
+        self._tg.cancel_tasks()
+
+    async def run(self) -> None:
+        try:
+            async with self._tg as tg:
+                for recv in self._inbound:
+                    tg.start_soon(self._publish, recv)
+                tg.start_soon(self._dispatch_inbound)
+        finally:
+            self.external_outbound.close()
+            for send in self._outbound:
+                send.close()
+
+    async def _publish(self, recv: Receiver[TransientEvent]) -> None:
+        with recv as events:
+            async for event in events:
+                await self.external_outbound.send(
+                    GlobalForwarderTransientEvent(
+                        origin=self.node_id,
+                        session=self.session_id,
+                        event=event,
+                    )
+                )
+
+    async def _dispatch_inbound(self) -> None:
+        with self.external_inbound as wrapped_events:
+            async for wrapped in wrapped_events:
+                if wrapped.session != self.session_id:
+                    continue
+                stale: set[int] = set()
+                for index, send in enumerate(self._outbound):
+                    try:
+                        await send.send(wrapped.event)
+                    except (ClosedResourceError, BrokenResourceError):
+                        stale.add(index)
+                if stale:
+                    for index in sorted(stale, reverse=True):
+                        self._outbound.pop(index)
+                    logger.debug(
+                        f"TransientRouter dropped {len(stale)} closed receivers"
+                    )

--- a/src/exo/shared/types/events.py
+++ b/src/exo/shared/types/events.py
@@ -172,6 +172,9 @@ Event = (
 )
 
 
+TransientEvent = TaskAcknowledged | ChunkGenerated | TracesCollected | TracesMerged
+
+
 class IndexedEvent(FrozenModel):
     """An event indexed by the master, with a globally unique index"""
 
@@ -195,3 +198,11 @@ class LocalForwarderEvent(FrozenModel):
     origin: SystemId
     session: SessionId
     event: Event
+
+
+class GlobalForwarderTransientEvent(FrozenModel):
+    """An unordered, non-durable event published to the cluster."""
+
+    origin: NodeId
+    session: SessionId
+    event: TransientEvent


### PR DESCRIPTION
## Why

Some messages currently carried as durable events are not state: stream acknowledgements, generated chunks, and trace notifications should not be persisted, replayed, or included in snapshot catch-up. Before moving producers/consumers, we need a separate transient transport that exists independently of the durable event log.

## How

- Add a `TransientEvent` union for unordered, non-durable events.
- Add `GlobalForwarderTransientEvent` as the network wrapper.
- Register a typed `TRANSIENT_EVENTS` topic.
- Add `TransientRouter`, with local senders/receivers and session filtering.
- Add tests for topic round-trip and router publish/dispatch behavior.

This PR does not move any existing production event to the transient path yet; it only introduces the transport.

## Tests

- `uv run pytest src/exo/routing/tests/test_transient_router.py`
- `uv run pytest`
- `uv run ruff check src/exo/shared/types/events.py src/exo/routing/topics.py src/exo/routing/transient_router.py src/exo/routing/tests/test_transient_router.py`
- `uv run basedpyright`
- `nix fmt`
