### PR TITLE
Stabilize GPT-OSS tool support; echo reasoning config in Responses API

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -478,6 +478,7 @@
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
 			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -488,6 +489,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
 			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
@@ -498,6 +500,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -507,12 +510,14 @@
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.31",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
 			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -1095,6 +1100,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.8.tgz",
 			"integrity": "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==",
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8.9.0"
@@ -1756,6 +1762,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/geojson": {
@@ -1779,6 +1786,7 @@
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1791,6 +1799,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
 			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
@@ -1800,6 +1809,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
 			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
@@ -2334,6 +2344,7 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.5.0.tgz",
 			"integrity": "sha512-69sM5yrHfFLJt0AZ9QqZXGCPfJ7fQjvpln3Rq5+PS03LD32Ost1Q9N+eEnaQwGRIriKkMImXD56ocjQmfjbV3w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/enhanced-resolve": {
@@ -2402,6 +2413,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.1.tgz",
 			"integrity": "sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
@@ -2489,6 +2501,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
 			"integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.6"
@@ -2804,12 +2817,14 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
 			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
 			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
@@ -3132,6 +3147,7 @@
 			"version": "5.45.3",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.45.3.tgz",
 			"integrity": "sha512-ngKXNhNvwPzF43QqEhDOue7TQTrG09em1sd4HBxVF0Wr2gopAmdEWan+rgbdgK4fhBtSOTJO8bYU4chUG7VXZQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
@@ -3391,6 +3407,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
 			"integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+			"dev": true,
 			"license": "MIT"
 		}
 	}

--- a/dashboard/src/lib/components/ModelPickerModal.svelte
+++ b/dashboard/src/lib/components/ModelPickerModal.svelte
@@ -75,6 +75,7 @@
     totalMemoryGB: number;
     usedMemoryGB: number;
     downloadsData?: Record<string, unknown[]>;
+    downloadedModelIds?: Set<string>;
     topologyNodes?: Record<
       string,
       {
@@ -104,6 +105,7 @@
     totalMemoryGB,
     usedMemoryGB,
     downloadsData,
+    downloadedModelIds = new Set(),
     topologyNodes,
     instanceStatuses = {},
   }: ModelPickerModalProps = $props();
@@ -137,16 +139,29 @@
 
   const modelDownloadAvailability = $derived.by(() => {
     const result = new Map<string, DownloadAvailability>();
-    if (!downloadsData || !topologyNodes) return result;
 
     for (const model of models) {
-      const nodeIds = getNodesWithModelDownloaded(downloadsData, model.id);
-      if (nodeIds.length === 0) continue;
+      const nodeIds =
+        downloadsData && topologyNodes
+          ? getNodesWithModelDownloaded(downloadsData, model.id)
+          : [];
+
+      if (nodeIds.length === 0) {
+        if (downloadedModelIds.has(model.id)) {
+          result.set(model.id, {
+            available: true,
+            nodeNames: ["local disk"],
+            nodeIds: ["local"],
+          });
+        }
+        continue;
+      }
 
       // Sum total RAM across nodes that have the model
       let totalRamBytes = 0;
+      const nodes = topologyNodes ?? {};
       for (const nodeId of nodeIds) {
-        const ramTotal = topologyNodes[nodeId]?.macmon_info?.memory?.ram_total;
+        const ramTotal = nodes[nodeId]?.macmon_info?.memory?.ram_total;
         if (typeof ramTotal === "number") totalRamBytes += ramTotal;
       }
 

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -785,6 +785,7 @@
       capabilities?: string[];
     }>
   >([]);
+  let downloadedModelIds = $state<Set<string>>(new Set());
   type ModelMemoryFitStatus =
     | "fits_now"
     | "fits_cluster_capacity"
@@ -1358,7 +1359,10 @@
 
   async function fetchModels() {
     try {
-      const response = await fetch("/models");
+      const [response, downloadedResponse] = await Promise.all([
+        fetch("/models"),
+        fetch("/models?status=downloaded"),
+      ]);
       if (response.ok) {
         const data = await response.json();
         // API returns { data: [{ id, name }] } format
@@ -1368,6 +1372,12 @@
           ? Object.keys(topologyData()!.nodes).length
           : 1;
         applyLaunchDefaults(models, currentNodeCount);
+      }
+      if (downloadedResponse.ok) {
+        const downloadedData = await downloadedResponse.json();
+        downloadedModelIds = new Set(
+          (downloadedData.data || []).map((model: { id: string }) => model.id),
+        );
       }
     } catch (error) {
       console.error("Failed to fetch models:", error);
@@ -4684,6 +4694,7 @@
         totalMemoryGB={clusterMemory().total / (1024 * 1024 * 1024)}
         usedMemoryGB={clusterMemory().used / (1024 * 1024 * 1024)}
         {downloadsData}
+        {downloadedModelIds}
         topologyNodes={data?.nodes}
       />
     {/if}
@@ -6760,6 +6771,7 @@
     totalMemoryGB={clusterMemory().total / (1024 * 1024 * 1024)}
     usedMemoryGB={clusterMemory().used / (1024 * 1024 * 1024)}
     {downloadsData}
+    {downloadedModelIds}
     topologyNodes={data?.nodes}
     instanceStatuses={modelInstanceStatuses}
   />

--- a/dashboard/src/routes/integrations/+page.svelte
+++ b/dashboard/src/routes/integrations/+page.svelte
@@ -15,6 +15,7 @@
   let modelCapabilities = $state<Record<string, string[]>>({});
   let modelContextLengths = $state<Record<string, number>>({});
   let modelReasoningDialects = $state<Record<string, string>>({});
+  let downloadedModels = $state<string[]>([]);
 
   const runningModels = $derived.by(() => {
     const models: string[] = [];
@@ -38,13 +39,20 @@
     return models;
   });
 
+  const selectableModels = $derived.by(() => {
+    const models = new Set<string>();
+    for (const model of runningModels) models.add(model);
+    for (const model of downloadedModels) models.add(model);
+    return [...models];
+  });
+
   function estimateParamSize(modelId: string): number {
     const match = modelId.match(/(\d+(?:\.\d+)?)[Bb]/);
     return match ? parseFloat(match[1]) : 0;
   }
 
   const modelsBySize = $derived(
-    [...runningModels].sort(
+    [...selectableModels].sort(
       (a, b) => estimateParamSize(b) - estimateParamSize(a),
     ),
   );
@@ -130,7 +138,7 @@
 
   const openCodeConfig = $derived.by(() => {
     const models: Record<string, Record<string, unknown>> = {};
-    for (const modelId of runningModels) {
+    for (const modelId of selectableModels) {
       const caps = modelCapabilities[modelId] || [];
       const ctxLen = modelContextLengths[modelId] || 0;
       const dialect = modelReasoningDialects[modelId];
@@ -168,7 +176,7 @@
       models["your-model-id"] = { name: "your-model-name" };
     }
     const firstModel =
-      runningModels.length > 0 ? runningModels[0] : "your-model-id";
+      selectableModels.length > 0 ? selectableModels[0] : "your-model-id";
     return JSON.stringify(
       {
         $schema: "https://opencode.ai/config.json",
@@ -245,7 +253,7 @@
 
   const piModelsJson = $derived.by(() => {
     const models: Record<string, unknown>[] = [];
-    for (const modelId of runningModels) {
+    for (const modelId of selectableModels) {
       const caps = modelCapabilities[modelId] || [];
       const ctxLen = modelContextLengths[modelId] || 0;
       const entry: Record<string, unknown> = { id: modelId };
@@ -371,8 +379,11 @@
   onMount(async () => {
     refreshState();
     try {
-      const resp = await fetch("/v1/models");
-      const data = (await resp.json()) as {
+      const [modelsResp, downloadedResp] = await Promise.all([
+        fetch("/v1/models"),
+        fetch("/models?status=downloaded"),
+      ]);
+      const data = (await modelsResp.json()) as {
         data: {
           id: string;
           capabilities: string[];
@@ -392,6 +403,12 @@
       modelCapabilities = caps;
       modelContextLengths = ctxs;
       modelReasoningDialects = dialects;
+      if (downloadedResp.ok) {
+        const downloadedData = (await downloadedResp.json()) as {
+          data: { id: string }[];
+        };
+        downloadedModels = (downloadedData.data || []).map((model) => model.id);
+      }
     } catch {
       /* ignore */
     }
@@ -490,7 +507,7 @@
     <!-- Tab Content -->
     <div class="space-y-4">
       {#if activeTab === "Claude Code"}
-        {#if runningModels.length > 1}
+        {#if selectableModels.length > 1}
           <div class="grid grid-cols-3 gap-3 text-xs">
             {#each [{ label: "Opus", bind: () => opusModel, set: (v: string) => (opusModel = v) }, { label: "Sonnet", bind: () => sonnetModel, set: (v: string) => (sonnetModel = v) }, { label: "Haiku", bind: () => haikuModel, set: (v: string) => (haikuModel = v) }] as tier}
               <div>
@@ -504,7 +521,7 @@
                     tier.set((e.target as HTMLSelectElement).value)}
                   class="w-full {selectClass}"
                 >
-                  {#each runningModels as model}
+                  {#each selectableModels as model}
                     <option value={model}>{model.split("/").pop()}</option>
                   {/each}
                 </select>
@@ -534,14 +551,14 @@
         />
       {:else if activeTab === "Codex"}
         <div class="flex gap-3 text-xs">
-          {#if runningModels.length > 1}
+          {#if selectableModels.length > 1}
             <div>
               <span
                 class="text-exo-light-gray/50 text-[10px] uppercase tracking-wider block mb-1"
                 >Model</span
               >
               <select bind:value={codexModel} class={selectClass}>
-                {#each runningModels as model}
+                {#each selectableModels as model}
                   <option value={model}>{model.split("/").pop()}</option>
                 {/each}
               </select>
@@ -573,14 +590,14 @@
           language="bash"
         />
       {:else if activeTab === "OpenClaw"}
-        {#if runningModels.length > 1}
+        {#if selectableModels.length > 1}
           <div class="text-xs">
             <span
               class="text-exo-light-gray/50 text-[10px] uppercase tracking-wider block mb-1"
               >Model</span
             >
             <select bind:value={openClawModel} class={selectClass}>
-              {#each runningModels as model}
+              {#each selectableModels as model}
                 <option value={model}>{model.split("/").pop()}</option>
               {/each}
             </select>
@@ -600,14 +617,14 @@
           language="bash"
         />
       {:else if activeTab === "Pi"}
-        {#if runningModels.length > 1}
+        {#if selectableModels.length > 1}
           <div class="text-xs">
             <span
               class="text-exo-light-gray/50 text-[10px] uppercase tracking-wider block mb-1"
               >Model</span
             >
             <select bind:value={piModel} class={selectClass}>
-              {#each runningModels as model}
+              {#each selectableModels as model}
                 <option value={model}>{model.split("/").pop()}</option>
               {/each}
             </select>
@@ -637,7 +654,7 @@
         <IntegrationCard
           title="2. Open & Select Model"
           subtitle="http://localhost:3000"
-          description={`Open http://localhost:3000 in your browser. Select the running model from the dropdown at the top: ${runningModels.length > 0 ? runningModels.join(", ") : "no models running"}`}
+          description={`Open http://localhost:3000 in your browser. Select an available model from the dropdown at the top: ${selectableModels.length > 0 ? selectableModels.join(", ") : "no local models detected"}`}
           config={"open http://localhost:3000"}
           language="bash"
         />

--- a/resources/inference_model_cards/mlx-community--gpt-oss-120b-MXFP4-Q8.toml
+++ b/resources/inference_model_cards/mlx-community--gpt-oss-120b-MXFP4-Q8.toml
@@ -7,7 +7,7 @@ tasks = ["TextGeneration"]
 family = "gpt-oss"
 quantization = "MXFP4-Q8"
 base_model = "GPT-OSS 120B"
-capabilities = ["text", "thinking"]
+capabilities = ["text", "thinking", "tools"]
 reasoning_dialect = "channel"
 context_length = 131072
 

--- a/resources/inference_model_cards/mlx-community--gpt-oss-20b-MXFP4-Q8.toml
+++ b/resources/inference_model_cards/mlx-community--gpt-oss-20b-MXFP4-Q8.toml
@@ -7,7 +7,7 @@ tasks = ["TextGeneration"]
 family = "gpt-oss"
 quantization = "MXFP4-Q8"
 base_model = "GPT-OSS 20B"
-capabilities = ["text", "thinking"]
+capabilities = ["text", "thinking", "tools"]
 reasoning_dialect = "channel"
 context_length = 131072
 

--- a/src/exo/api/adapters/responses.py
+++ b/src/exo/api/adapters/responses.py
@@ -130,6 +130,54 @@ def _append_tool_call(
     )
 
 
+def _custom_tool_parameters(tool: dict[str, Any]) -> dict[str, Any]:
+    """Build a JSON schema for Responses custom/freeform tools.
+
+    Codex exposes some tools, notably apply_patch, as custom/freeform tools in
+    the Responses API. MLX chat templates expect function-style JSON schemas,
+    so preserve that freeform input as a single required string argument.
+    """
+    format_config = tool.get("format")
+    description = "Freeform tool input."
+    if isinstance(format_config, dict) and isinstance(
+        format_config.get("description"), str
+    ):
+        description = format_config["description"]
+
+    return {
+        "type": "object",
+        "properties": {
+            "input": {
+                "type": "string",
+                "description": description,
+            }
+        },
+        "required": ["input"],
+        "additionalProperties": False,
+    }
+
+
+def _normalise_responses_tool(tool: dict[str, Any]) -> dict[str, Any]:
+    """Convert a Responses API tool definition into chat-completions shape."""
+    if "function" in tool:
+        return tool
+
+    name = tool.get("name", "")
+    parameters = tool.get("parameters")
+    if not isinstance(parameters, dict):
+        parameters = _custom_tool_parameters(tool) if tool.get("type") == "custom" else {}
+
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": tool.get("description", ""),
+            "parameters": parameters,
+            **({"strict": tool["strict"]} if "strict" in tool else {}),
+        },
+    }
+
+
 async def responses_request_to_text_generation(
     request: ResponsesRequest,
 ) -> TextGenerationTaskParams:
@@ -234,7 +282,7 @@ async def responses_request_to_text_generation(
                             "type": "function",
                             "function": {
                                 "name": "apply_patch",
-                                "arguments": json.dumps({"patch": item.patch}),
+                                "arguments": json.dumps({"input": item.patch}),
                             },
                         },
                     )
@@ -289,19 +337,10 @@ async def responses_request_to_text_generation(
                         }
                     )
                 case ReasoningInputItem():
-                    reasoning_text = ""
-                    if item.content:
-                        reasoning_text = "".join(
-                            entry.get("text", "") for entry in item.content
-                        )
-                    elif item.summary:
-                        reasoning_text = "".join(
-                            entry.get("text", "") for entry in item.summary
-                        )
-                    if reasoning_text:
-                        chat_template_messages.append(
-                            {"role": "assistant", "content": reasoning_text}
-                        )
+                    # Reasoning items are internal assistant state. Replaying
+                    # them as assistant messages can separate an assistant
+                    # tool_call from its tool output in chat-template history.
+                    continue
                 case CompactionInputItem():
                     if item.summary:
                         chat_template_messages.append(
@@ -356,22 +395,7 @@ async def responses_request_to_text_generation(
     # we need to normalise to this format.
     normalised_tools: list[dict[str, Any]] | None = None
     if request.tools:
-        normalised_tools = []
-        for tool in request.tools:
-            if "function" in tool:
-                normalised_tools.append(tool)
-            else:
-                normalised_tools.append(
-                    {
-                        "type": "function",
-                        "function": {
-                            "name": tool.get("name", ""),
-                            "description": tool.get("description", ""),
-                            "parameters": tool.get("parameters", {}),
-                            **({"strict": tool["strict"]} if "strict" in tool else {}),
-                        },
-                    }
-                )
+        normalised_tools = [_normalise_responses_tool(tool) for tool in request.tools]
 
     return TextGenerationTaskParams(
         model=request.model,
@@ -455,13 +479,22 @@ async def collect_responses_response(
                 summary=[ResponseReasoningSummaryText(text="".join(thinking_parts))],
             )
         )
-    output.append(
-        ResponseMessageItem(
-            id=item_id,
-            content=[ResponseOutputText(text=accumulated_text)],
-            status="completed",
+    if accumulated_text and not function_call_items:
+        output.append(
+            ResponseMessageItem(
+                id=item_id,
+                content=[ResponseOutputText(text=accumulated_text)],
+                status="completed",
+            )
         )
-    )
+    elif not function_call_items:
+        output.append(
+            ResponseMessageItem(
+                id=item_id,
+                content=[ResponseOutputText(text="")],
+                status="completed",
+            )
+        )
     output.extend(function_call_items)
 
     yield ResponsesResponse(
@@ -515,6 +548,7 @@ async def generate_responses_stream(
 
     # Track dynamic block creation
     reasoning_started = False
+    reasoning_closed = False
     reasoning_output_index = -1
     message_started = False
     message_output_index = -1
@@ -630,7 +664,7 @@ async def generate_responses_stream(
             continue
 
         # Close reasoning block when transitioning to text
-        if reasoning_started and not message_started:
+        if reasoning_started and not reasoning_closed:
             # response.reasoning_summary_text.done
             rs_text_done = ResponseReasoningSummaryTextDoneEvent(
                 sequence_number=next(seq),
@@ -661,49 +695,12 @@ async def generate_responses_stream(
                 ),
             )
             yield _format_sse(rs_item_done)
-
-        # Start message block on first text token
-        if not message_started:
-            message_started = True
-            message_output_index = next_output_index
-            next_output_index += 1
-
-            initial_item = ResponseMessageItem(
-                id=item_id,
-                content=[ResponseOutputText(text="")],
-                status="in_progress",
-            )
-            item_added = ResponseOutputItemAddedEvent(
-                sequence_number=next(seq),
-                output_index=message_output_index,
-                item=initial_item,
-            )
-            yield _format_sse(item_added)
-
-            initial_part = ResponseOutputText(text="")
-            part_added = ResponseContentPartAddedEvent(
-                sequence_number=next(seq),
-                item_id=item_id,
-                output_index=message_output_index,
-                content_index=0,
-                part=initial_part,
-            )
-            yield _format_sse(part_added)
+            reasoning_closed = True
 
         accumulated_text += chunk.text
 
-        # response.output_text.delta
-        delta_event = ResponseTextDeltaEvent(
-            sequence_number=next(seq),
-            item_id=item_id,
-            output_index=message_output_index,
-            content_index=0,
-            delta=chunk.text,
-        )
-        yield _format_sse(delta_event)
-
     # Close reasoning block if it was never followed by text
-    if reasoning_started and not message_started:
+    if reasoning_started and not reasoning_closed:
         rs_text_done = ResponseReasoningSummaryTextDoneEvent(
             sequence_number=next(seq),
             item_id=reasoning_id,
@@ -731,9 +728,40 @@ async def generate_responses_stream(
             ),
         )
         yield _format_sse(rs_item_done)
+        reasoning_closed = True
 
-    # If no message block was started, create one now (empty text)
+    # If this response has tool calls, do not also emit a pre-tool assistant
+    # message. Codex replays streamed items in a way that can place that message
+    # between the assistant tool_call and the tool output, which breaks local
+    # chat-template continuations.
+    tool_call_response = bool(function_call_items)
+    if not message_started and tool_call_response:
+        usage = _build_response_usage(last_usage) if last_usage is not None else None
+        output: list[ResponseItem] = []
+        if reasoning_started:
+            output.append(
+                ResponseReasoningItem(
+                    id=reasoning_id,
+                    summary=[ResponseReasoningSummaryText(text=accumulated_thinking)],
+                )
+            )
+        output.extend(function_call_items)
+        final_response = ResponsesResponse(
+            id=response_id,
+            model=model,
+            status="completed",
+            output=output,
+            output_text=accumulated_text,
+            usage=usage,
+        )
+        completed_event = ResponseCompletedEvent(
+            sequence_number=next(seq), response=final_response
+        )
+        yield _format_sse(completed_event)
+        return
+
     if not message_started:
+        message_started = True
         message_output_index = next_output_index
         next_output_index += 1
 
@@ -758,6 +786,16 @@ async def generate_responses_stream(
             part=initial_part,
         )
         yield _format_sse(part_added_evt)
+
+        if accumulated_text:
+            delta_event = ResponseTextDeltaEvent(
+                sequence_number=next(seq),
+                item_id=item_id,
+                output_index=message_output_index,
+                content_index=0,
+                delta=accumulated_text,
+            )
+            yield _format_sse(delta_event)
 
     # response.output_text.done
     text_done = ResponseTextDoneEvent(
@@ -805,7 +843,8 @@ async def generate_responses_stream(
                 summary=[ResponseReasoningSummaryText(text=accumulated_thinking)],
             )
         )
-    output.append(final_message_item)
+    if not function_call_items:
+        output.append(final_message_item)
     output.extend(function_call_items)
     final_response = ResponsesResponse(
         id=response_id,

--- a/src/exo/api/adapters/responses.py
+++ b/src/exo/api/adapters/responses.py
@@ -32,6 +32,7 @@ from exo.api.types.openai_responses import (
     McpCallInputItem,
     McpListToolsInputItem,
     OutputTokensDetails,
+    Reasoning,
     ReasoningInputItem,
     ResponseCompletedEvent,
     ResponseContentPart,
@@ -424,6 +425,7 @@ async def collect_responses_response(
     chunk_stream: AsyncGenerator[
         ErrorChunk | ToolCallChunk | TokenChunk | PrefillProgressChunk, None
     ],
+    reasoning: Reasoning | None = None,
 ) -> AsyncGenerator[str]:
     # This is an AsyncGenerator[str] rather than returning a ChatCompletionReponse because
     # FastAPI handles the cancellation better but wouldn't auto-serialize for some reason
@@ -504,6 +506,7 @@ async def collect_responses_response(
         output=output,
         output_text=accumulated_text,
         usage=usage,
+        reasoning=reasoning,
     ).model_dump_json()
     return
 
@@ -514,6 +517,7 @@ async def generate_responses_stream(
     chunk_stream: AsyncGenerator[
         ErrorChunk | ToolCallChunk | TokenChunk | PrefillProgressChunk, None
     ],
+    reasoning: Reasoning | None = None,
 ) -> AsyncGenerator[str, None]:
     """Generate OpenAI Responses API streaming events from TokenChunks."""
     response_id = f"resp_{command_id}"
@@ -528,6 +532,7 @@ async def generate_responses_stream(
         status="in_progress",
         output=[],
         output_text="",
+        reasoning=reasoning,
     )
     created_event = ResponseCreatedEvent(
         sequence_number=next(seq), response=initial_response
@@ -790,6 +795,7 @@ async def generate_responses_stream(
             output=output,
             output_text=accumulated_text,
             usage=usage,
+            reasoning=reasoning,
         )
         completed_event = ResponseCompletedEvent(
             sequence_number=next(seq), response=final_response
@@ -880,6 +886,7 @@ async def generate_responses_stream(
         output=output,
         output_text=accumulated_text,
         usage=usage,
+        reasoning=reasoning,
     )
     completed_event = ResponseCompletedEvent(
         sequence_number=next(seq), response=final_response

--- a/src/exo/api/adapters/responses.py
+++ b/src/exo/api/adapters/responses.py
@@ -697,7 +697,44 @@ async def generate_responses_stream(
             yield _format_sse(rs_item_done)
             reasoning_closed = True
 
+        # Start message block on first visible text token.
+        if not message_started:
+            message_started = True
+            message_output_index = next_output_index
+            next_output_index += 1
+
+            initial_item = ResponseMessageItem(
+                id=item_id,
+                content=[ResponseOutputText(text="")],
+                status="in_progress",
+            )
+            item_added = ResponseOutputItemAddedEvent(
+                sequence_number=next(seq),
+                output_index=message_output_index,
+                item=initial_item,
+            )
+            yield _format_sse(item_added)
+
+            initial_part = ResponseOutputText(text="")
+            part_added = ResponseContentPartAddedEvent(
+                sequence_number=next(seq),
+                item_id=item_id,
+                output_index=message_output_index,
+                content_index=0,
+                part=initial_part,
+            )
+            yield _format_sse(part_added)
+
         accumulated_text += chunk.text
+
+        delta_event = ResponseTextDeltaEvent(
+            sequence_number=next(seq),
+            item_id=item_id,
+            output_index=message_output_index,
+            content_index=0,
+            delta=chunk.text,
+        )
+        yield _format_sse(delta_event)
 
     # Close reasoning block if it was never followed by text
     if reasoning_started and not reasoning_closed:
@@ -786,16 +823,6 @@ async def generate_responses_stream(
             part=initial_part,
         )
         yield _format_sse(part_added_evt)
-
-        if accumulated_text:
-            delta_event = ResponseTextDeltaEvent(
-                sequence_number=next(seq),
-                item_id=item_id,
-                output_index=message_output_index,
-                content_index=0,
-                delta=accumulated_text,
-            )
-            yield _format_sse(delta_event)
 
     # response.output_text.done
     text_done = ResponseTextDoneEvent(

--- a/src/exo/api/adapters/responses.py
+++ b/src/exo/api/adapters/responses.py
@@ -140,10 +140,10 @@ def _custom_tool_parameters(tool: dict[str, Any]) -> dict[str, Any]:
     """
     format_config = tool.get("format")
     description = "Freeform tool input."
-    if isinstance(format_config, dict) and isinstance(
-        format_config.get("description"), str
-    ):
-        description = format_config["description"]
+    if isinstance(format_config, dict):
+        candidate_description: object = format_config.get("description")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        if isinstance(candidate_description, str):
+            description = candidate_description
 
     return {
         "type": "object",
@@ -163,10 +163,13 @@ def _normalise_responses_tool(tool: dict[str, Any]) -> dict[str, Any]:
     if "function" in tool:
         return tool
 
-    name = tool.get("name", "")
+    name_value = tool.get("name", "")  # pyright: ignore[reportAny]
+    name: str = name_value if isinstance(name_value, str) else ""
     parameters = tool.get("parameters")
     if not isinstance(parameters, dict):
-        parameters = _custom_tool_parameters(tool) if tool.get("type") == "custom" else {}
+        parameters = (
+            _custom_tool_parameters(tool) if tool.get("type") == "custom" else {}
+        )
 
     return {
         "type": "function",
@@ -779,20 +782,20 @@ async def generate_responses_stream(
     tool_call_response = bool(function_call_items)
     if not message_started and tool_call_response:
         usage = _build_response_usage(last_usage) if last_usage is not None else None
-        output: list[ResponseItem] = []
+        tool_only_output: list[ResponseItem] = []
         if reasoning_started:
-            output.append(
+            tool_only_output.append(
                 ResponseReasoningItem(
                     id=reasoning_id,
                     summary=[ResponseReasoningSummaryText(text=accumulated_thinking)],
                 )
             )
-        output.extend(function_call_items)
+        tool_only_output.extend(function_call_items)
         final_response = ResponsesResponse(
             id=response_id,
             model=model,
             status="completed",
-            output=output,
+            output=tool_only_output,
             output_text=accumulated_text,
             usage=usage,
             reasoning=reasoning,

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -119,6 +119,7 @@ from exo.api.types.openai_responses import (
     ResponsesRequest,
     ResponsesResponse,
 )
+from exo.download.download_utils import resolve_existing_model
 from exo.master.image_store import ImageStore
 from exo.master.placement import place_instance as get_instance_placements
 from exo.shared.apply import apply
@@ -1728,7 +1729,12 @@ class API:
                 for dl in node_downloads:
                     if isinstance(dl, DownloadCompleted):
                         downloaded_model_ids.add(dl.shard_metadata.model_card.model_id)
-            cards = [c for c in cards if c.model_id in downloaded_model_ids]
+            cards = [
+                c
+                for c in cards
+                if c.model_id in downloaded_model_ids
+                or resolve_existing_model(c.model_id, c) is not None
+            ]
 
         return ModelList(
             data=[

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -1535,6 +1535,7 @@ class API:
                         command.command_id,
                         payload.model,
                         self._token_chunk_stream(command.command_id),
+                        reasoning=payload.reasoning,
                     ),
                 ),
                 media_type="text/event-stream",
@@ -1551,6 +1552,7 @@ class API:
                     command.command_id,
                     payload.model,
                     self._token_chunk_stream(command.command_id),
+                    reasoning=payload.reasoning,
                 ),
                 media_type="application/json",
             )

--- a/src/exo/api/types/openai_responses.py
+++ b/src/exo/api/types/openai_responses.py
@@ -440,6 +440,7 @@ class ResponsesResponse(BaseModel, frozen=True):
     output: list[ResponseItem]
     output_text: str
     usage: ResponseUsage | None = None
+    reasoning: Reasoning | None = None
 
 
 # Streaming event types

--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -66,7 +66,7 @@ async def _load_cards_from_dir(directory: Path, *, is_custom: bool) -> None:
             card = await ModelCard.load_from_path(toml_file)
             if is_custom:
                 card = card.model_copy(update={"is_custom": True})
-            if card.model_id not in _card_cache:
+            if is_custom or card.model_id not in _card_cache:
                 _card_cache[card.model_id] = card
         except (ValidationError, TOMLKitError):
             pass
@@ -75,6 +75,10 @@ async def _load_cards_from_dir(directory: Path, *, is_custom: bool) -> None:
 async def _refresh_card_cache() -> None:
     for path in _BUILTIN_CARD_DIRS:
         await _load_cards_from_dir(path, is_custom=False)
+    await _load_cards_from_dir(_custom_cards_dir, is_custom=True)
+
+
+async def _refresh_custom_card_cache() -> None:
     await _load_cards_from_dir(_custom_cards_dir, is_custom=True)
 
 
@@ -90,6 +94,8 @@ def get_card(model_id: ModelId) -> "ModelCard | None":
 async def get_model_cards() -> list["ModelCard"]:
     if len(_card_cache) == 0:
         await _refresh_card_cache()
+    else:
+        await _refresh_custom_card_cache()
     if EXO_ENABLE_IMAGE_MODELS:
         return list(_card_cache.values())
     return [c for c in _card_cache.values() if not _is_image_card(c)]

--- a/src/exo/shared/tests/test_model_cards.py
+++ b/src/exo/shared/tests/test_model_cards.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from anyio import Path as AsyncPath
+import pytest
+
+from exo.shared.models import model_cards
+from exo.shared.models.model_cards import ModelCard, ModelId, get_model_cards
+
+
+@pytest.mark.asyncio
+async def test_gpt_oss_cards_advertise_tools() -> None:
+    cards = {card.model_id: card for card in await get_model_cards()}
+
+    for model_id in (
+        ModelId("mlx-community/gpt-oss-120b-MXFP4-Q8"),
+        ModelId("mlx-community/gpt-oss-20b-MXFP4-Q8"),
+    ):
+        assert model_id in cards
+        assert "tools" in cards[model_id].capabilities
+
+
+@pytest.mark.asyncio
+async def test_custom_cards_override_cached_builtin_cards(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    builtin_dir = tmp_path / "builtin"
+    custom_dir = tmp_path / "custom"
+    builtin_dir.mkdir()
+    custom_dir.mkdir()
+
+    card = """\
+model_id = "test/model"
+n_layers = 1
+hidden_size = 1
+supports_tensor = false
+tasks = ["TextGeneration"]
+capabilities = {capabilities}
+
+[storage_size]
+in_bytes = 1
+"""
+    (builtin_dir / "test--model.toml").write_text(
+        card.format(capabilities='["text"]')
+    )
+    (custom_dir / "test--model.toml").write_text(
+        card.format(capabilities='["text", "tools"]')
+    )
+
+    monkeypatch.setattr(model_cards, "_BUILTIN_CARD_DIRS", [AsyncPath(builtin_dir)])
+    monkeypatch.setattr(model_cards, "_custom_cards_dir", AsyncPath(custom_dir))
+    monkeypatch.setattr(model_cards, "_card_cache", {})
+
+    loaded = {card.model_id: card for card in await get_model_cards()}
+
+    assert loaded[ModelId("test/model")].capabilities == ["text", "tools"]
+    assert loaded[ModelId("test/model")].is_custom is True

--- a/src/exo/shared/tests/test_model_cards.py
+++ b/src/exo/shared/tests/test_model_cards.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
-from anyio import Path as AsyncPath
 import pytest
+from anyio import Path as AsyncPath
 
 from exo.shared.models import model_cards
-from exo.shared.models.model_cards import ModelCard, ModelId, get_model_cards
+from exo.shared.models.model_cards import ModelId, get_model_cards
 
 
 @pytest.mark.asyncio
@@ -39,9 +39,7 @@ capabilities = {capabilities}
 [storage_size]
 in_bytes = 1
 """
-    (builtin_dir / "test--model.toml").write_text(
-        card.format(capabilities='["text"]')
-    )
+    (builtin_dir / "test--model.toml").write_text(card.format(capabilities='["text"]'))
     (custom_dir / "test--model.toml").write_text(
         card.format(capabilities='["text", "tools"]')
     )

--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -405,16 +405,22 @@ class BatchGenerator(Engine):
         if not self._queue:
             self.agree_on_tasks()
 
+        output: list[
+            tuple[TaskId, GenerationChunk | CancelledResponse | FinishedResponse]
+        ] = []
+
         # Submit any queued tasks to the engine
         while self._queue and len(self._active_tasks) < EXO_MAX_CONCURRENT_REQUESTS:
             task = self._queue.popleft()
             try:
-                uid = self._start_task(task)
+                prompt = apply_chat_template(self.tokenizer, task.task_params)
+                uid = self._start_task(task, prompt)
             except PrefillCancelled:
                 continue
             except Exception as e:
                 self._send_error(task, e)
-                raise
+                output.append((task.task_id, FinishedResponse()))
+                continue
 
             queue = GeneratorQueue[GenerationResponse]()
             if task.task_params.bench:
@@ -424,7 +430,7 @@ class BatchGenerator(Engine):
             else:
                 output_generator = apply_all_parsers(
                     queue.gen(),
-                    apply_chat_template(self.tokenizer, task.task_params),
+                    prompt,
                     self.tool_parser,
                     self.tokenizer,
                     type(self.model),
@@ -434,13 +440,9 @@ class BatchGenerator(Engine):
             self._active_tasks[uid] = (task, queue, output_generator)
 
         if not self._gen.has_work:
-            return self._apply_cancellations()
+            return itertools.chain(output, self._apply_cancellations())
 
         results = self._gen.step()
-
-        output: list[
-            tuple[TaskId, GenerationChunk | CancelledResponse | FinishedResponse]
-        ] = []
         for uid, response in results:
             if uid not in self._active_tasks:
                 # should we error here?
@@ -506,9 +508,8 @@ class BatchGenerator(Engine):
                 )
             )
 
-    def _start_task(self, task: TextGeneration) -> int:
+    def _start_task(self, task: TextGeneration, prompt: str) -> int:
         _check_for_debug_prompts(task.task_params)
-        prompt = apply_chat_template(self.tokenizer, task.task_params)
 
         def on_prefill_progress(processed: int, total: int) -> None:
             if self.device_rank == 0:

--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -217,7 +217,7 @@ def parse_gpt_oss(
                 tool_arg_parts = []
             continue
 
-        if delta:
+        if delta and ch != "commentary":
             yield response.model_copy(
                 update={"text": delta, "is_thinking": ch == "analysis"}
             )

--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -29,7 +29,10 @@ from exo.worker.engines.mlx.utils_mlx import (
 )
 from exo.worker.engines.mlx.vendor.dsml_encoding import parse_dsml_output
 from exo.worker.runner.bootstrap import logger
-from exo.worker.runner.llm_inference.tool_parsers import ToolParser
+from exo.worker.runner.llm_inference.tool_parsers import (
+    ToolParser,
+    _coerce_tool_calls_to_schema,  # pyright: ignore[reportPrivateUsage]
+)
 
 
 @cache
@@ -77,7 +80,7 @@ def apply_all_parsers(
 
     normalized_id = model_id.normalize().lower()
     if issubclass(model_type, GptOssModel):
-        generator = parse_gpt_oss(generator)
+        generator = parse_gpt_oss(generator, tools)
     elif issubclass(model_type, DeepseekV32Model) and "deepseek" in normalized_id:
         if tokenizer.has_thinking:
             generator = parse_thinking_models(
@@ -154,6 +157,7 @@ def map_responses_to_chunks(
 
 def parse_gpt_oss(
     responses: Generator[GenerationResponse | None],
+    tools: list[dict[str, Any]] | None = None,
 ) -> Generator[GenerationResponse | ToolCallResponse | None]:
     encoding = get_gpt_oss_encoding()
     stream = StreamableParser(encoding, role=Role.ASSISTANT)
@@ -189,13 +193,16 @@ def parse_gpt_oss(
                 logger.info(
                     f"parse_gpt_oss yielding tool call: name={current_tool_name!r}"
                 )
+                tool_calls = [
+                    ToolCallItem(
+                        name=current_tool_name,
+                        arguments="".join(tool_arg_parts).strip(),
+                    )
+                ]
+                if tools is not None:
+                    tool_calls = _coerce_tool_calls_to_schema(tool_calls, tools)
                 yield ToolCallResponse(
-                    tool_calls=[
-                        ToolCallItem(
-                            name=current_tool_name,
-                            arguments="".join(tool_arg_parts).strip(),
-                        )
-                    ],
+                    tool_calls=tool_calls,
                     usage=response.usage,
                 )
                 tool_arg_parts = []

--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -31,7 +31,7 @@ from exo.worker.engines.mlx.vendor.dsml_encoding import parse_dsml_output
 from exo.worker.runner.bootstrap import logger
 from exo.worker.runner.llm_inference.tool_parsers import (
     ToolParser,
-    _coerce_tool_calls_to_schema,  # pyright: ignore[reportPrivateUsage]
+    coerce_tool_calls_to_schema,
 )
 
 
@@ -200,7 +200,7 @@ def parse_gpt_oss(
                     )
                 ]
                 if tools is not None:
-                    tool_calls = _coerce_tool_calls_to_schema(tool_calls, tools)
+                    tool_calls = coerce_tool_calls_to_schema(tool_calls, tools)
                 yield ToolCallResponse(
                     tool_calls=tool_calls,
                     usage=response.usage,

--- a/src/exo/worker/runner/llm_inference/tool_parsers.py
+++ b/src/exo/worker/runner/llm_inference/tool_parsers.py
@@ -139,6 +139,84 @@ def _coerce_tool_arg_with_schema(value: Any, schema: dict[str, Any]) -> Any:  # 
     return value  # pyright: ignore[reportAny]
 
 
+def _normalise_apply_patch_input(input_value: Any) -> Any:  # pyright: ignore[reportAny]
+    if not isinstance(input_value, str):
+        return input_value
+
+    patch = input_value.strip()
+    if patch.startswith("```"):
+        lines = patch.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        patch = "\n".join(lines).strip()
+
+    end_marker = "*** End Patch"
+    lines = patch.splitlines()
+    while (
+        len(lines) >= 2
+        and lines[-1].strip() == end_marker
+        and lines[-2].strip() == end_marker
+    ):
+        lines.pop()
+
+    normalised_lines: list[str] = []
+    in_add_file = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("*** Add File: "):
+            in_add_file = True
+            normalised_lines.append(line)
+            continue
+        if stripped.startswith("*** "):
+            in_add_file = False
+            normalised_lines.append(line)
+            continue
+        if in_add_file and not line.startswith("+"):
+            normalised_lines.append(f"+{line}")
+            continue
+        normalised_lines.append(line)
+    lines = normalised_lines
+
+    if lines and lines[-1].strip() == end_marker:
+        return "\n".join(lines)
+    return patch
+
+
+def _coerce_freeform_input_arg(
+    tool_name: str, parsed_args: dict[str, Any], schema: dict[str, Any]
+) -> dict[str, Any]:
+    properties = schema.get("properties")
+    required = schema.get("required")
+    if not isinstance(properties, dict) or "input" not in properties:
+        return parsed_args
+    if not isinstance(required, list) or "input" not in required:
+        return parsed_args
+    if "input" in parsed_args:
+        if tool_name == "apply_patch":
+            return {
+                **parsed_args,
+                "input": _normalise_apply_patch_input(parsed_args["input"]),
+            }
+        return parsed_args
+
+    # Local tool-call models often infer a semantically named argument such as
+    # "patch" for apply_patch even though Codex's freeform tool contract wants
+    # the complete payload in "input". Preserve exactly one supplied payload.
+    if len(parsed_args) == 1:
+        input_value = next(iter(parsed_args.values()))
+        if tool_name == "apply_patch":
+            input_value = _normalise_apply_patch_input(input_value)
+        return {"input": input_value}
+    if "patch" in parsed_args:
+        input_value = parsed_args["patch"]
+        if tool_name == "apply_patch":
+            input_value = _normalise_apply_patch_input(input_value)
+        return {"input": input_value}
+    return parsed_args
+
+
 def _coerce_tool_calls_to_schema(
     tool_calls: list[ToolCallItem], tools: list[dict[str, Any]]
 ) -> list[ToolCallItem]:
@@ -172,6 +250,7 @@ def _coerce_tool_calls_to_schema(
             coerced_calls.append(tool_call)
             continue
 
+        parsed_args = _coerce_freeform_input_arg(tool_call.name, parsed_args, schema)
         coerced_args = _coerce_tool_arg_with_schema(parsed_args, schema)  # pyright: ignore[reportAny]
         if not isinstance(coerced_args, dict):
             coerced_calls.append(tool_call)

--- a/src/exo/worker/runner/llm_inference/tool_parsers.py
+++ b/src/exo/worker/runner/llm_inference/tool_parsers.py
@@ -1,7 +1,7 @@
 import json
 import math
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from exo.api.types import ToolCallItem
 
@@ -19,7 +19,7 @@ class ToolParser:
         if parsed is None:
             return None
         if tools is not None:
-            parsed = _coerce_tool_calls_to_schema(parsed, tools)
+            parsed = coerce_tool_calls_to_schema(parsed, tools)
         return parsed
 
 
@@ -141,7 +141,7 @@ def _coerce_tool_arg_with_schema(value: Any, schema: dict[str, Any]) -> Any:  # 
 
 def _normalise_apply_patch_input(input_value: Any) -> Any:  # pyright: ignore[reportAny]
     if not isinstance(input_value, str):
-        return input_value
+        return input_value  # pyright: ignore[reportAny]
 
     patch = input_value.strip()
     if patch.startswith("```"):
@@ -205,19 +205,19 @@ def _coerce_freeform_input_arg(
     # "patch" for apply_patch even though Codex's freeform tool contract wants
     # the complete payload in "input". Preserve exactly one supplied payload.
     if len(parsed_args) == 1:
-        input_value = next(iter(parsed_args.values()))
+        input_value: Any = next(iter(parsed_args.values()))  # pyright: ignore[reportAny]
         if tool_name == "apply_patch":
-            input_value = _normalise_apply_patch_input(input_value)
+            input_value = _normalise_apply_patch_input(input_value)  # pyright: ignore[reportAny]
         return {"input": input_value}
     if "patch" in parsed_args:
-        input_value = parsed_args["patch"]
+        input_value = parsed_args["patch"]  # pyright: ignore[reportAny]
         if tool_name == "apply_patch":
-            input_value = _normalise_apply_patch_input(input_value)
+            input_value = _normalise_apply_patch_input(input_value)  # pyright: ignore[reportAny]
         return {"input": input_value}
     return parsed_args
 
 
-def _coerce_tool_calls_to_schema(
+def coerce_tool_calls_to_schema(
     tool_calls: list[ToolCallItem], tools: list[dict[str, Any]]
 ) -> list[ToolCallItem]:
     schema_by_name: dict[str, dict[str, Any]] = {}
@@ -250,7 +250,11 @@ def _coerce_tool_calls_to_schema(
             coerced_calls.append(tool_call)
             continue
 
-        parsed_args = _coerce_freeform_input_arg(tool_call.name, parsed_args, schema)
+        # json.loads narrows to dict[Unknown, Unknown] after isinstance; we treat
+        # JSON object payloads as dict[str, Any] by contract.
+        parsed_args = _coerce_freeform_input_arg(
+            tool_call.name, cast(dict[str, Any], parsed_args), schema
+        )
         coerced_args = _coerce_tool_arg_with_schema(parsed_args, schema)  # pyright: ignore[reportAny]
         if not isinstance(coerced_args, dict):
             coerced_calls.append(tool_call)

--- a/src/exo/worker/tests/unittests/test_runner/test_batch_generator_errors.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_batch_generator_errors.py
@@ -1,0 +1,76 @@
+from collections import deque
+
+from exo.shared.types.chunks import ErrorChunk
+from exo.shared.types.common import CommandId, ModelId
+from exo.shared.types.events import ChunkGenerated
+from exo.shared.types.tasks import TextGeneration
+from exo.shared.types.text_generation import (
+    InputMessage,
+    InputMessageContent,
+    TextGenerationTaskParams,
+)
+from exo.shared.types.worker.instances import InstanceId
+from exo.worker.runner.llm_inference import batch_generator as batch_generator_module
+from exo.worker.runner.llm_inference.batch_generator import BatchGenerator, Finished
+
+
+class _FakeBatchEngine:
+    has_work = False
+
+
+class _FakeEventSender:
+    def __init__(self) -> None:
+        self.events = []
+
+    def send(self, event) -> None:
+        self.events.append(event)
+
+
+def test_batch_generator_finishes_task_when_prompt_template_fails(
+    monkeypatch,
+) -> None:
+    sender = _FakeEventSender()
+    model_id = ModelId("mlx-community/gpt-oss-120b-MXFP4-Q8")
+    task = TextGeneration(
+        instance_id=InstanceId("instance"),
+        command_id=CommandId("command"),
+        task_params=TextGenerationTaskParams(
+            model=model_id,
+            input=[
+                InputMessage(
+                    role="user",
+                    content=InputMessageContent("hello"),
+                )
+            ],
+        ),
+    )
+
+    generator = object.__new__(BatchGenerator)
+    generator.model_id = model_id
+    generator.device_rank = 0
+    generator.tokenizer = object()
+    generator.event_sender = sender
+    generator._queue = deque([task])
+    generator._active_tasks = {}
+    generator._cancelled_tasks = set()
+    generator._mlx_gen = _FakeBatchEngine()
+
+    def fail_template(*_args, **_kwargs):
+        raise ValueError("bad tool history")
+
+    monkeypatch.setattr(
+        batch_generator_module,
+        "apply_chat_template",
+        fail_template,
+    )
+
+    results = list(generator.step())
+
+    assert len(results) == 1
+    assert results[0][0] == task.task_id
+    assert isinstance(results[0][1], Finished)
+    assert generator._active_tasks == {}
+    assert len(sender.events) == 1
+    assert isinstance(sender.events[0], ChunkGenerated)
+    assert isinstance(sender.events[0].chunk, ErrorChunk)
+    assert sender.events[0].chunk.error_message == "bad tool history"

--- a/src/exo/worker/tests/unittests/test_runner/test_batch_generator_errors.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_batch_generator_errors.py
@@ -1,8 +1,11 @@
 from collections import deque
+from typing import Any, cast
+
+import pytest
 
 from exo.shared.types.chunks import ErrorChunk
 from exo.shared.types.common import CommandId, ModelId
-from exo.shared.types.events import ChunkGenerated
+from exo.shared.types.events import ChunkGenerated, Event
 from exo.shared.types.tasks import TextGeneration
 from exo.shared.types.text_generation import (
     InputMessage,
@@ -10,24 +13,27 @@ from exo.shared.types.text_generation import (
     TextGenerationTaskParams,
 )
 from exo.shared.types.worker.instances import InstanceId
+from exo.shared.types.worker.runner_response import FinishedResponse
+from exo.utils.channels import MpSender
+from exo.worker.engines.mlx.generator.batch_generate import ExoBatchGenerator
 from exo.worker.runner.llm_inference import batch_generator as batch_generator_module
-from exo.worker.runner.llm_inference.batch_generator import BatchGenerator, Finished
+from exo.worker.runner.llm_inference.batch_generator import BatchGenerator
 
 
 class _FakeBatchEngine:
-    has_work = False
+    has_work: bool = False
 
 
 class _FakeEventSender:
     def __init__(self) -> None:
-        self.events = []
+        self.events: list[Event] = []
 
-    def send(self, event) -> None:
+    def send(self, event: Event) -> None:
         self.events.append(event)
 
 
 def test_batch_generator_finishes_task_when_prompt_template_fails(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sender = _FakeEventSender()
     model_id = ModelId("mlx-community/gpt-oss-120b-MXFP4-Q8")
@@ -45,17 +51,21 @@ def test_batch_generator_finishes_task_when_prompt_template_fails(
         ),
     )
 
+    # We bypass the dataclass __init__ because constructing a real BatchGenerator
+    # requires a full inference engine, tokenizer, and MP queue stack. The test
+    # only exercises the prompt-templating error path inside step(), so we wire
+    # in fakes for just the attributes that path touches.
     generator = object.__new__(BatchGenerator)
     generator.model_id = model_id
     generator.device_rank = 0
-    generator.tokenizer = object()
-    generator.event_sender = sender
-    generator._queue = deque([task])
-    generator._active_tasks = {}
-    generator._cancelled_tasks = set()
-    generator._mlx_gen = _FakeBatchEngine()
+    generator.tokenizer = cast(Any, object())
+    generator.event_sender = cast(MpSender[Event], cast(object, sender))
+    generator._queue = deque([task])  # pyright: ignore[reportPrivateUsage]
+    generator._active_tasks = {}  # pyright: ignore[reportPrivateUsage]
+    generator._cancelled_tasks = set()  # pyright: ignore[reportPrivateUsage]
+    generator._gen = cast(ExoBatchGenerator, cast(object, _FakeBatchEngine()))  # pyright: ignore[reportPrivateUsage]
 
-    def fail_template(*_args, **_kwargs):
+    def fail_template(*_args: object, **_kwargs: object) -> None:
         raise ValueError("bad tool history")
 
     monkeypatch.setattr(
@@ -68,8 +78,8 @@ def test_batch_generator_finishes_task_when_prompt_template_fails(
 
     assert len(results) == 1
     assert results[0][0] == task.task_id
-    assert isinstance(results[0][1], Finished)
-    assert generator._active_tasks == {}
+    assert isinstance(results[0][1], FinishedResponse)
+    assert generator._active_tasks == {}  # pyright: ignore[reportPrivateUsage]
     assert len(sender.events) == 1
     assert isinstance(sender.events[0], ChunkGenerated)
     assert isinstance(sender.events[0].chunk, ErrorChunk)

--- a/src/exo/worker/tests/unittests/test_runner/test_parse_gpt_oss.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_parse_gpt_oss.py
@@ -23,6 +23,7 @@ _MESSAGE = 200008  # <|message|>
 _CALL = 200012  # <|call|>
 _END = 200007  # <|end|>
 _ASSISTANT = 173781  # "assistant"
+_FINAL = 17196  # "final"
 
 # fmt: off
 # " to=functions.get_current_weather<|channel|>commentary json<|message|>{\"location\": \"Tokyo\"}<|call|>"
@@ -243,12 +244,25 @@ PLAIN_TEXT_TOKENS: list[tuple[int, str]] = [
     (_START, "<|start|>"),
     (_ASSISTANT, "assistant"),
     (_CHANNEL, "<|channel|>"),
-    (12606,  "comment"),
-    (815,    "ary"),
+    (_FINAL, "final"),
     (_MESSAGE, "<|message|>"),
-    (9906,   "Hello"),
-    (14,     ","),
-    (2989,   " world"),
+    (13225,  "Hello"),
+    (11,     ","),
+    (2375,   " world"),
+]
+
+COMMENTARY_TEXT_THEN_TOOL_TOKENS: list[tuple[int, str]] = [
+    (_CHANNEL, "<|channel|>"),
+    (12606, "comment"),
+    (815, "ary"),
+    (_MESSAGE, "<|message|>"),
+    (13225, "Hello"),
+    (11, ","),
+    (2375, " world"),
+    (_END, "<|end|>"),
+    (_START, "<|start|>"),
+    (_ASSISTANT, "assistant"),
+    *FORMAT_B_TOKENS,
 ]
 # fmt: on
 
@@ -281,6 +295,32 @@ class TestParseGptOssMaxTokensTruncation:
         # due to Harmony encoding, so we just check something was emitted)
         all_text = "".join(r.text for r in gen_responses)
         assert len(all_text) > 0
+
+
+class TestParseGptOssHarmonyChannels:
+    """Harmony channels should map to Codex output types directly."""
+
+    def test_final_channel_streams_visible_text(self):
+        results = _collect(PLAIN_TEXT_TOKENS)
+
+        visible_text = "".join(
+            r.text
+            for r in results
+            if isinstance(r, GenerationResponse) and not r.is_thinking
+        )
+
+        assert "Hello, world" in visible_text
+
+    def test_standalone_commentary_before_tool_call_is_suppressed(self):
+        results = _collect(COMMENTARY_TEXT_THEN_TOOL_TOKENS)
+
+        visible_text = "".join(
+            r.text for r in results if isinstance(r, GenerationResponse)
+        )
+        assert "Hello, world" not in visible_text
+
+        tc = _get_tool_call(results)
+        assert tc.tool_calls[0].name == "get_current_weather"
 
 
 class TestGptOssReasoningTokensCounted:

--- a/src/exo/worker/tests/unittests/test_runner/test_parse_gpt_oss.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_parse_gpt_oss.py
@@ -113,13 +113,14 @@ def _make_gen_responses(
 def _collect(
     tokens: list[tuple[int, str]],
     last_finish_reason: FinishReason = "stop",
+    tools: list[dict] | None = None,
 ) -> list[GenerationResponse | ToolCallResponse]:
     """Feed tokens through parse_gpt_oss and collect all yielded responses."""
 
     def _gen() -> Generator[GenerationResponse, None, None]:
         yield from _make_gen_responses(tokens, last_finish_reason)
 
-    return list(x for x in parse_gpt_oss(_gen()) if x is not None)
+    return list(x for x in parse_gpt_oss(_gen(), tools=tools) if x is not None)
 
 
 def _get_tool_call(
@@ -153,6 +154,26 @@ class TestParseGptOssRecipientPlacement:
         tc_b = _get_tool_call(_collect(FORMAT_B_TOKENS))
         assert tc_a.tool_calls[0].name == tc_b.tool_calls[0].name
         assert tc_a.tool_calls[0].arguments == tc_b.tool_calls[0].arguments
+
+    def test_gpt_oss_tool_calls_are_coerced_to_schema(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_current_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"input": {"type": "string"}},
+                        "required": ["input"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
+        ]
+
+        tc = _get_tool_call(_collect(FORMAT_B_TOKENS, tools=tools))
+
+        assert tc.tool_calls[0].arguments == '{"input": "Tokyo"}'
 
 
 class TestParseGptOssThinkingThenToolCall:

--- a/src/exo/worker/tests/unittests/test_runner/test_parse_gpt_oss.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_parse_gpt_oss.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from typing import Any
 
 from exo.api.types import (
     CompletionTokensDetails,
@@ -114,7 +115,7 @@ def _make_gen_responses(
 def _collect(
     tokens: list[tuple[int, str]],
     last_finish_reason: FinishReason = "stop",
-    tools: list[dict] | None = None,
+    tools: list[dict[str, Any]] | None = None,
 ) -> list[GenerationResponse | ToolCallResponse]:
     """Feed tokens through parse_gpt_oss and collect all yielded responses."""
 

--- a/src/exo/worker/tests/unittests/test_runner/test_responses_tool_compat.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_responses_tool_compat.py
@@ -1,0 +1,291 @@
+import json
+
+import pytest
+
+from exo.api.adapters.responses import (
+    collect_responses_response,
+    generate_responses_stream,
+    responses_request_to_text_generation,
+)
+from exo.api.types import ToolCallItem
+from exo.api.types.openai_responses import (
+    ApplyPatchCallInputItem,
+    FunctionCallInputItem,
+    FunctionCallOutputInputItem,
+    ReasoningInputItem,
+    ResponsesRequest,
+)
+from exo.worker.runner.llm_inference.tool_parsers import _coerce_tool_calls_to_schema
+from exo.shared.types.chunks import TokenChunk, ToolCallChunk
+
+
+@pytest.mark.asyncio
+async def test_custom_responses_tool_gets_freeform_input_schema():
+    request = ResponsesRequest(
+        model="test-model",
+        input="edit a file",
+        tools=[
+            {
+                "type": "custom",
+                "name": "apply_patch",
+                "description": "Apply a patch",
+                "format": {"type": "grammar", "description": "Patch text"},
+            }
+        ],
+    )
+
+    params = await responses_request_to_text_generation(request)
+
+    assert params.tools is not None
+    function = params.tools[0]["function"]
+    assert function["name"] == "apply_patch"
+    assert function["parameters"]["required"] == ["input"]
+    assert function["parameters"]["properties"]["input"]["type"] == "string"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_replay_uses_codex_input_argument():
+    request = ResponsesRequest(
+        model="test-model",
+        input=[
+            ApplyPatchCallInputItem(
+                call_id="call_1",
+                patch="*** Begin Patch\n*** End Patch",
+            )
+        ],
+    )
+
+    params = await responses_request_to_text_generation(request)
+
+    assert params.chat_template_messages is not None
+    tool_call = params.chat_template_messages[0]["tool_calls"][0]
+    assert json.loads(tool_call["function"]["arguments"]) == {
+        "input": "*** Begin Patch\n*** End Patch"
+    }
+
+
+def test_freeform_tool_args_are_coerced_to_input():
+    tool_calls = [
+        ToolCallItem(
+            id="call_1",
+            name="apply_patch",
+            arguments=json.dumps({"patch": "*** Begin Patch\n*** End Patch"}),
+        )
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "apply_patch",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"input": {"type": "string"}},
+                    "required": ["input"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+
+    coerced = _coerce_tool_calls_to_schema(tool_calls, tools)
+
+    assert json.loads(coerced[0].arguments) == {
+        "input": "*** Begin Patch\n*** End Patch"
+    }
+
+
+def test_apply_patch_input_drops_duplicate_end_marker():
+    tool_calls = [
+        ToolCallItem(
+            id="call_1",
+            name="apply_patch",
+            arguments=json.dumps(
+                {
+                    "input": "\n".join(
+                        [
+                            "*** Begin Patch",
+                            "*** Add File: hello.txt",
+                            "+hello",
+                            "*** End Patch",
+                            "*** End Patch",
+                        ]
+                    )
+                }
+            ),
+        )
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "apply_patch",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"input": {"type": "string"}},
+                    "required": ["input"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+
+    coerced = _coerce_tool_calls_to_schema(tool_calls, tools)
+
+    assert json.loads(coerced[0].arguments) == {
+        "input": "\n".join(
+            [
+                "*** Begin Patch",
+                "*** Add File: hello.txt",
+                "+hello",
+                "*** End Patch",
+            ]
+        )
+    }
+
+
+def test_apply_patch_add_file_prefixes_content_lines():
+    tool_calls = [
+        ToolCallItem(
+            id="call_1",
+            name="apply_patch",
+            arguments=json.dumps(
+                {
+                    "input": "\n".join(
+                        [
+                            "*** Begin Patch",
+                            "*** Add File: hello.txt",
+                            "hello",
+                            "*** End Patch",
+                        ]
+                    )
+                }
+            ),
+        )
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "apply_patch",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"input": {"type": "string"}},
+                    "required": ["input"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+
+    coerced = _coerce_tool_calls_to_schema(tool_calls, tools)
+
+    assert json.loads(coerced[0].arguments) == {
+        "input": "\n".join(
+            [
+                "*** Begin Patch",
+                "*** Add File: hello.txt",
+                "+hello",
+                "*** End Patch",
+            ]
+        )
+    }
+
+
+@pytest.mark.asyncio
+async def test_reasoning_replay_does_not_split_tool_call_and_output():
+    request = ResponsesRequest(
+        model="test-model",
+        input=[
+            FunctionCallInputItem(
+                call_id="call_1",
+                name="exec_command",
+                arguments=json.dumps({"cmd": "printf ok"}),
+            ),
+            ReasoningInputItem(summary=[{"text": "thinking"}]),
+            FunctionCallOutputInputItem(call_id="call_1", output="ok"),
+        ],
+    )
+
+    params = await responses_request_to_text_generation(request)
+
+    assert params.chat_template_messages == [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "exec_command",
+                        "arguments": json.dumps({"cmd": "printf ok"}),
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tool_call_response_omits_pre_tool_message():
+    async def chunks():
+        yield TokenChunk(
+            model="test-model",
+            text="Creating hello.txt",
+            token_id=1,
+            usage=None,
+        )
+        yield ToolCallChunk(
+            model="test-model",
+            tool_calls=[
+                ToolCallItem(
+                    id="call_1",
+                    name="apply_patch",
+                    arguments=json.dumps({"input": "*** Begin Patch\n*** End Patch"}),
+                )
+            ],
+            usage=None,
+        )
+
+    responses = [
+        json.loads(chunk)
+        async for chunk in collect_responses_response("cmd_1", "test-model", chunks())
+    ]
+
+    output = responses[0]["output"]
+    assert [item["type"] for item in output] == ["function_call"]
+    assert responses[0]["output_text"] == "Creating hello.txt"
+
+
+@pytest.mark.asyncio
+async def test_streaming_tool_call_response_buffers_pre_tool_text():
+    async def chunks():
+        yield TokenChunk(
+            model="test-model",
+            text="Creating hello.txt",
+            token_id=1,
+            usage=None,
+        )
+        yield ToolCallChunk(
+            model="test-model",
+            tool_calls=[
+                ToolCallItem(
+                    id="call_1",
+                    name="apply_patch",
+                    arguments=json.dumps({"input": "*** Begin Patch\n*** End Patch"}),
+                )
+            ],
+            usage=None,
+        )
+
+    events = [
+        event
+        async for event in generate_responses_stream("cmd_1", "test-model", chunks())
+    ]
+
+    assert "response.output_text.delta" not in "".join(events)
+    completed = json.loads(events[-1].split("data: ", 1)[1])
+    output = completed["response"]["output"]
+    assert [item["type"] for item in output] == ["function_call"]
+    assert completed["response"]["output_text"] == "Creating hello.txt"

--- a/src/exo/worker/tests/unittests/test_runner/test_responses_tool_compat.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_responses_tool_compat.py
@@ -259,7 +259,7 @@ async def test_tool_call_response_omits_pre_tool_message():
 
 
 @pytest.mark.asyncio
-async def test_streaming_tool_call_response_buffers_pre_tool_text():
+async def test_streaming_text_deltas_are_not_buffered():
     async def chunks():
         yield TokenChunk(
             model="test-model",
@@ -284,7 +284,7 @@ async def test_streaming_tool_call_response_buffers_pre_tool_text():
         async for event in generate_responses_stream("cmd_1", "test-model", chunks())
     ]
 
-    assert "response.output_text.delta" not in "".join(events)
+    assert "response.output_text.delta" in "".join(events)
     completed = json.loads(events[-1].split("data: ", 1)[1])
     output = completed["response"]["output"]
     assert [item["type"] for item in output] == ["function_call"]

--- a/src/exo/worker/tests/unittests/test_runner/test_responses_tool_compat.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_responses_tool_compat.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any, cast
 
 import pytest
 
@@ -15,14 +16,18 @@ from exo.api.types.openai_responses import (
     ReasoningInputItem,
     ResponsesRequest,
 )
-from exo.worker.runner.llm_inference.tool_parsers import _coerce_tool_calls_to_schema
 from exo.shared.types.chunks import TokenChunk, ToolCallChunk
+from exo.shared.types.common import CommandId, ModelId
+from exo.worker.runner.llm_inference.tool_parsers import coerce_tool_calls_to_schema
+
+_TEST_MODEL = ModelId("test-model")
+_TEST_COMMAND_ID = CommandId("cmd_1")
 
 
 @pytest.mark.asyncio
-async def test_custom_responses_tool_gets_freeform_input_schema():
+async def test_custom_responses_tool_gets_freeform_input_schema() -> None:
     request = ResponsesRequest(
-        model="test-model",
+        model=_TEST_MODEL,
         input="edit a file",
         tools=[
             {
@@ -37,16 +42,16 @@ async def test_custom_responses_tool_gets_freeform_input_schema():
     params = await responses_request_to_text_generation(request)
 
     assert params.tools is not None
-    function = params.tools[0]["function"]
+    function = cast(dict[str, Any], params.tools[0]["function"])
     assert function["name"] == "apply_patch"
     assert function["parameters"]["required"] == ["input"]
     assert function["parameters"]["properties"]["input"]["type"] == "string"
 
 
 @pytest.mark.asyncio
-async def test_apply_patch_replay_uses_codex_input_argument():
+async def test_apply_patch_replay_uses_codex_input_argument() -> None:
     request = ResponsesRequest(
-        model="test-model",
+        model=_TEST_MODEL,
         input=[
             ApplyPatchCallInputItem(
                 call_id="call_1",
@@ -58,13 +63,16 @@ async def test_apply_patch_replay_uses_codex_input_argument():
     params = await responses_request_to_text_generation(request)
 
     assert params.chat_template_messages is not None
-    tool_call = params.chat_template_messages[0]["tool_calls"][0]
-    assert json.loads(tool_call["function"]["arguments"]) == {
+    # chat_template_messages is typed loosely as a list of dicts of mixed
+    # values; coerce the navigation through the assistant tool_calls payload.
+    first_message = cast(dict[str, Any], params.chat_template_messages[0])
+    tool_call = cast(dict[str, Any], first_message["tool_calls"][0])
+    assert json.loads(cast(str, tool_call["function"]["arguments"])) == {
         "input": "*** Begin Patch\n*** End Patch"
     }
 
 
-def test_freeform_tool_args_are_coerced_to_input():
+def test_freeform_tool_args_are_coerced_to_input() -> None:
     tool_calls = [
         ToolCallItem(
             id="call_1",
@@ -72,7 +80,7 @@ def test_freeform_tool_args_are_coerced_to_input():
             arguments=json.dumps({"patch": "*** Begin Patch\n*** End Patch"}),
         )
     ]
-    tools = [
+    tools: list[dict[str, Any]] = [
         {
             "type": "function",
             "function": {
@@ -87,14 +95,14 @@ def test_freeform_tool_args_are_coerced_to_input():
         }
     ]
 
-    coerced = _coerce_tool_calls_to_schema(tool_calls, tools)
+    coerced = coerce_tool_calls_to_schema(tool_calls, tools)
 
     assert json.loads(coerced[0].arguments) == {
         "input": "*** Begin Patch\n*** End Patch"
     }
 
 
-def test_apply_patch_input_drops_duplicate_end_marker():
+def test_apply_patch_input_drops_duplicate_end_marker() -> None:
     tool_calls = [
         ToolCallItem(
             id="call_1",
@@ -114,7 +122,7 @@ def test_apply_patch_input_drops_duplicate_end_marker():
             ),
         )
     ]
-    tools = [
+    tools: list[dict[str, Any]] = [
         {
             "type": "function",
             "function": {
@@ -129,7 +137,7 @@ def test_apply_patch_input_drops_duplicate_end_marker():
         }
     ]
 
-    coerced = _coerce_tool_calls_to_schema(tool_calls, tools)
+    coerced = coerce_tool_calls_to_schema(tool_calls, tools)
 
     assert json.loads(coerced[0].arguments) == {
         "input": "\n".join(
@@ -143,7 +151,7 @@ def test_apply_patch_input_drops_duplicate_end_marker():
     }
 
 
-def test_apply_patch_add_file_prefixes_content_lines():
+def test_apply_patch_add_file_prefixes_content_lines() -> None:
     tool_calls = [
         ToolCallItem(
             id="call_1",
@@ -162,7 +170,7 @@ def test_apply_patch_add_file_prefixes_content_lines():
             ),
         )
     ]
-    tools = [
+    tools: list[dict[str, Any]] = [
         {
             "type": "function",
             "function": {
@@ -177,7 +185,7 @@ def test_apply_patch_add_file_prefixes_content_lines():
         }
     ]
 
-    coerced = _coerce_tool_calls_to_schema(tool_calls, tools)
+    coerced = coerce_tool_calls_to_schema(tool_calls, tools)
 
     assert json.loads(coerced[0].arguments) == {
         "input": "\n".join(
@@ -192,9 +200,9 @@ def test_apply_patch_add_file_prefixes_content_lines():
 
 
 @pytest.mark.asyncio
-async def test_reasoning_replay_does_not_split_tool_call_and_output():
+async def test_reasoning_replay_does_not_split_tool_call_and_output() -> None:
     request = ResponsesRequest(
-        model="test-model",
+        model=_TEST_MODEL,
         input=[
             FunctionCallInputItem(
                 call_id="call_1",
@@ -228,16 +236,16 @@ async def test_reasoning_replay_does_not_split_tool_call_and_output():
 
 
 @pytest.mark.asyncio
-async def test_tool_call_response_omits_pre_tool_message():
+async def test_tool_call_response_omits_pre_tool_message() -> None:
     async def chunks():
         yield TokenChunk(
-            model="test-model",
+            model=_TEST_MODEL,
             text="Creating hello.txt",
             token_id=1,
             usage=None,
         )
         yield ToolCallChunk(
-            model="test-model",
+            model=_TEST_MODEL,
             tool_calls=[
                 ToolCallItem(
                     id="call_1",
@@ -250,25 +258,27 @@ async def test_tool_call_response_omits_pre_tool_message():
 
     responses = [
         json.loads(chunk)
-        async for chunk in collect_responses_response("cmd_1", "test-model", chunks())
+        async for chunk in collect_responses_response(
+            _TEST_COMMAND_ID, "test-model", chunks()
+        )
     ]
 
-    output = responses[0]["output"]
+    output = cast(list[dict[str, Any]], responses[0]["output"])
     assert [item["type"] for item in output] == ["function_call"]
     assert responses[0]["output_text"] == "Creating hello.txt"
 
 
 @pytest.mark.asyncio
-async def test_streaming_text_deltas_are_not_buffered():
+async def test_streaming_text_deltas_are_not_buffered() -> None:
     async def chunks():
         yield TokenChunk(
-            model="test-model",
+            model=_TEST_MODEL,
             text="Creating hello.txt",
             token_id=1,
             usage=None,
         )
         yield ToolCallChunk(
-            model="test-model",
+            model=_TEST_MODEL,
             tool_calls=[
                 ToolCallItem(
                     id="call_1",
@@ -281,11 +291,13 @@ async def test_streaming_text_deltas_are_not_buffered():
 
     events = [
         event
-        async for event in generate_responses_stream("cmd_1", "test-model", chunks())
+        async for event in generate_responses_stream(
+            _TEST_COMMAND_ID, "test-model", chunks()
+        )
     ]
 
     assert "response.output_text.delta" in "".join(events)
-    completed = json.loads(events[-1].split("data: ", 1)[1])
-    output = completed["response"]["output"]
+    completed = cast(dict[str, Any], json.loads(events[-1].split("data: ", 1)[1]))
+    output = cast(list[dict[str, Any]], completed["response"]["output"])
     assert [item["type"] for item in output] == ["function_call"]
     assert completed["response"]["output_text"] == "Creating hello.txt"


### PR DESCRIPTION
## Motivation

A multi-commit cleanup of GPT-OSS tool-calling on the Responses API. Running gpt-oss-120b/20b through OpenAI-compatible \`/v1/responses\` exposed several issues:

1. The model card didn't advertise \`tools\` capability, so the Responses adapter wouldn't surface tool calls back to the client.
2. The harmony parser was called without the request's \`tools\` list, which meant tool-call schemas couldn't be coerced to match the user's declared tool definitions.
3. Tool-call loops over Responses ran into a state where the same tool call was emitted repeatedly.
4. Reasoning config supplied on the request wasn't echoed in the response object the way OpenAI's spec calls for.
5. Symlinked-model handling for download/delete needed to recognize streamed availability cleanly.
6. Driving the count of inherited basedpyright errors on the GPT-OSS tool-support stack to zero.

## Changes

### \`worker/runner/llm_inference/batch_generator.py\` — early-return tool output preservation
- Hoist the per-step \`output\` list above the engine \`has_work\` early-return path so tasks that errored during prompt-template application aren't silently dropped.
- Use \`itertools.chain(output, self._apply_cancellations())\` for the no-work path so the error-finished records still propagate to the caller.

### \`worker/runner/llm_inference/model_output_parsers.py\` — pass tools into harmony parser
- Forward the request's \`tools\` list into \`parse_gpt_oss(generator, tools)\` so the harmony parser can coerce tool-call shapes to the user's declared schema.

### \`worker/runner/llm_inference/tool_parsers.py\` — public coerce helper
- Rename \`_coerce_tool_calls_to_schema\` → \`coerce_tool_calls_to_schema\` since it's intentionally re-used outside the module by \`model_output_parsers.py\` and the tests; the underscore prefix was misleading.

### \`api/adapters/responses.py\` — split chained isinstance + echo reasoning config
- Split \`isinstance(format_config.get(\"description\"), str)\` so the str narrow lands on a fresh local; coerce \`tool.get(\"name\", \"\")\` to \`str\` defensively.
- Rename inner \`output: list[ResponseItem]\` shadow to \`tool_only_output\` to drop \`reportRedeclaration\`.
- Echo reasoning config back in the Responses response object.

### Model cards
- \`mlx-community--gpt-oss-{120b,20b}-MXFP4-Q8.toml\`: add \`tools\` to the capabilities list (preserved alongside upstream's \`reasoning_dialect = \"channel\"\` addition).

### Symlinked model availability
- \`download/download_utils.py\`: refuse to delete symlink targets that don't look like model directories; add streaming availability hooks so the dashboard can show partially-downloaded models.

### Tests
- \`test_batch_generator_errors.py\`: cover the prompt-template error path through \`step()\`. Uses scoped \`# pyright: ignore[reportPrivateUsage]\` for legitimate internal-state setup.
- \`test_responses_tool_compat.py\`: factor \`_TEST_MODEL\` / \`_TEST_COMMAND_ID\` constants so tests stop passing bare strings into Pydantic \`NewType\`s. Switch to the renamed public \`coerce_tool_calls_to_schema\`.
- \`test_parse_gpt_oss.py\`: declare the \`tools\` fixture as \`list[dict[str, Any]] | None\` to match \`parse_gpt_oss\`'s signature.
- \`test_model_cards.py\`: assert that the gpt-oss model cards advertise \`tools\`.

## Why It Works

The root cause for (1)-(3) was an under-typed harmony parser surface: \`parse_gpt_oss\` was being called as if tools were optional and tool-call schemas were already correct, but the Responses spec requires us to coerce them against the user's declared shape. Threading \`tools\` through and renaming the coercion helper to a public name makes the surface honest. The \`output\`-list hoist in \`batch_generator.py\` is the smaller fix: error responses generated during template application were getting dropped because the \`has_work\` early-return short-circuited before they were yielded.

## Test Plan

### Automated Testing

- \`uv run basedpyright\`: 0 errors, 0 warnings, 0 notes.
- \`uv run ruff check\`: All checks passed.
- \`uv run ruff format\`: clean.
- \`uv run pytest src/exo/worker/runner/llm_inference/ src/exo/worker/tests/unittests/test_runner/ src/exo/shared/tests/test_model_cards.py\`: **92 passed in 9.99s**.

### Manual Testing

Hardware: 4-node Apple Silicon cluster, master M5 Max 128GB.

- Loaded \`mlx-community/gpt-oss-120b-MXFP4-Q8\`. Issued Responses API requests with custom apply-patch and function-call tools. Tool calls now arrive with schemas matching the declared \`format\`/\`parameters\` rather than raw strings.
- Reasoning config \`{ \"reasoning\": { \"effort\": \"high\" } }\` on the request is echoed in the response object.
- Triggered the prompt-template error path by sending malformed tool history: the response now finishes cleanly rather than hanging.

## Notes for reviewers

- Several conflicts during cherry-pick reflected upstream renames since these commits were authored in our fork: \`Cancelled\` → \`CancelledResponse\`, \`Finished\` → \`FinishedResponse\`, \`_mlx_gen\` → \`_gen\`. Resolutions are mechanical; happy to walk through any zone.
- The \`f394f23d chore: ruff cleanup\` commit was skipped — its mechanical formatting fixes are now subsumed by the final \`ruff format\` pass on the squashed work.