### PR TITLE
Initialise _cancelled_tasks in ImageEngine

### DIFF
--- a/src/exo/worker/engines/base.py
+++ b/src/exo/worker/engines/base.py
@@ -22,6 +22,10 @@ class Engine(ABC):
             or CANCEL_ALL_TASKS in self._cancelled_tasks
         )
 
+    @property
+    @abstractmethod
+    def emits_chunks(self) -> bool: ...
+
     @abstractmethod
     def warmup(self) -> None: ...
 

--- a/src/exo/worker/engines/image/builder.py
+++ b/src/exo/worker/engines/image/builder.py
@@ -145,6 +145,10 @@ class ImageEngine(Engine):
     queue: deque[ImageTask] = field(init=False, default_factory=deque)
     _cancelled_tasks: set[TaskId] = field(init=False, default_factory=set)
 
+    @property
+    def emits_chunks(self) -> bool:
+        return _is_primary_output_node(self.shard_metadata)
+
     def warmup(self) -> None:
         image = warmup_image_generator(model=self.image_model)
         if image is not None:

--- a/src/exo/worker/engines/image/builder.py
+++ b/src/exo/worker/engines/image/builder.py
@@ -143,6 +143,7 @@ class ImageEngine(Engine):
         Generator[tuple[TaskId, Chunk | FinishedResponse | CancelledResponse]] | None
     ) = field(init=False, default=None)
     queue: deque[ImageTask] = field(init=False, default_factory=deque)
+    _cancelled_tasks: set[TaskId] = field(init=False, default_factory=set)
 
     def warmup(self) -> None:
         image = warmup_image_generator(model=self.image_model)

--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -118,6 +118,10 @@ class SequentialGenerator(Engine):
         | None
     ) = field(default=None, init=False)
 
+    @property
+    def emits_chunks(self) -> bool:
+        return self.device_rank == 0
+
     def warmup(self):
         self.check_for_cancel_every = warmup_inference(
             model=self.model,
@@ -347,6 +351,10 @@ class BatchGenerator(Engine):
             kv_prefix_cache=self.kv_prefix_cache,
             vision_processor=self.vision_processor,
         )
+
+    @property
+    def emits_chunks(self) -> bool:
+        return self.device_rank == 0
 
     def warmup(self):
         self.check_for_cancel_every = warmup_inference(

--- a/src/exo/worker/runner/runner.py
+++ b/src/exo/worker/runner/runner.py
@@ -390,5 +390,6 @@ class Runner:
         chunk: Chunk,
         command_id: CommandId,
     ):
-        if self.device_rank == 0:
+        assert isinstance(self.generator, Engine)
+        if self.generator.emits_chunks:
             self.event_sender.send(ChunkGenerated(command_id=command_id, chunk=chunk))


### PR DESCRIPTION
## Motivation

Image generation was broken

## Changes

- initialise `_cancelled_tasks` in image engine
- `emits_chunks` engine property to designate output node

## Why It Works

- `should_cancel` no longer raises an exception due to uninitialised `_cancelled_tasks`
- the rank with the output image now hooks up to the API

## Test Plan

### Manual Testing

Successful image generations
