### PR TITLE
Tune event router NACK backoff for snapshots

### DIFF
--- a/src/exo/routing/event_router.py
+++ b/src/exo/routing/event_router.py
@@ -40,8 +40,9 @@ class EventRouter:
 
     _nack_cancel_scope: CancelScope | None = field(init=False, default=None)
     _nack_attempts: int = field(init=False, default=0)
-    _nack_base_seconds: float = field(init=False, default=0.5)
-    _nack_cap_seconds: float = field(init=False, default=10.0)
+    # Snapshot bootstrap leaves only a short post-snapshot tail for NACK replay.
+    _nack_base_seconds: float = field(init=False, default=0.05)
+    _nack_cap_seconds: float = field(init=False, default=1.0)
 
     async def run(self):
         try:


### PR DESCRIPTION
## Why

Before snapshots, a missing event could imply a long replay path, so the event router backed off over a 0.5s to 10s window. With snapshot bootstrap, NACK replay should usually fetch only the short tail after the snapshot. A faster retry window reduces worker/API catch-up latency without changing the durable event model.

## How

- Lower the NACK base delay from `0.5s` to `0.05s`.
- Lower the NACK cap from `10s` to `1s`.
- Add a short comment tying the retry window to snapshot-based catch-up.

## Tests

- `uv run pytest`
- `uv run basedpyright`
- `uv run ruff check`
- `nix fmt`