### PR TITLE
Restrict durable events to state changes

### DIFF
--- a/src/exo/shared/apply.py
+++ b/src/exo/shared/apply.py
@@ -7,7 +7,6 @@ from loguru import logger
 from exo.shared.models.model_cards import ModelCard
 from exo.shared.types.common import ModelId, NodeId
 from exo.shared.types.events import (
-    ChunkGenerated,
     CustomModelCardAdded,
     CustomModelCardDeleted,
     Event,
@@ -21,7 +20,6 @@ from exo.shared.types.events import (
     NodeGatheredInfo,
     NodeTimedOut,
     RunnerStatusUpdated,
-    TaskAcknowledged,
     TaskCreated,
     TaskDeleted,
     TaskFailed,
@@ -29,8 +27,6 @@ from exo.shared.types.events import (
     TestEvent,
     TopologyEdgeCreated,
     TopologyEdgeDeleted,
-    TracesCollected,
-    TracesMerged,
 )
 from exo.shared.types.instance_link import InstanceLink, InstanceLinkId
 from exo.shared.types.profiling import (
@@ -76,13 +72,7 @@ from exo.utils.info_gatherer.info_gatherer import (
 def event_apply(event: Event, state: State) -> State:
     """Apply an event to state."""
     match event:
-        case (
-            TestEvent()
-            | ChunkGenerated()
-            | TaskAcknowledged()
-            | TracesCollected()
-            | TracesMerged()
-        ):  # Pass-through events that don't modify state
+        case TestEvent():
             return state
         case CustomModelCardAdded():
             return apply_custom_model_card_added(event, state)

--- a/src/exo/shared/types/events.py
+++ b/src/exo/shared/types/events.py
@@ -152,19 +152,15 @@ Event = (
     | TaskStatusUpdated
     | TaskFailed
     | TaskDeleted
-    | TaskAcknowledged
     | InstanceCreated
     | InstanceDeleted
     | RunnerStatusUpdated
     | NodeTimedOut
     | NodeGatheredInfo
     | NodeDownloadProgress
-    | ChunkGenerated
     | InputChunkReceived
     | TopologyEdgeCreated
     | TopologyEdgeDeleted
-    | TracesCollected
-    | TracesMerged
     | CustomModelCardAdded
     | CustomModelCardDeleted
     | InstanceLinkCreated
@@ -173,6 +169,7 @@ Event = (
 
 
 TransientEvent = TaskAcknowledged | ChunkGenerated | TracesCollected | TracesMerged
+RunnerEvent = Event | TransientEvent
 
 
 class IndexedEvent(FrozenModel):

--- a/src/exo/worker/engines/image/builder.py
+++ b/src/exo/worker/engines/image/builder.py
@@ -12,7 +12,7 @@ from exo.shared.constants import EXO_TRACING_ENABLED
 from exo.shared.tracing import clear_trace_buffer, get_trace_buffer
 from exo.shared.types.chunks import Chunk, ErrorChunk
 from exo.shared.types.events import (
-    Event,
+    RunnerEvent,
     TraceEventData,
     TracesCollected,
 )
@@ -66,7 +66,7 @@ def _is_primary_output_node(shard_metadata: ShardMetadata) -> bool:
 
 
 def _send_traces_if_enabled(
-    event_sender: MpSender[Event],
+    event_sender: MpSender[RunnerEvent],
     task_id: TaskId,
     rank: int,
 ) -> None:
@@ -97,7 +97,7 @@ def _send_traces_if_enabled(
 
 @dataclass
 class MfluxBuilder(Builder):
-    event_sender: MpSender[Event]
+    event_sender: MpSender[RunnerEvent]
     cancel_receiver: MpReceiver[TaskId]
     shard_metadata: ShardMetadata | None = None
     image_model: DistributedImageModel | None = None
@@ -137,7 +137,7 @@ class MfluxBuilder(Builder):
 class ImageEngine(Engine):
     image_model: DistributedImageModel
     shard_metadata: ShardMetadata
-    event_sender: MpSender[Event]
+    event_sender: MpSender[RunnerEvent]
     cancel_receiver: MpReceiver[TaskId]
     current_gen: (
         Generator[tuple[TaskId, Chunk | FinishedResponse | CancelledResponse]] | None

--- a/src/exo/worker/engines/mlx/builder.py
+++ b/src/exo/worker/engines/mlx/builder.py
@@ -7,7 +7,7 @@ import mlx.core as mx
 from mlx_lm.tokenizer_utils import TokenizerWrapper
 
 from exo.shared.types.common import ModelId
-from exo.shared.types.events import Event
+from exo.shared.types.events import RunnerEvent
 from exo.shared.types.tasks import TaskId
 from exo.shared.types.worker.instances import BoundInstance
 from exo.shared.types.worker.runner_response import ModelLoadingResponse
@@ -32,7 +32,7 @@ from .vision import VisionProcessor
 @dataclass
 class MlxBuilder(Builder):
     model_id: ModelId
-    event_sender: MpSender[Event]
+    event_sender: MpSender[RunnerEvent]
     cancel_receiver: MpReceiver[TaskId]
     inference_model: Model | None = None
     tokenizer: TokenizerWrapper | None = None

--- a/src/exo/worker/runner/bootstrap.py
+++ b/src/exo/worker/runner/bootstrap.py
@@ -3,7 +3,7 @@ import resource
 
 import loguru
 
-from exo.shared.types.events import Event, RunnerStatusUpdated
+from exo.shared.types.events import RunnerEvent, RunnerStatusUpdated
 from exo.shared.types.tasks import Task, TaskId
 from exo.shared.types.worker.instances import BoundInstance
 from exo.shared.types.worker.runners import RunnerFailed
@@ -15,7 +15,7 @@ logger: "loguru.Logger" = loguru.logger
 
 def entrypoint(
     bound_instance: BoundInstance,
-    event_sender: MpSender[Event],
+    event_sender: MpSender[RunnerEvent],
     task_receiver: MpReceiver[Task],
     cancel_receiver: MpReceiver[TaskId],
     _logger: "loguru.Logger",

--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -11,7 +11,7 @@ from mlx_lm.tokenizer_utils import TokenizerWrapper
 from exo.shared.constants import EXO_MAX_CONCURRENT_REQUESTS
 from exo.shared.types.chunks import ErrorChunk, GenerationChunk, PrefillProgressChunk
 from exo.shared.types.common import ModelId
-from exo.shared.types.events import ChunkGenerated, Event
+from exo.shared.types.events import ChunkGenerated, RunnerEvent
 from exo.shared.types.tasks import (
     CANCEL_ALL_TASKS,
     GenerationTask,
@@ -96,7 +96,7 @@ class SequentialGenerator(Engine):
     model_id: ModelId
     device_rank: int
     cancel_receiver: MpReceiver[TaskId]
-    event_sender: MpSender[Event]
+    event_sender: MpSender[RunnerEvent]
     vision_processor: VisionProcessor | None = None
     check_for_cancel_every: int = 50
 
@@ -320,7 +320,7 @@ class BatchGenerator(Engine):
     model_id: ModelId
     device_rank: int
     cancel_receiver: MpReceiver[TaskId]
-    event_sender: MpSender[Event]
+    event_sender: MpSender[RunnerEvent]
     check_for_cancel_every: int = 50
     vision_processor: VisionProcessor | None = None
 

--- a/src/exo/worker/runner/runner.py
+++ b/src/exo/worker/runner/runner.py
@@ -12,7 +12,7 @@ from exo.shared.types.chunks import Chunk
 from exo.shared.types.common import CommandId
 from exo.shared.types.events import (
     ChunkGenerated,
-    Event,
+    RunnerEvent,
     RunnerStatusUpdated,
     TaskAcknowledged,
     TaskStatusUpdated,
@@ -86,7 +86,7 @@ class Runner:
         self,
         bound_instance: BoundInstance,
         builder: Builder,
-        event_sender: MpSender[Event],
+        event_sender: MpSender[RunnerEvent],
         task_receiver: MpReceiver[Task],
     ):
         self.event_sender = event_sender

--- a/src/exo/worker/runner/supervisor.py
+++ b/src/exo/worker/runner/supervisor.py
@@ -16,6 +16,7 @@ from exo.shared.types.chunks import ErrorChunk
 from exo.shared.types.events import (
     ChunkGenerated,
     Event,
+    RunnerEvent,
     RunnerStatusUpdated,
     TaskAcknowledged,
     TaskStatusUpdated,
@@ -58,7 +59,7 @@ class RunnerSupervisor:
     bound_instance: BoundInstance
     runner_process: mp.Process
     initialize_timeout: float
-    _ev_recv: MpReceiver[Event]
+    _ev_recv: MpReceiver[RunnerEvent]
     _task_sender: MpSender[Task]
     _event_sender: Sender[Event]
     _transient_event_sender: Sender[TransientEvent]
@@ -82,7 +83,7 @@ class RunnerSupervisor:
         transient_event_sender: Sender[TransientEvent],
         initialize_timeout: float = 400,
     ) -> Self:
-        ev_send, ev_recv = mp_channel[Event]()
+        ev_send, ev_recv = mp_channel[RunnerEvent]()
         task_sender, task_recv = mp_channel[Task]()
         cancel_sender, cancel_recv = mp_channel[TaskId]()
 

--- a/src/exo/worker/tests/unittests/test_runner/test_event_ordering.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_event_ordering.py
@@ -11,7 +11,7 @@ import exo.worker.runner.llm_inference.model_output_parsers as mlx_model_output_
 from exo.shared.types.chunks import TokenChunk
 from exo.shared.types.events import (
     ChunkGenerated,
-    Event,
+    RunnerEvent,
     RunnerStatusUpdated,
     TaskAcknowledged,
     TaskStatusUpdated,
@@ -110,7 +110,9 @@ CHAT_TASK = TextGeneration(
 )
 
 
-def assert_events_equal(test_events: Iterable[Event], true_events: Iterable[Event]):
+def assert_events_equal(
+    test_events: Iterable[RunnerEvent], true_events: Iterable[RunnerEvent]
+):
     for test_event, true_event in zip(test_events, true_events, strict=True):
         test_event = test_event.model_copy(update={"event_id": true_event.event_id})
         assert test_event == true_event, f"{test_event} != {true_event}"
@@ -200,11 +202,11 @@ class FakeExoBatchGenerator:
 
 # Use a fake event_sender to remove test flakiness.
 class EventCollector:
-    def __init__(self, on_event: Callable[[Event], None] | None = None) -> None:
-        self.events: list[Event] = []
+    def __init__(self, on_event: Callable[[RunnerEvent], None] | None = None) -> None:
+        self.events: list[RunnerEvent] = []
         self._on_event = on_event
 
-    def send(self, event: Event) -> None:
+    def send(self, event: RunnerEvent) -> None:
         self.events.append(event)
         if self._on_event:
             self._on_event(event)
@@ -254,11 +256,11 @@ def _run(tasks: Iterable[Task], send_after_ready: list[Task] | None = None):
     task_sender, task_receiver = mp_channel[Task]()
     _cancel_sender, cancel_receiver = mp_channel[TaskId]()
 
-    on_event: Callable[[Event], None] | None = None
+    on_event: Callable[[RunnerEvent], None] | None = None
     if send_after_ready:
         _saw_running = False
 
-        def _on_event(event: Event) -> None:
+        def _on_event(event: RunnerEvent) -> None:
             nonlocal _saw_running
             if isinstance(event, RunnerStatusUpdated):
                 if isinstance(event.runner_status, RunnerRunning):

--- a/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
@@ -10,6 +10,7 @@ from exo.shared.types.common import CommandId, NodeId
 from exo.shared.types.events import (
     ChunkGenerated,
     Event,
+    RunnerEvent,
     RunnerStatusUpdated,
     TransientEvent,
 )
@@ -51,7 +52,7 @@ async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> 
     transient_sender, transient_receiver = channel[TransientEvent]()
     task_sender, _ = mp_channel[Task]()
     cancel_sender, _ = mp_channel[TaskId]()
-    _, ev_recv = mp_channel[Event]()
+    _, ev_recv = mp_channel[RunnerEvent]()
 
     bound_instance: BoundInstance = get_bound_mlx_ring_instance(
         instance_id=InstanceId("instance-a"),
@@ -113,7 +114,7 @@ async def test_forward_events_routes_generated_chunks_to_transient() -> None:
     transient_sender, transient_receiver = channel[TransientEvent]()
     task_sender, _ = mp_channel[Task]()
     cancel_sender, _ = mp_channel[TaskId]()
-    ev_send, ev_recv = mp_channel[Event]()
+    ev_send, ev_recv = mp_channel[RunnerEvent]()
 
     bound_instance: BoundInstance = get_bound_mlx_ring_instance(
         instance_id=InstanceId("instance-a"),


### PR DESCRIPTION
## Why

After chunks and traces move to transient transport, the durable `Event` union should only contain events that reduce into `State`. That makes the event-sourcing boundary explicit: durable indexed events are replayable state transitions; runner-local acknowledgements, output chunks, and trace signals are transient side effects.

## How

- Remove `TaskAcknowledged`, `ChunkGenerated`, `TracesCollected`, and `TracesMerged` from the durable `Event` union.
- Keep those types in `TransientEvent`.
- Add `RunnerEvent = Event | TransientEvent` for runner-process channels that still carry both state changes and runner-local/transient signals.
- Update runner, builder, and generator channel annotations to use `RunnerEvent`.
- Remove transient pass-through cases from `apply()`, leaving `TestEvent` as the only no-op durable event.

## Tests

- `uv run pytest src/exo/shared/tests/test_state_serialization.py src/exo/shared/tests/test_apply/test_apply_input_chunks.py src/exo/worker/tests/unittests/test_runner/test_event_ordering.py src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py src/exo/master/tests/test_master.py src/exo/api/tests/test_api_snapshot_bootstrap.py`
- `uv run pytest`
- `uv run basedpyright`
- `uv run ruff check`
- `nix fmt`