### PR TITLE
fix: set processor_repo to vision weights repo in Kimi model cards

### DIFF
--- a/resources/inference_model_cards/mlx-community--Kimi-K2.5.toml
+++ b/resources/inference_model_cards/mlx-community--Kimi-K2.5.toml
@@ -17,8 +17,8 @@ in_bytes = 662498705408
 [vision]
 image_token_id = 163605
 model_type = "kimi_vl"
-weights_repo = "davehind/Kimi-K2.5-vision"
-processor_repo = "moonshotai/Kimi-K2.5"
+weights_repo = "Drifter4242/Kimi-K2.5-vision"
+processor_repo = "Drifter4242/Kimi-K2.5-vision"
 
 # Source: https://deepwiki.com/MoonshotAI/Kimi-K2.5/3.7-recommended-parameters
 # Source: https://unsloth.ai/docs/models/kimi-k2.5

--- a/resources/inference_model_cards/mlx-community--Kimi-K2.6-mlx-DQ3_K_M-q8.toml
+++ b/resources/inference_model_cards/mlx-community--Kimi-K2.6-mlx-DQ3_K_M-q8.toml
@@ -18,7 +18,7 @@ in_bytes = 470628683776
 image_token_id = 163605
 model_type = "kimi_vl"
 weights_repo = "exolabs/Kimi-K2.6-vision"
-processor_repo = "moonshotai/Kimi-K2.6"
+processor_repo = "exolabs/Kimi-K2.6-vision"
 
 # Source: https://huggingface.co/moonshotai/Kimi-K2.6
 [sampling_defaults]

--- a/resources/inference_model_cards/moonshotai--Kimi-K2.6.toml
+++ b/resources/inference_model_cards/moonshotai--Kimi-K2.6.toml
@@ -18,7 +18,7 @@ in_bytes = 595148192736
 image_token_id = 163605
 model_type = "kimi_vl"
 weights_repo = "exolabs/Kimi-K2.6-vision"
-processor_repo = "moonshotai/Kimi-K2.6"
+processor_repo = "exolabs/Kimi-K2.6-vision"
 
 # Source: https://huggingface.co/moonshotai/Kimi-K2.6
 [sampling_defaults]


### PR DESCRIPTION
Just some small changes to the vision model cards. Two things: if the model isn't loaded then specifying it in the processor_repo can cause it to fail (I must have had the models downloaded before so it wasn't a problem). Also I've renamed my hf depot (old links should still work though), so I updated the links.

The rest is written by Sonnet (reviewed by me):

The processor_repo fields for Kimi K2.5 and K2.6 pointed to the full LLM repos (moonshotai/Kimi-K2.5, moonshotai/Kimi-K2.6), which are not downloaded locally (595+ GB). The image processor must be loaded from the vision weights repo, which IS downloaded alongside the vision weights.

- mlx-community/Kimi-K2.5: processor_repo -> Drifter4242/Kimi-K2.5-vision
  (also fixes weights_repo: davehind/ -> Drifter4242/ after account transfer)
- mlx-community/Kimi-K2.6-mlx-DQ3_K_M-q8: processor_repo -> exolabs/Kimi-K2.6-vision
- moonshotai/Kimi-K2.6: processor_repo -> exolabs/Kimi-K2.6-vision

Without this fix vision loading fails immediately with a FileNotFoundError when trying to load the tokenizer/processor from the non-existent local path for the full model.

## Motivation

The `processor_repo` fields for three Kimi vision model cards pointed to the
full LLM repos (`moonshotai/Kimi-K2.5`, `moonshotai/Kimi-K2.6`). These are
500–660 GB models that are not downloaded locally. When exo loads the vision
pipeline, it calls `build_model_path(ModelId(processor_repo))` to construct a
local filesystem path — if that path doesn't exist, loading fails.

The image processor must be loaded from the **vision weights repo**, which is
downloaded automatically alongside the vision weights and is always present.

A secondary fix: `mlx-community/Kimi-K2.5` had `weights_repo = "davehind/Kimi-K2.5-vision"`,
a now-stale HuggingFace account that was transferred to `Drifter4242`.

## Changes

| Model card | Field | Before | After |
|---|---|---|---|
| `mlx-community/Kimi-K2.5` | `weights_repo` | `davehind/Kimi-K2.5-vision` | `Drifter4242/Kimi-K2.5-vision` |
| `mlx-community/Kimi-K2.5` | `processor_repo` | `moonshotai/Kimi-K2.5` | `Drifter4242/Kimi-K2.5-vision` |
| `mlx-community/Kimi-K2.6-mlx-DQ3_K_M-q8` | `processor_repo` | `moonshotai/Kimi-K2.6` | `exolabs/Kimi-K2.6-vision` |
| `moonshotai/Kimi-K2.6` | `processor_repo` | `moonshotai/Kimi-K2.6` | `exolabs/Kimi-K2.6-vision` |

## Why It Works

`vision.py` resolves `processor_repo` via `build_model_path(ModelId(processor_repo))`,
which maps a HuggingFace repo ID to a local cache path. The full LLM repos are
never fully downloaded by vision users, so their local paths do not exist.
The vision-specific repos (`Drifter4242/Kimi-K2.5-vision`, `exolabs/Kimi-K2.6-vision`)
are small (~1–2 GB) and are downloaded as part of the normal vision weight fetch,
so their local paths are always present by the time the processor is needed.

## Test Plan

### Manual Testing

**Hardware:** 2× Mac Studio M3 Ultra 512 GB, Thunderbolt 5 direct bridge,
`MlxJaccl` RDMA tensor-parallel (`moonshotai/Kimi-K2.6`, 595 GB INT4, 61 layers).

- Confirmed vision pipeline loads successfully after this change with
  `moonshotai/Kimi-K2.6` + `exolabs/Kimi-K2.6-vision` weights.
- Sent image requests and received correct responses.

### Automated Testing

No code changes — model card data files only. All existing tests pass:
`pytest src -m "not slow" --import-mode=importlib`
