### PR TITLE
Add rambo prefill decode bench config

### DIFF
--- a/bench/prefill-decode-rambo.toml
+++ b/bench/prefill-decode-rambo.toml
@@ -1,0 +1,21 @@
+port = 52415
+timeout = 72000.0
+settle_timeout = 60.0
+prefill_server_host = "169.254.100.1"
+prefill_server_wait_timeout = 60.0
+
+[prefill]
+model = "sakamakismile/Qwen3.6-27B-NVFP4"
+node = "gx10-de89"
+instance_meta = "vllm"
+sharding = "pipeline"
+min_nodes = 1
+max_nodes = 1
+
+[decode]
+model = "mlx-community/Qwen3.6-27B-4bit"
+node = "rambo"
+instance_meta = "ring"
+sharding = "pipeline"
+min_nodes = 1
+max_nodes = 1


### PR DESCRIPTION
## Why

The rambo/gx10 split prefill benchmark setup is useful to keep as a checked-in, reproducible config instead of a local-only file. This is stacked on #2039 because it uses the new `prefill_server_host` and `prefill_server_wait_timeout` config keys added there.

## How

- Adds `bench/prefill-decode-rambo.toml` for the rambo decode node and gx10 prefill node.
- Pins the prefill server host to the Thunderbolt/local link address and gives startup polling a bounded timeout.

## Testing

- `nix fmt`
- `uv run python -c 'import tomllib; tomllib.load(open("bench/prefill-decode-rambo.toml", "rb"))'`