### PR TITLE
Wire transient router through node lifecycle

### DIFF
--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -180,6 +180,7 @@ from exo.shared.types.events import (
     Event,
     IndexedEvent,
     TracesMerged,
+    TransientEvent,
 )
 from exo.shared.types.instance_link import InstanceLink, InstanceLinkId
 from exo.shared.types.memory import Memory
@@ -246,6 +247,7 @@ class API:
         port: int,
         event_router: EventRouter,
         event_receiver: Receiver[IndexedEvent],
+        transient_event_receiver: Receiver[TransientEvent],
         snapshot_chunk_receiver: Receiver[SnapshotChunk],
         command_sender: Sender[ForwarderCommand],
         download_command_sender: Sender[ForwarderDownloadCommand],
@@ -260,6 +262,7 @@ class API:
         self.command_sender = command_sender
         self.download_command_sender = download_command_sender
         self.event_receiver = event_receiver
+        self.transient_event_receiver = transient_event_receiver
         self.snapshot_chunk_receiver = snapshot_chunk_receiver
         self.election_receiver = election_receiver
         self.node_id: NodeId = node_id
@@ -309,6 +312,7 @@ class API:
         session_id: SessionId,
         event_router: EventRouter,
         event_receiver: Receiver[IndexedEvent],
+        transient_event_receiver: Receiver[TransientEvent],
         snapshot_chunk_receiver: Receiver[SnapshotChunk],
     ):
         logger.info("Resetting API State")
@@ -324,6 +328,8 @@ class API:
         self.unpause(result_clock)
         self.event_receiver.close()
         self.event_receiver = event_receiver
+        self.transient_event_receiver.close()
+        self.transient_event_receiver = transient_event_receiver
         self.snapshot_chunk_receiver.close()
         self.snapshot_chunk_receiver = snapshot_chunk_receiver
         self._tg.start_soon(self._bootstrap_then_apply_state)
@@ -1875,6 +1881,7 @@ class API:
             self._event_log.close()
             self.command_sender.close()
             self.event_receiver.close()
+            self.transient_event_receiver.close()
             self.snapshot_chunk_receiver.close()
 
     async def run_api(self, ev: anyio.Event):

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -17,6 +17,7 @@ from exo.download.impl_shard_downloader import exo_shard_downloader
 from exo.master.main import Master
 from exo.routing.event_router import EventRouter
 from exo.routing.router import Router, get_node_id_keypair
+from exo.routing.transient_router import TransientRouter
 from exo.shared.constants import EXO_LOG
 from exo.shared.election import Election, ElectionResult
 from exo.shared.logging import logger_cleanup, logger_setup
@@ -31,6 +32,7 @@ from exo.worker.main import Worker
 class Node:
     router: Router
     event_router: EventRouter
+    transient_router: TransientRouter
     download_coordinator: DownloadCoordinator | None
     worker: Worker | None
     election: Election  # Every node participates in election, as we do want a node to become master even if it isn't a master candidate if no master candidates are present.
@@ -55,6 +57,7 @@ class Node:
         )
         await router.register_topic(topics.GLOBAL_EVENTS)
         await router.register_topic(topics.LOCAL_EVENTS)
+        await router.register_topic(topics.TRANSIENT_EVENTS)
         await router.register_topic(topics.COMMANDS)
         await router.register_topic(topics.ELECTION_MESSAGES)
         await router.register_topic(topics.CONNECTION_MESSAGES)
@@ -65,6 +68,12 @@ class Node:
             command_sender=router.sender(topics.COMMANDS),
             external_outbound=router.sender(topics.LOCAL_EVENTS),
             external_inbound=router.receiver(topics.GLOBAL_EVENTS),
+        )
+        transient_router = TransientRouter(
+            node_id=node_id,
+            session_id=session_id,
+            external_outbound=router.sender(topics.TRANSIENT_EVENTS),
+            external_inbound=router.receiver(topics.TRANSIENT_EVENTS),
         )
 
         logger.info(f"Starting node {node_id}")
@@ -88,6 +97,7 @@ class Node:
                 port=args.api_port,
                 event_router=event_router,
                 event_receiver=event_router.receiver(),
+                transient_event_receiver=transient_router.receiver(),
                 snapshot_chunk_receiver=router.receiver(topics.SNAPSHOT_RESPONSES),
                 command_sender=router.sender(topics.COMMANDS),
                 download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
@@ -103,6 +113,8 @@ class Node:
                 event_router=event_router,
                 event_receiver=event_router.receiver(),
                 event_sender=event_router.sender(),
+                transient_event_receiver=transient_router.receiver(),
+                transient_event_sender=transient_router.sender(),
                 snapshot_chunk_receiver=router.receiver(topics.SNAPSHOT_RESPONSES),
                 command_sender=router.sender(topics.COMMANDS),
                 download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
@@ -116,6 +128,8 @@ class Node:
             node_id,
             session_id,
             event_sender=event_router.sender(),
+            transient_event_receiver=transient_router.receiver(),
+            transient_event_sender=transient_router.sender(),
             global_event_sender=router.sender(topics.GLOBAL_EVENTS),
             local_event_receiver=router.receiver(topics.LOCAL_EVENTS),
             command_receiver=router.receiver(topics.COMMANDS),
@@ -140,6 +154,7 @@ class Node:
         return cls(
             router,
             event_router,
+            transient_router,
             download_coordinator,
             worker,
             election,
@@ -157,6 +172,7 @@ class Node:
             signal.signal(signal.SIGTERM, lambda _, __: self.shutdown())
             tg.start_soon(self.router.run)
             tg.start_soon(self.event_router.run)
+            tg.start_soon(self.transient_router.run)
             tg.start_soon(self.election.run)
             if self.download_coordinator:
                 tg.start_soon(self.download_coordinator.run)
@@ -200,6 +216,13 @@ class Node:
                         self.router.receiver(topics.GLOBAL_EVENTS),
                         self.router.sender(topics.LOCAL_EVENTS),
                     )
+                    self.transient_router.shutdown()
+                    self.transient_router = TransientRouter(
+                        node_id=self.node_id,
+                        session_id=result.session_id,
+                        external_outbound=self.router.sender(topics.TRANSIENT_EVENTS),
+                        external_inbound=self.router.receiver(topics.TRANSIENT_EVENTS),
+                    )
 
                 if (
                     result.session_id.master_node_id == self.node_id
@@ -215,6 +238,8 @@ class Node:
                         self.node_id,
                         result.session_id,
                         event_sender=self.event_router.sender(),
+                        transient_event_receiver=self.transient_router.receiver(),
+                        transient_event_sender=self.transient_router.sender(),
                         global_event_sender=self.router.sender(topics.GLOBAL_EVENTS),
                         local_event_receiver=self.router.receiver(topics.LOCAL_EVENTS),
                         command_receiver=self.router.receiver(topics.COMMANDS),
@@ -261,6 +286,8 @@ class Node:
                             event_router=self.event_router,
                             event_receiver=self.event_router.receiver(),
                             event_sender=self.event_router.sender(),
+                            transient_event_receiver=self.transient_router.receiver(),
+                            transient_event_sender=self.transient_router.sender(),
                             snapshot_chunk_receiver=self.router.receiver(
                                 topics.SNAPSHOT_RESPONSES
                             ),
@@ -277,9 +304,11 @@ class Node:
                             result.session_id,
                             self.event_router,
                             self.event_router.receiver(),
+                            self.transient_router.receiver(),
                             self.router.receiver(topics.SNAPSHOT_RESPONSES),
                         )
                     self._tg.start_soon(self.event_router.run)
+                    self._tg.start_soon(self.transient_router.run)
                 else:
                     if self.api:
                         self.api.unpause(result.won_clock)

--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -55,6 +55,7 @@ from exo.shared.types.events import (
     TraceEventData,
     TracesCollected,
     TracesMerged,
+    TransientEvent,
 )
 from exo.shared.types.instance_link import InstanceLink
 from exo.shared.types.snapshots import SnapshotChunk, SnapshotTransferId
@@ -136,6 +137,8 @@ class Master:
         *,
         command_receiver: Receiver[ForwarderCommand],
         event_sender: Sender[Event],
+        transient_event_receiver: Receiver[TransientEvent],
+        transient_event_sender: Sender[TransientEvent],
         local_event_receiver: Receiver[LocalForwarderEvent],
         global_event_sender: Sender[GlobalForwarderEvent],
         snapshot_chunk_sender: Sender[SnapshotChunk],
@@ -148,6 +151,8 @@ class Master:
         self.command_task_mapping: dict[CommandId, TaskId] = {}
         self.command_receiver = command_receiver
         self.local_event_receiver = local_event_receiver
+        self.transient_event_receiver = transient_event_receiver
+        self.transient_event_sender = transient_event_sender
         self.global_event_sender = global_event_sender
         self.snapshot_chunk_sender = snapshot_chunk_sender
         self.download_command_sender = download_command_sender
@@ -170,6 +175,8 @@ class Master:
             self._event_log.close()
             self.global_event_sender.close()
             self.local_event_receiver.close()
+            self.transient_event_receiver.close()
+            self.transient_event_sender.close()
             self.snapshot_chunk_sender.close()
             self.command_receiver.close()
 

--- a/src/exo/master/tests/test_master.py
+++ b/src/exo/master/tests/test_master.py
@@ -26,6 +26,7 @@ from exo.shared.types.events import (
     LocalForwarderEvent,
     NodeGatheredInfo,
     TaskCreated,
+    TransientEvent,
 )
 from exo.shared.types.memory import Memory
 from exo.shared.types.profiling import (
@@ -59,6 +60,7 @@ async def test_master():
     local_event_sender, le_receiver = channel[LocalForwarderEvent]()
     fcds, _fcdr = channel[ForwarderDownloadCommand]()
     ev_send, ev_recv = channel[Event]()
+    transient_send, transient_recv = channel[TransientEvent]()
     snapshot_chunk_send, _snapshot_chunk_recv = channel[SnapshotChunk]()
 
     async def mock_event_router():
@@ -93,6 +95,8 @@ async def test_master():
         node_id,
         session_id,
         event_sender=ev_send,
+        transient_event_receiver=transient_recv,
+        transient_event_sender=transient_send,
         global_event_sender=ge_sender,
         local_event_receiver=le_receiver,
         command_receiver=co_receiver,
@@ -249,12 +253,15 @@ async def test_master_serves_snapshot_for_current_state():
         ForwarderDownloadCommand
     ]()
     event_sender, _event_receiver = channel[Event]()
+    transient_event_sender, transient_event_receiver = channel[TransientEvent]()
     snapshot_chunk_sender, snapshot_chunk_receiver = channel[SnapshotChunk]()
 
     master = Master(
         node_id,
         session_id,
         event_sender=event_sender,
+        transient_event_receiver=transient_event_receiver,
+        transient_event_sender=transient_event_sender,
         global_event_sender=ge_sender,
         local_event_receiver=local_event_receiver,
         command_receiver=command_receiver,

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -36,6 +36,7 @@ from exo.shared.types.events import (
     TaskStatusUpdated,
     TopologyEdgeCreated,
     TopologyEdgeDeleted,
+    TransientEvent,
 )
 from exo.shared.types.multiaddr import Multiaddr
 from exo.shared.types.snapshots import SnapshotChunk
@@ -76,6 +77,8 @@ class Worker:
         event_router: EventRouter,
         event_receiver: Receiver[IndexedEvent],
         event_sender: Sender[Event],
+        transient_event_receiver: Receiver[TransientEvent],
+        transient_event_sender: Sender[TransientEvent],
         snapshot_chunk_receiver: Receiver[SnapshotChunk],
         # This is for requesting updates. It doesn't need to be a general command sender right now,
         # but I think it's the correct way to be thinking about commands
@@ -88,6 +91,8 @@ class Worker:
         self.event_router = event_router
         self.event_receiver = event_receiver
         self.event_sender = event_sender
+        self.transient_event_receiver = transient_event_receiver
+        self.transient_event_sender = transient_event_sender
         self.snapshot_chunk_receiver = snapshot_chunk_receiver
         self.command_sender = command_sender
         self.download_command_sender = download_command_sender
@@ -124,6 +129,8 @@ class Worker:
             # Actual shutdown code - waits for all tasks to complete before executing.
             logger.info("Stopping Worker")
             self.event_sender.close()
+            self.transient_event_receiver.close()
+            self.transient_event_sender.close()
             self.snapshot_chunk_receiver.close()
             self.command_sender.close()
             self.download_command_sender.close()

--- a/src/exo/worker/tests/unittests/test_worker_snapshot_bootstrap.py
+++ b/src/exo/worker/tests/unittests/test_worker_snapshot_bootstrap.py
@@ -19,6 +19,7 @@ from exo.shared.types.events import (
     IndexedEvent,
     LocalForwarderEvent,
     TestEvent,
+    TransientEvent,
 )
 from exo.shared.types.snapshots import SnapshotChunk, SnapshotTransferId
 from exo.shared.types.state import State
@@ -64,6 +65,7 @@ def _worker(
 
     event_sender, event_receiver = channel[IndexedEvent]()
     local_event_output_sender, _local_event_output_receiver = channel[Event]()
+    transient_sender, transient_receiver = channel[TransientEvent]()
     command_sender, command_receiver = channel[ForwarderCommand]()
     download_command_sender, _download_command_receiver = channel[
         ForwarderDownloadCommand
@@ -76,6 +78,8 @@ def _worker(
         event_router=event_router,
         event_receiver=event_receiver,
         event_sender=local_event_output_sender,
+        transient_event_receiver=transient_receiver,
+        transient_event_sender=transient_sender,
         snapshot_chunk_receiver=snapshot_receiver,
         command_sender=command_sender,
         download_command_sender=download_command_sender,


### PR DESCRIPTION
## Why

The previous PR added the transient event transport primitives, but the runtime node graph did not yet create or run a transient router. Before moving generated chunks or traces off the durable event log, every node needs a session-scoped transient channel that is recreated across elections alongside the durable event router.

This keeps the split incremental: this PR adds plumbing only and intentionally leaves current durable event behavior unchanged.

## How

- Register the `TRANSIENT_EVENTS` pubsub topic during node startup.
- Create and run a `TransientRouter` next to the existing `EventRouter`.
- Recreate the transient router on new elections so transient messages are scoped to the new session.
- Pass transient receivers/senders into API, worker, and master constructors so later PRs can move individual event families over without changing node lifecycle again.
- Update direct master/worker test construction helpers with transient channels.

## Tests

- `uv run pytest src/exo/routing/tests/test_transient_router.py src/exo/master/tests/test_master.py src/exo/worker/tests/unittests/test_worker_snapshot_bootstrap.py`
- `uv run pytest`
- `uv run basedpyright`
- `uv run ruff check`
- `nix fmt`