### PR TITLE
Retry custom card reconciliation failures

### DIFF
--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -226,15 +226,25 @@ class Worker:
         for model_id, card in target.items():
             if self._synced_custom_cards.get(model_id) == card:
                 continue
-            await card.save_to_custom_dir()
-            add_to_card_cache(card)
-            self._synced_custom_cards[model_id] = card
+            try:
+                await card.save_to_custom_dir()
+                add_to_card_cache(card)
+                self._synced_custom_cards[model_id] = card
+            except OSError as e:
+                logger.opt(exception=e).warning(
+                    f"Failed to write custom model card {model_id}; will retry"
+                )
 
         for model_id in list(self._synced_custom_cards):
             if model_id in target:
                 continue
-            await delete_custom_card(model_id)
-            self._synced_custom_cards.pop(model_id, None)
+            try:
+                await delete_custom_card(model_id)
+                self._synced_custom_cards.pop(model_id, None)
+            except OSError as e:
+                logger.opt(exception=e).warning(
+                    f"Failed to delete custom model card {model_id}; will retry"
+                )
 
     def _sync_input_views_from_state(self) -> None:
         self.input_chunk_buffer = {

--- a/src/exo/worker/tests/unittests/test_worker_custom_cards.py
+++ b/src/exo/worker/tests/unittests/test_worker_custom_cards.py
@@ -76,3 +76,46 @@ async def test_worker_deletes_custom_cards_missing_from_state(
 
     assert deleted == [card.model_id]
     assert worker._synced_custom_cards == {}
+
+
+@pytest.mark.asyncio
+async def test_worker_retries_custom_card_save_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cached: list[ModelId] = []
+
+    async def save_to_custom_dir(_card: ModelCard) -> None:
+        raise OSError("disk unavailable")
+
+    def add_to_card_cache(card: ModelCard) -> None:
+        cached.append(card.model_id)
+
+    monkeypatch.setattr(ModelCard, "save_to_custom_dir", save_to_custom_dir)
+    monkeypatch.setattr(worker_main, "add_to_card_cache", add_to_card_cache)
+
+    card = _model_card(ModelId("custom/model"))
+    worker = _worker()
+    worker.state = State(custom_model_cards={card.model_id: card})
+
+    await worker._sync_custom_cards_from_state()
+
+    assert cached == []
+    assert worker._synced_custom_cards == {}
+
+
+@pytest.mark.asyncio
+async def test_worker_retries_custom_card_delete_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def delete_custom_card(_model_id: ModelId) -> bool:
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(worker_main, "delete_custom_card", delete_custom_card)
+
+    card = _model_card(ModelId("custom/model"))
+    worker = _worker()
+    worker._synced_custom_cards = {card.model_id: card}
+
+    await worker._sync_custom_cards_from_state()
+
+    assert worker._synced_custom_cards == {card.model_id: card}


### PR DESCRIPTION
## Why

Custom model cards are now reconciled from durable `State`, which is the right event-sourcing shape. That reconciliation loop should be robust to transient filesystem failures: one failed write/delete should not kill the loop and leave the worker permanently out of sync with state.

## How

- Catch `OSError` while writing a custom card to disk.
- Catch `OSError` while deleting a stale custom card from disk.
- Leave `_synced_custom_cards` unchanged on failure so the next reconciliation tick retries.
- Add focused tests for save and delete failure retry behavior.

## Tests

- `uv run pytest src/exo/worker/tests/unittests/test_worker_custom_cards.py`
- `uv run pytest`
- `uv run basedpyright`
- `uv run ruff check`
- `nix fmt`