### PR TITLE
Tune cluster liveness polling cadence

### DIFF
--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -485,6 +485,9 @@ class Master:
 
     # These plan loops are the cracks showing in our event sourcing architecture - more things could be commands
     async def _plan(self) -> None:
+        node_inactivity_timeout = timedelta(seconds=5)
+        tick_interval_seconds = 1.0
+
         while True:
             # kill broken instances
             connected_node_ids = set(self.state.topology.list_nodes())
@@ -499,11 +502,11 @@ class Master:
             # time out dead nodes
             for node_id, time in self.state.last_seen.items():
                 now = datetime.now(tz=timezone.utc)
-                if now - time > timedelta(seconds=30):
+                if now - time > node_inactivity_timeout:
                     logger.info(f"Manually removing node {node_id} due to inactivity")
                     await self.event_sender.send(NodeTimedOut(node_id=node_id))
 
-            await anyio.sleep(10)
+            await anyio.sleep(tick_interval_seconds)
 
     async def _event_processor(self) -> None:
         with self.local_event_receiver as local_events:

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -445,6 +445,8 @@ class Worker:
         return runner
 
     async def _poll_connection_updates(self):
+        poll_interval_seconds = 2.0
+
         while True:
             edges = set(
                 conn.edge for conn in self.state.topology.out_edges(self.node_id)
@@ -487,4 +489,4 @@ class Worker:
                     logger.debug(f"ping failed to discover {conn=}")
                     await self.event_sender.send(TopologyEdgeDeleted(conn=conn))
 
-            await anyio.sleep(10)
+            await anyio.sleep(poll_interval_seconds)


### PR DESCRIPTION
## Why

Snapshot/state reconciliation gets workers caught up correctly, but stale topology still affects placement and dashboard freshness. The original branch reduced the time it takes to notice dead nodes and connection changes. This PR keeps that behavioral tuning isolated from the event-sourcing changes.

## How

- Master now checks node inactivity every `1s` instead of every `10s`.
- Master considers a node inactive after `5s` instead of `30s`.
- Workers poll connection reachability every `2s` instead of every `10s`.
- The values are local variables in each loop so future tuning is explicit.

## Tests

- `uv run pytest`
- `uv run basedpyright`
- `uv run ruff check`
- `nix fmt`