### PR TITLE
Route generated chunks over transient events

### DIFF
--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -333,6 +333,7 @@ class API:
         self.snapshot_chunk_receiver.close()
         self.snapshot_chunk_receiver = snapshot_chunk_receiver
         self._tg.start_soon(self._bootstrap_then_apply_state)
+        self._tg.start_soon(self._apply_transient)
 
     def unpause(self, result_clock: int):
         logger.info("Unpausing API")
@@ -1867,6 +1868,7 @@ class API:
             async with self._tg as tg:
                 logger.info("Starting API")
                 tg.start_soon(self._bootstrap_then_apply_state)
+                tg.start_soon(self._apply_transient)
                 tg.start_soon(self._reconcile_streams)
                 tg.start_soon(self._pause_on_new_election)
                 tg.start_soon(self._cleanup_expired_images)
@@ -1939,25 +1941,28 @@ class API:
                 self.state = apply(self.state, i_event)
                 event = i_event.event
 
-                if isinstance(event, ChunkGenerated):
-                    if queue := self._image_generation_queues.get(
-                        event.command_id, None
-                    ):
-                        assert isinstance(event.chunk, ImageChunk)
-                        try:
-                            await queue.send(event.chunk)
-                        except (BrokenResourceError, ClosedResourceError):
-                            self._image_generation_queues.pop(event.command_id, None)
-                    if queue := self._text_generation_queues.get(
-                        event.command_id, None
-                    ):
-                        assert not isinstance(event.chunk, ImageChunk)
-                        try:
-                            await queue.send(event.chunk)
-                        except (BrokenResourceError, ClosedResourceError):
-                            self._text_generation_queues.pop(event.command_id, None)
                 if isinstance(event, TracesMerged):
                     self._save_merged_trace(event)
+
+    async def _apply_transient(self) -> None:
+        with self.transient_event_receiver as events:
+            async for event in events:
+                if isinstance(event, ChunkGenerated):
+                    await self._dispatch_chunk(event)
+
+    async def _dispatch_chunk(self, event: ChunkGenerated) -> None:
+        if queue := self._image_generation_queues.get(event.command_id, None):
+            assert isinstance(event.chunk, ImageChunk)
+            try:
+                await queue.send(event.chunk)
+            except (BrokenResourceError, ClosedResourceError):
+                self._image_generation_queues.pop(event.command_id, None)
+        if queue := self._text_generation_queues.get(event.command_id, None):
+            assert not isinstance(event.chunk, ImageChunk)
+            try:
+                await queue.send(event.chunk)
+            except (BrokenResourceError, ClosedResourceError):
+                self._text_generation_queues.pop(event.command_id, None)
 
     async def _reconcile_streams(self) -> None:
         while True:

--- a/src/exo/api/tests/test_api_snapshot_bootstrap.py
+++ b/src/exo/api/tests/test_api_snapshot_bootstrap.py
@@ -8,14 +8,23 @@ import zstandard
 
 from exo.api.main import API
 from exo.routing.event_router import EventRouter
+from exo.shared.models.model_cards import ModelId
+from exo.shared.types.chunks import (
+    ErrorChunk,
+    PrefillProgressChunk,
+    TokenChunk,
+    ToolCallChunk,
+)
 from exo.shared.types.commands import ForwarderCommand, RequestSnapshot
-from exo.shared.types.common import NodeId, SessionId, SystemId
+from exo.shared.types.common import CommandId, NodeId, SessionId, SystemId
 from exo.shared.types.events import (
+    ChunkGenerated,
     Event,
     GlobalForwarderEvent,
     IndexedEvent,
     LocalForwarderEvent,
     TestEvent,
+    TransientEvent,
 )
 from exo.shared.types.snapshots import SnapshotChunk, SnapshotTransferId
 from exo.shared.types.state import State
@@ -54,6 +63,7 @@ def _api(
     EventRouter,
     Receiver[ForwarderCommand],
     Sender[SnapshotChunk],
+    Sender[TransientEvent],
     Sender[IndexedEvent],
     _FakeEventLog,
 ]:
@@ -68,6 +78,7 @@ def _api(
     )
 
     event_sender, event_receiver = channel[IndexedEvent]()
+    transient_sender, transient_receiver = channel[TransientEvent]()
     command_sender, command_receiver = channel[ForwarderCommand]()
     snapshot_sender, snapshot_receiver = channel[SnapshotChunk]()
 
@@ -76,6 +87,7 @@ def _api(
     api.session_id = session_id
     api.event_router = event_router
     api.event_receiver = event_receiver
+    api.transient_event_receiver = transient_receiver
     api.snapshot_chunk_receiver = snapshot_receiver
     api.command_sender = command_sender
     api._system_id = SystemId("api-system")
@@ -84,16 +96,30 @@ def _api(
     api._event_log = event_log  # pyright: ignore[reportAttributeAccessIssue]
     api._image_generation_queues = {}
     api._text_generation_queues = {}
-    return api, event_router, command_receiver, snapshot_sender, event_sender, event_log
+    return (
+        api,
+        event_router,
+        command_receiver,
+        snapshot_sender,
+        transient_sender,
+        event_sender,
+        event_log,
+    )
 
 
 @pytest.mark.asyncio
 async def test_api_fetch_snapshot_applies_state_and_fast_forwards_router() -> None:
     node_id = NodeId("api")
     session_id = SessionId(master_node_id=NodeId("master"), election_clock=1)
-    api, event_router, command_receiver, snapshot_sender, _event_sender, _event_log = (
-        _api(node_id, session_id)
-    )
+    (
+        api,
+        event_router,
+        command_receiver,
+        snapshot_sender,
+        _transient_sender,
+        _event_sender,
+        _event_log,
+    ) = _api(node_id, session_id)
     state = State(last_event_applied_idx=7)
 
     async with anyio.create_task_group() as tg:
@@ -119,6 +145,7 @@ async def test_api_apply_state_ignores_events_covered_by_snapshot() -> None:
         _event_router,
         _command_receiver,
         _snapshot_sender,
+        _transient_sender,
         event_sender,
         event_log,
     ) = _api(node_id, session_id)
@@ -134,3 +161,31 @@ async def test_api_apply_state_ignores_events_covered_by_snapshot() -> None:
         tg.cancel_scope.cancel()
 
     assert len(event_log.appended) == 1
+
+
+@pytest.mark.asyncio
+async def test_api_apply_transient_dispatches_generated_chunks() -> None:
+    node_id = NodeId("api")
+    session_id = SessionId(master_node_id=NodeId("master"), election_clock=1)
+    (
+        api,
+        _event_router,
+        _command_receiver,
+        _snapshot_sender,
+        transient_sender,
+        _event_sender,
+        _event_log,
+    ) = _api(node_id, session_id)
+    command_id = CommandId("cmd-a")
+    chunk_sender, chunk_receiver = channel[
+        TokenChunk | ErrorChunk | ToolCallChunk | PrefillProgressChunk
+    ]()
+    api._text_generation_queues[command_id] = chunk_sender
+
+    chunk = ErrorChunk(model=ModelId("test-model"), error_message="test chunk")
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(api._apply_transient)
+        await transient_sender.send(ChunkGenerated(command_id=command_id, chunk=chunk))
+
+        assert await chunk_receiver.receive() == chunk
+        tg.cancel_scope.cancel()

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -438,6 +438,7 @@ class Worker:
         runner = RunnerSupervisor.create(
             bound_instance=task.bound_instance,
             event_sender=self.event_sender.clone(),
+            transient_event_sender=self.transient_event_sender.clone(),
         )
         self.runners[task.bound_instance.bound_runner_id] = runner
         self._tg.start_soon(runner.run)

--- a/src/exo/worker/runner/supervisor.py
+++ b/src/exo/worker/runner/supervisor.py
@@ -19,6 +19,7 @@ from exo.shared.types.events import (
     RunnerStatusUpdated,
     TaskAcknowledged,
     TaskStatusUpdated,
+    TransientEvent,
 )
 from exo.shared.types.tasks import (
     CANCEL_ALL_TASKS,
@@ -58,6 +59,7 @@ class RunnerSupervisor:
     _ev_recv: MpReceiver[Event]
     _task_sender: MpSender[Task]
     _event_sender: Sender[Event]
+    _transient_event_sender: Sender[TransientEvent]
     _cancel_sender: MpSender[TaskId]
     _tg: TaskGroup = field(default_factory=TaskGroup, init=False)
     status: RunnerStatus = field(default_factory=RunnerIdle, init=False)
@@ -75,6 +77,7 @@ class RunnerSupervisor:
         *,
         bound_instance: BoundInstance,
         event_sender: Sender[Event],
+        transient_event_sender: Sender[TransientEvent],
         initialize_timeout: float = 400,
     ) -> Self:
         ev_send, ev_recv = mp_channel[Event]()
@@ -104,6 +107,7 @@ class RunnerSupervisor:
             _task_sender=task_sender,
             _cancel_sender=cancel_sender,
             _event_sender=event_sender,
+            _transient_event_sender=transient_event_sender,
         )
 
         return self
@@ -124,6 +128,8 @@ class RunnerSupervisor:
                 self._task_sender.close()
             with contextlib.suppress(ClosedResourceError):
                 self._event_sender.close()
+            with contextlib.suppress(ClosedResourceError):
+                self._transient_event_sender.close()
             with contextlib.suppress(ClosedResourceError):
                 self._cancel_sender.send(CANCEL_ALL_TASKS)
             with contextlib.suppress(ClosedResourceError):
@@ -235,7 +241,10 @@ class RunnerSupervisor:
                         )
                         self.in_progress.pop(event.task_id, None)
                         self.completed.add(event.task_id)
-                    await self._event_sender.send(event)
+                    if isinstance(event, ChunkGenerated):
+                        await self._transient_event_sender.send(event)
+                    else:
+                        await self._event_sender.send(event)
         except (ClosedResourceError, BrokenResourceError) as e:
             await self._check_runner(e)
         finally:
@@ -275,7 +284,7 @@ class RunnerSupervisor:
         for task in self.in_progress.values():
             if isinstance(task, (TextGeneration, ImageGeneration, ImageEdits)):
                 with anyio.CancelScope(shield=True):
-                    await self._event_sender.send(
+                    await self._transient_event_sender.send(
                         ChunkGenerated(
                             command_id=task.command_id,
                             chunk=ErrorChunk(

--- a/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
@@ -7,7 +7,12 @@ import pytest
 from exo.shared.models.model_cards import ModelId
 from exo.shared.types.chunks import ErrorChunk
 from exo.shared.types.common import CommandId, NodeId
-from exo.shared.types.events import ChunkGenerated, Event, RunnerStatusUpdated
+from exo.shared.types.events import (
+    ChunkGenerated,
+    Event,
+    RunnerStatusUpdated,
+    TransientEvent,
+)
 from exo.shared.types.tasks import Task, TaskId, TextGeneration
 from exo.shared.types.text_generation import (
     InputMessage,
@@ -43,6 +48,7 @@ class _DeadProcess:
 @pytest.mark.asyncio
 async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> None:
     event_sender, event_receiver = channel[Event]()
+    transient_sender, transient_receiver = channel[TransientEvent]()
     task_sender, _ = mp_channel[Task]()
     cancel_sender, _ = mp_channel[TaskId]()
     _, ev_recv = mp_channel[Event]()
@@ -62,6 +68,7 @@ async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> 
         _ev_recv=ev_recv,
         _task_sender=task_sender,
         _event_sender=event_sender,
+        _transient_event_sender=transient_sender,
         _cancel_sender=cancel_sender,
     )
 
@@ -81,7 +88,7 @@ async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> 
 
     await supervisor._check_runner(RuntimeError("boom"))  # pyright: ignore[reportPrivateUsage]
 
-    got_chunk = await event_receiver.receive()
+    got_chunk = await transient_receiver.receive()
     got_status = await event_receiver.receive()
 
     assert isinstance(got_chunk, ChunkGenerated)
@@ -93,5 +100,57 @@ async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> 
     assert isinstance(got_status.runner_status, RunnerFailed)
 
     event_sender.close()
+    transient_sender.close()
     with anyio.move_on_after(0.1):
         await event_receiver.aclose()
+    with anyio.move_on_after(0.1):
+        await transient_receiver.aclose()
+
+
+@pytest.mark.asyncio
+async def test_forward_events_routes_generated_chunks_to_transient() -> None:
+    event_sender, event_receiver = channel[Event]()
+    transient_sender, transient_receiver = channel[TransientEvent]()
+    task_sender, _ = mp_channel[Task]()
+    cancel_sender, _ = mp_channel[TaskId]()
+    ev_send, ev_recv = mp_channel[Event]()
+
+    bound_instance: BoundInstance = get_bound_mlx_ring_instance(
+        instance_id=InstanceId("instance-a"),
+        model_id=ModelId("mlx-community/Llama-3.2-1B-Instruct-4bit"),
+        runner_id=RunnerId("runner-a"),
+        node_id=NodeId("node-a"),
+    )
+
+    supervisor = RunnerSupervisor(
+        shard_metadata=bound_instance.bound_shard,
+        bound_instance=bound_instance,
+        runner_process=cast("mp.Process", cast(object, _DeadProcess())),
+        initialize_timeout=400,
+        _ev_recv=ev_recv,
+        _task_sender=task_sender,
+        _event_sender=event_sender,
+        _transient_event_sender=transient_sender,
+        _cancel_sender=cancel_sender,
+    )
+
+    command_id = CommandId("cmd-a")
+    chunk = ChunkGenerated(
+        command_id=command_id,
+        chunk=ErrorChunk(
+            model=bound_instance.bound_shard.model_card.model_id,
+            error_message="test chunk",
+        ),
+    )
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(supervisor._forward_events)  # pyright: ignore[reportPrivateUsage]
+        ev_send.send(chunk)
+        assert await transient_receiver.receive() == chunk
+        tg.cancel_scope.cancel()
+
+    assert event_receiver.collect() == []
+
+    event_sender.close()
+    transient_sender.close()
+    ev_send.close()


### PR DESCRIPTION
## Why

Generated chunks are streaming outputs, not durable state transitions. Keeping them in the indexed event log means snapshot-based nodes can either miss client-visible stream data or incorrectly replay stale stream data. The durable log should reduce to `State`; chunks should travel over the transient channel.

## How

- Start the API transient-event loop and dispatch `ChunkGenerated` from that loop.
- Stop dispatching generated chunks from durable `_apply_state`.
- Give `RunnerSupervisor` a transient sender and route `ChunkGenerated` through it instead of the durable event sender.
- Send runner-shutdown error chunks over the same transient path.
- Keep `ChunkGenerated` in the durable event union for now so this change is small and compatible with the existing runner-process event channel; a later PR can harden the type boundary.

## Tests

- `uv run pytest src/exo/api/tests/test_api_snapshot_bootstrap.py src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py`
- `uv run pytest`
- `uv run basedpyright`
- `uv run ruff check`
- `nix fmt`