### PR TITLE
Add Gemma 4 drafter support: ModelCard.drafter_model_id + mlx_generate plumbing

### DIFF
--- a/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
@@ -8,6 +8,7 @@ family = "gemma"
 quantization = "4bit"
 base_model = "Gemma 4 26B A4B"
 capabilities = ["text", "vision"]
+drafter_model_id = "mlx-community/gemma-4-e2b-it-4bit"
 
 context_length = 262144
 

--- a/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-6bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-6bit.toml
@@ -8,6 +8,7 @@ family = "gemma"
 quantization = "6bit"
 base_model = "Gemma 4 26B A4B"
 capabilities = ["text", "vision"]
+drafter_model_id = "mlx-community/gemma-4-e2b-it-6bit"
 
 context_length = 262144
 

--- a/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-8bit.toml
@@ -8,6 +8,7 @@ family = "gemma"
 quantization = "8bit"
 base_model = "Gemma 4 26B A4B"
 capabilities = ["text", "vision"]
+drafter_model_id = "mlx-community/gemma-4-e2b-it-8bit"
 
 context_length = 262144
 

--- a/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-bf16.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-bf16.toml
@@ -8,6 +8,7 @@ family = "gemma"
 quantization = "bf16"
 base_model = "Gemma 4 26B A4B"
 capabilities = ["text", "vision"]
+drafter_model_id = "mlx-community/gemma-4-e2b-it-bf16"
 
 context_length = 262144
 

--- a/resources/inference_model_cards/mlx-community--gemma-4-31b-it-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-31b-it-4bit.toml
@@ -8,6 +8,7 @@ family = "gemma"
 quantization = "4bit"
 base_model = "Gemma 4 31B"
 capabilities = ["text", "vision"]
+drafter_model_id = "mlx-community/gemma-4-e2b-it-4bit"
 
 context_length = 262144
 

--- a/resources/inference_model_cards/mlx-community--gemma-4-31b-it-6bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-31b-it-6bit.toml
@@ -8,6 +8,7 @@ family = "gemma"
 quantization = "6bit"
 base_model = "Gemma 4 31B"
 capabilities = ["text", "vision"]
+drafter_model_id = "mlx-community/gemma-4-e2b-it-6bit"
 
 context_length = 262144
 

--- a/resources/inference_model_cards/mlx-community--gemma-4-31b-it-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-31b-it-8bit.toml
@@ -8,6 +8,7 @@ family = "gemma"
 quantization = "8bit"
 base_model = "Gemma 4 31B"
 capabilities = ["text", "vision"]
+drafter_model_id = "mlx-community/gemma-4-e2b-it-8bit"
 
 context_length = 262144
 

--- a/resources/inference_model_cards/mlx-community--gemma-4-31b-it-bf16.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-31b-it-bf16.toml
@@ -8,6 +8,7 @@ family = "gemma"
 quantization = "bf16"
 base_model = "Gemma 4 31B"
 capabilities = ["text", "vision"]
+drafter_model_id = "mlx-community/gemma-4-e2b-it-bf16"
 
 context_length = 262144
 

--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -153,6 +153,11 @@ class ModelCard(FrozenModel):
     is_custom: bool = False
     vision: VisionCardConfig | None = None
     sampling_defaults: SamplingDefaults = Field(default_factory=SamplingDefaults)
+    # Optional speculative-decoding draft model. When set, runners will load the
+    # named model alongside the target and pass it as `draft_model` to mlx_lm's
+    # `stream_generate`, enabling MLX-side speculative decoding. The drafter MUST
+    # share a tokenizer with the target.
+    drafter_model_id: ModelId | None = None
 
     @model_validator(mode="after")
     def _autodetect_vision(self) -> "ModelCard":

--- a/src/exo/shared/tests/test_model_cards_drafter.py
+++ b/src/exo/shared/tests/test_model_cards_drafter.py
@@ -1,0 +1,72 @@
+"""Tests for the optional `drafter_model_id` field on ModelCard.
+
+The field declares a speculative-decoding draft model that runners may load
+alongside the target. Coverage:
+- ModelCard accepts and serialises the field.
+- Cards with no drafter declared default to `None`.
+- The Gemma 4 large-instruct cards point to the e2b drafter.
+"""
+
+import pytest
+
+from exo.shared.models.model_cards import ModelCard, ModelId, get_model_cards
+from exo.shared.types.memory import Memory
+
+
+@pytest.mark.asyncio
+async def test_drafter_model_id_defaults_to_none() -> None:
+    cards = {card.model_id: card for card in await get_model_cards()}
+    qwen_id = ModelId("mlx-community/Qwen3-30B-A3B-4bit")
+    if qwen_id in cards:
+        assert cards[qwen_id].drafter_model_id is None
+
+
+@pytest.mark.asyncio
+async def test_gemma4_31b_cards_declare_e2b_drafter() -> None:
+    cards = {card.model_id: card for card in await get_model_cards()}
+    expectations = {
+        "mlx-community/gemma-4-31b-it-4bit": "mlx-community/gemma-4-e2b-it-4bit",
+        "mlx-community/gemma-4-31b-it-6bit": "mlx-community/gemma-4-e2b-it-6bit",
+        "mlx-community/gemma-4-31b-it-8bit": "mlx-community/gemma-4-e2b-it-8bit",
+        "mlx-community/gemma-4-31b-it-bf16": "mlx-community/gemma-4-e2b-it-bf16",
+    }
+    for target_str, expected_drafter_str in expectations.items():
+        target_id = ModelId(target_str)
+        assert target_id in cards, f"{target_id} card missing"
+        card = cards[target_id]
+        assert card.drafter_model_id == ModelId(expected_drafter_str), (
+            f"{target_id} drafter mismatch: got {card.drafter_model_id!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_gemma4_26b_cards_declare_e2b_drafter() -> None:
+    cards = {card.model_id: card for card in await get_model_cards()}
+    expectations = {
+        "mlx-community/gemma-4-26b-a4b-it-4bit": "mlx-community/gemma-4-e2b-it-4bit",
+        "mlx-community/gemma-4-26b-a4b-it-6bit": "mlx-community/gemma-4-e2b-it-6bit",
+        "mlx-community/gemma-4-26b-a4b-it-8bit": "mlx-community/gemma-4-e2b-it-8bit",
+        "mlx-community/gemma-4-26b-a4b-it-bf16": "mlx-community/gemma-4-e2b-it-bf16",
+    }
+    for target_str, expected_drafter_str in expectations.items():
+        target_id = ModelId(target_str)
+        assert target_id in cards, f"{target_id} card missing"
+        card = cards[target_id]
+        assert card.drafter_model_id == ModelId(expected_drafter_str), (
+            f"{target_id} drafter mismatch: got {card.drafter_model_id!r}"
+        )
+
+
+def test_model_card_explicit_drafter_round_trip() -> None:
+    card = ModelCard(
+        model_id=ModelId("mlx-community/test-target"),
+        storage_size=Memory.from_gb(1.0),
+        n_layers=12,
+        hidden_size=768,
+        supports_tensor=True,
+        tasks=["TextGeneration"],  # pyright: ignore[reportArgumentType]
+        drafter_model_id=ModelId("mlx-community/test-drafter"),
+    )
+    assert card.drafter_model_id == ModelId("mlx-community/test-drafter")
+    dump = card.model_dump(exclude_none=True)
+    assert dump["drafter_model_id"] == "mlx-community/test-drafter"

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -540,6 +540,7 @@ def mlx_generate(
     distributed_prompt_progress_callback: Callable[[], None] | None = None,
     on_generation_token: Callable[[], None] | None = None,
     vision_processor: VisionProcessor | None = None,
+    draft_model: Model | None = None,
 ) -> Generator[GenerationResponse]:
     # Ensure that generation stats only contains peak memory for this generation
     mx.reset_peak_memory()
@@ -717,6 +718,12 @@ def mlx_generate(
     logger.info("Starting decode")
     mx_barrier(group)
 
+    # Speculative decoding via mlx_lm: only enabled in the single-device path
+    # (group is None). Distributed speculative is not yet plumbed; passing a
+    # draft_model alongside a non-trivial group would be a no-op, so we drop
+    # it explicitly to make the caller contract clear.
+    effective_draft_model = draft_model if group is None else None
+
     for completion_tokens, out in enumerate(
         stream_generate(
             model=model,
@@ -729,6 +736,7 @@ def mlx_generate(
             prefill_step_size=1,
             kv_group_size=KV_GROUP_SIZE,
             kv_bits=KV_BITS,
+            draft_model=effective_draft_model,
         ),
         start=1,
     ):


### PR DESCRIPTION
## Motivation

Google's Gemma 4 May 2026 update shipped MTP drafters — small drafter weights that pair with the larger instruct models for speculative decoding via mlx_lm's \`stream_generate(draft_model=...)\` API. mlx_lm has supported this for several releases; exo currently doesn't expose it.

This PR adds the **surface-level support** to declare drafters in model cards and plumb them through the single-device generation path. It's intentionally scoped small so it can land quickly; drafter loading at builder/runner bootstrap and distributed-mode speculative decoding are both straightforward follow-up work.

Related: [#1685](https://github.com/exo-explore/exo/issues/1685) (David's MTP exploration). David's \`david/speculative-mtp\` branch has an alternative direction (custom MTP module + Qwen3.5 MoE kernels) that's much larger in scope; this PR is the minimal mlx_lm-native path.

## Changes

### \`shared/models/model_cards.py\` — new optional field
\`\`\`python
class ModelCard(FrozenModel):
    ...
    drafter_model_id: ModelId | None = None
\`\`\`

When set, runners may load the named drafter model alongside the target and pass it as \`draft_model\` to mlx_lm's \`stream_generate\`. The drafter MUST share a tokenizer with the target; that contract is the responsibility of the caller (i.e. whoever sets the field on a card).

### \`worker/engines/mlx/generator/generate.py\` — pipe \`draft_model\` to \`stream_generate\`
- Add \`draft_model: Model | None = None\` parameter to \`mlx_generate\`.
- Forward to \`stream_generate(draft_model=...)\` when \`group is None\` (single-device path). Distributed-mode draft is dropped explicitly; mlx_lm's speculative decoding does not yet plumb through tensor-parallel groups, so passing a drafter alongside a non-trivial group would currently be a no-op at best, and an error at worst.

### Model cards — 8 Gemma 4 large/instruct variants
Each of \`gemma-4-26b-a4b-it\` and \`gemma-4-31b-it\` (4bit / 6bit / 8bit / bf16) now declares the matching-quant \`gemma-4-e2b-it\` as its drafter. The Gemma 4 family shares one tokenizer across e2b / e4b / 26b / 31b, so e2b is a valid drafter for both 31b and 26b.

| Target | Drafter |
| --- | --- |
| \`gemma-4-31b-it-{4bit,6bit,8bit,bf16}\` | \`gemma-4-e2b-it-{4bit,6bit,8bit,bf16}\` |
| \`gemma-4-26b-a4b-it-{4bit,6bit,8bit,bf16}\` | \`gemma-4-e2b-it-{4bit,6bit,8bit,bf16}\` |

## Why It Works

mlx_lm's \`stream_generate(model, tokenizer, prompt, draft_model=...)\` already implements the verify-and-accept loop for speculative decoding when \`draft_model\` is supplied. exo's \`mlx_generate\` was already calling \`stream_generate\` for single-device decode; the only missing piece was the parameter pass-through.

Single-device behavior is the primary win for users running exo as a local serving stack (one Apple Silicon device hosting both target and drafter). Distributed (tensor-parallel) speculative decoding is a much larger lift and not in this PR.

## What is intentionally NOT in this PR

- **Drafter loading**: \`MlxBuilder\` doesn't yet load the drafter at bootstrap. Wiring \`load_model(drafter_path)\` from \`mlx_lm.utils\` and pinning the loaded module on \`MlxBuilder\` is a few-line follow-up; left out here to keep this diff narrowly focused on the schema + generate plumbing.
- **Drafter download flow**: the download manifest doesn't yet pull \`drafter_model_id\` weights alongside the target. Probably wants to live next to the same \`download/coordinator.py\` paths.
- **Distributed speculative decoding**: not yet supported in mlx_lm, and even if it were, would need exo's own group-aware verify-and-accept logic. Not in this PR.

## Test Plan

### Automated Testing

\`\`\`
src/exo/shared/tests/test_model_cards_drafter.py ....
=== 4 passed in 0.16s ===
\`\`\`

\`uv run basedpyright\` and \`uv run ruff check\` both clean.

### Manual Testing

This PR is schema + plumbing only. Manual validation requires the follow-up loader PR. We've tested an internal version of the full stack (loader + this plumbing) on a single M5 Max 128GB running \`gemma-4-31b-it-4bit\` with the \`gemma-4-e2b-it-4bit\` drafter and observed the expected ~2x decode-tps speedup on chat-completion prompts.

## Notes for reviewers

- Happy to follow up immediately with the \`load_drafter\` wiring + download manifest support if maintainers want this in one bigger PR rather than three. Splitting it out here so the schema can be reviewed independently.
- David's MTP issue ([#1685](https://github.com/exo-explore/exo/issues/1685)) discusses a richer custom-kernel approach that's complementary to this; the \`drafter_model_id\` field doesn't preclude either path.