### PR TITLE
Add exo-diagnostics CLI + diagnostic snapshot loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 
 [project.scripts]
 exo = "exo.main:main"
+exo-diagnostics = "exo.diagnostics:main"
 
 # dependencies only required for development
 [dependency-groups]

--- a/src/exo/diagnostics.py
+++ b/src/exo/diagnostics.py
@@ -1,0 +1,194 @@
+"""Collect local exo diagnostics for postmortem analysis."""
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol, cast
+
+
+class _ReadableResponse(Protocol):
+    def read(self) -> bytes: ...
+
+    def close(self) -> None: ...
+
+
+def _get_xdg_dir(env_var: str, fallback: str) -> Path:
+    exo_home = os.environ.get("EXO_HOME")
+    if exo_home is not None:
+        return Path.home() / exo_home
+    if sys.platform != "linux":
+        return Path.home() / ".exo"
+    xdg_value = os.environ.get(env_var)
+    if xdg_value is not None:
+        return Path(xdg_value) / "exo"
+    return Path.home() / fallback / "exo"
+
+
+_EXO_CACHE_HOME = _get_xdg_dir("XDG_CACHE_HOME", ".cache")
+_EXO_DATA_HOME = _get_xdg_dir("XDG_DATA_HOME", ".local/share")
+_EXO_LOG_DIR = _EXO_CACHE_HOME / "exo_log"
+_EXO_EVENT_LOG_DIR = _EXO_DATA_HOME / "event_log"
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Create a compressed local diagnostics bundle.
+
+    Args:
+        argv: Optional command-line arguments for tests or embedded callers.
+    """
+    parser = argparse.ArgumentParser(prog="exo-diagnostics")
+    parser.add_argument(
+        "bundle",
+        choices=("bundle",),
+        help="Collect local process, API, event-log, and file-log diagnostics.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default="http://127.0.0.1:52415",
+        help="Local exo API base URL to query.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output .tar.gz path. Defaults to ./exo-diagnostics-<timestamp>.tar.gz.",
+    )
+    namespace = parser.parse_args(argv)
+    base_url = cast(str, namespace.base_url)
+    output_arg = cast(str | None, namespace.output)
+    output_path = (
+        Path(output_arg).expanduser()
+        if output_arg is not None
+        else Path.cwd() / f"exo-diagnostics-{_timestamp()}.tar.gz"
+    )
+    bundle_path = collect_bundle(base_url=base_url, output_path=output_path)
+    print(bundle_path)
+
+
+def collect_bundle(*, base_url: str, output_path: Path) -> Path:
+    """Collect local diagnostics and write them to a compressed archive.
+
+    Args:
+        base_url: Local exo API base URL.
+        output_path: Destination archive path.
+
+    Returns:
+        The path to the written archive.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="exo-diagnostics-") as temp_directory:
+        root = Path(temp_directory) / "exo-diagnostics"
+        root.mkdir()
+        _write_manifest(root, base_url)
+        _collect_http(base_url, root / "api")
+        _collect_processes(root / "processes")
+        _collect_memory(root / "memory")
+        _copy_existing_path(_EXO_LOG_DIR, root / "logs")
+        _copy_existing_path(_EXO_EVENT_LOG_DIR, root / "event_log")
+        _copy_existing_path(_EXO_CACHE_HOME / "exo.log", root / "legacy-exo.log")
+        with tarfile.open(output_path, "w:gz") as archive:
+            archive.add(root, arcname=root.name)
+    return output_path
+
+
+def _write_manifest(root: Path, base_url: str) -> None:
+    manifest = {
+        "createdAt": datetime.now(timezone.utc).isoformat(),
+        "hostname": platform.node(),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "baseUrl": base_url,
+    }
+    (root / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def _collect_http(base_url: str, target: Path) -> None:
+    target.mkdir()
+    for endpoint in ("node_id", "state", "v1/models"):
+        safe_name = endpoint.replace("/", "_")
+        url = f"{base_url.rstrip('/')}/{endpoint}"
+        try:
+            response = cast(_ReadableResponse, urllib.request.urlopen(url, timeout=5))
+            try:
+                body = response.read().decode("utf-8", "replace")
+            finally:
+                response.close()
+            (target / f"{safe_name}.json").write_text(body)
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            payload = {
+                "url": url,
+                "errorType": type(error).__name__,
+                "error": str(error),
+            }
+            (target / f"{safe_name}.error.json").write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            )
+
+
+def _collect_processes(target: Path) -> None:
+    target.mkdir()
+    (target / "ps.txt").write_text(
+        _run_command(("ps", "-axo", "pid,ppid,etime,rss,command"))
+    )
+
+
+def _collect_memory(target: Path) -> None:
+    target.mkdir()
+    system = platform.system()
+    if system == "Darwin":
+        commands = {
+            "vm_stat.txt": ("vm_stat",),
+            "memory_pressure.txt": ("memory_pressure",),
+        }
+    elif system == "Linux":
+        commands = {
+            "free.txt": ("free", "-m"),
+        }
+        meminfo = Path("/proc/meminfo")
+        if meminfo.exists():
+            (target / "meminfo.txt").write_text(meminfo.read_text())
+    else:
+        commands = {"platform.txt": ("uname", "-a")}
+    for filename, command in commands.items():
+        (target / filename).write_text(_run_command(command))
+
+
+def _run_command(command: Sequence[str]) -> str:
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return f"{type(error).__name__}: {error}\n"
+    return result.stdout
+
+
+def _copy_existing_path(source: Path, destination: Path) -> None:
+    if not source.exists():
+        return
+    if source.is_dir():
+        shutil.copytree(source, destination, dirs_exist_ok=True)
+    else:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -3,7 +3,9 @@ import multiprocessing as mp
 import os
 import resource
 import signal
+import subprocess
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Self
 
 import anyio
@@ -19,8 +21,9 @@ from exo.routing.event_router import EventRouter
 from exo.routing.router import Router, get_node_id_keypair
 from exo.shared.constants import EXO_LOG
 from exo.shared.election import Election, ElectionResult
-from exo.shared.logging import logger_cleanup, logger_setup
+from exo.shared.logging import logger_cleanup, logger_set_context, logger_setup
 from exo.shared.types.common import NodeId, SessionId
+from exo.shared.types.state import State
 from exo.utils.channels import Receiver, channel
 from exo.utils.pydantic_ext import FrozenModel
 from exo.utils.task_group import TaskGroup
@@ -129,7 +132,7 @@ class Node:
             election_result_sender=er_send,
         )
 
-        return cls(
+        self = cls(
             router,
             event_router,
             download_coordinator,
@@ -142,6 +145,14 @@ class Node:
             args.offline,
             args.api_port,
         )
+        logger_set_context(
+            node_id=node_id, role="master" if args.force_master else "node"
+        )
+        logger.info(
+            f"Node components created node_id={node_id} api_port={args.api_port} "
+            f"libp2p_port={args.libp2p_port} bootstrap_peers={args.bootstrap_peers}"
+        )
+        return self
 
     async def run(self):
         async with self._tg as tg:
@@ -159,6 +170,7 @@ class Node:
             if self.api:
                 tg.start_soon(self.api.run)
             tg.start_soon(self._elect_loop)
+            tg.start_soon(self._diagnostic_snapshot_loop)
 
     def shutdown(self):
         # if this is our second call to shutdown, just sys.exit
@@ -197,11 +209,13 @@ class Node:
                     result.session_id.master_node_id == self.node_id
                     and self.master is not None
                 ):
+                    logger_set_context(role="master", session_id=str(result.session_id))
                     logger.info("Node elected Master")
                 elif (
                     result.session_id.master_node_id == self.node_id
                     and self.master is None
                 ):
+                    logger_set_context(role="master", session_id=str(result.session_id))
                     logger.info("Node elected Master - promoting self")
                     self.master = Master(
                         self.node_id,
@@ -219,12 +233,14 @@ class Node:
                     result.session_id.master_node_id != self.node_id
                     and self.master is not None
                 ):
+                    logger_set_context(role="worker", session_id=str(result.session_id))
                     logger.info(
                         f"Node {result.session_id.master_node_id} elected master - demoting self"
                     )
                     await self.master.shutdown()
                     self.master = None
                 else:
+                    logger_set_context(role="worker", session_id=str(result.session_id))
                     logger.info(
                         f"Node {result.session_id.master_node_id} elected master"
                     )
@@ -262,6 +278,85 @@ class Node:
                     if self.api:
                         self.api.unpause(result.won_clock)
 
+    async def _diagnostic_snapshot_loop(self) -> None:
+        interval_value = os.getenv("EXO_DIAGNOSTIC_SNAPSHOT_SECONDS", "15")
+        try:
+            interval_seconds = float(interval_value)
+        except ValueError:
+            logger.warning(
+                "Invalid EXO_DIAGNOSTIC_SNAPSHOT_SECONDS value "
+                f"{interval_value!r}; using default 15s"
+            )
+            interval_seconds = 15.0
+        if interval_seconds <= 0:
+            logger.info("Cluster diagnostic snapshots disabled")
+            return
+        while True:
+            await anyio.sleep(interval_seconds)
+            self._log_diagnostic_snapshot()
+
+    def _log_diagnostic_snapshot(self) -> None:
+        state_source = "none"
+        state: State | None = None
+        if self.master is not None:
+            state_source = "master"
+            state = self.master.state
+        elif self.worker is not None:
+            state_source = "worker"
+            state = self.worker.state
+
+        if state is None:
+            logger.info("Cluster diagnostic snapshot state_source=none")
+            return
+
+        node_names = self._topology_node_names(state)
+        runner_states = [
+            f"{runner_id}:{type(runner_status).__name__}"
+            for runner_id, runner_status in state.runners.items()
+        ]
+        instance_models = [
+            (
+                f"{instance_id}:"
+                f"{instance.shard_assignments.model_id}:"
+                f"{len(instance.shard_assignments.node_to_runner)}-node"
+            )
+            for instance_id, instance in state.instances.items()
+        ]
+        last_seen_ages = self._last_seen_ages(state)
+        local_runner_processes = (
+            len(self.worker.runners) if self.worker is not None else 0
+        )
+        outbound_events = len(self.event_router.out_for_delivery)
+        logger.info(
+            "Cluster diagnostic snapshot "
+            f"state_source={state_source} "
+            f"last_event_applied_idx={state.last_event_applied_idx} "
+            f"topology_nodes={node_names} "
+            f"last_seen_ages_seconds={last_seen_ages} "
+            f"state_runners={runner_states} "
+            f"state_instances={instance_models} "
+            f"local_runner_processes={local_runner_processes} "
+            f"out_for_delivery={outbound_events}"
+        )
+
+    def _topology_node_names(self, state: State) -> list[str]:
+        names: list[str] = []
+        for node_id in state.topology.list_nodes():
+            identity = state.node_identities.get(node_id)
+            names.append(
+                identity.friendly_name if identity is not None else str(node_id)
+            )
+        return names
+
+    def _last_seen_ages(self, state: State) -> dict[str, float]:
+        now = datetime.now(tz=timezone.utc)
+        ages: dict[str, float] = {}
+        for node_id, last_seen in state.last_seen.items():
+            identity = state.node_identities.get(node_id)
+            name = identity.friendly_name if identity is not None else str(node_id)
+            ages[name] = round((now - last_seen).total_seconds(), 3)
+        return ages
+
 
 def main():
     args = Args.parse()
@@ -272,6 +367,7 @@ def main():
     mp.set_start_method("spawn", force=True)
     # TODO: Refactor the current verbosity system
     logger_setup(EXO_LOG, args.verbosity)
+    logger_set_context(git_commit=_git_commit())
     logger.info(f"{'=' * 40}")
     logger.info(f"Starting EXO | pid={os.getpid()}")
     logger.info(f"{'=' * 40}")
@@ -306,6 +402,21 @@ def main():
     finally:
         logger.info("EXO Shutdown complete")
         logger_cleanup()
+
+
+def _git_commit() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError:
+        return "unknown"
+    commit = result.stdout.strip()
+    return commit if result.returncode == 0 and commit else "unknown"
 
 
 class Args(FrozenModel):

--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -460,6 +460,14 @@ class Master:
             for instance_id, instance in self.state.instances.items():
                 for node_id in instance.shard_assignments.node_to_runner:
                     if node_id not in connected_node_ids:
+                        logger.warning(
+                            "Deleting instance because a shard node is disconnected "
+                            f"instance_id={instance_id} "
+                            f"model_id={instance.shard_assignments.model_id} "
+                            f"missing_node={node_id} "
+                            f"missing_node_name={self._friendly_name(node_id)} "
+                            f"connected_nodes={self._topology_node_names()}"
+                        )
                         await self.event_sender.send(
                             InstanceDeleted(instance_id=instance_id)
                         )
@@ -469,7 +477,20 @@ class Master:
             for node_id, time in self.state.last_seen.items():
                 now = datetime.now(tz=timezone.utc)
                 if now - time > timedelta(seconds=30):
-                    logger.info(f"Manually removing node {node_id} due to inactivity")
+                    impacted_instances = [
+                        str(instance_id)
+                        for instance_id, instance in self.state.instances.items()
+                        if node_id in instance.shard_assignments.node_to_runner
+                    ]
+                    logger.warning(
+                        "Timing out inactive node "
+                        f"node_id={node_id} node_name={self._friendly_name(node_id)} "
+                        f"last_seen={time.isoformat()} "
+                        f"age_seconds={(now - time).total_seconds():.3f} "
+                        f"last_event_applied_idx={self.state.last_event_applied_idx} "
+                        f"topology_nodes={self._topology_node_names()} "
+                        f"impacted_instances={impacted_instances}"
+                    )
                     await self.event_sender.send(NodeTimedOut(node_id=node_id))
 
             await anyio.sleep(10)
@@ -517,6 +538,15 @@ class Master:
                 event=event.event,
             )
         )
+
+    def _friendly_name(self, node_id: NodeId) -> str:
+        identity = self.state.node_identities.get(node_id)
+        return identity.friendly_name if identity is not None else str(node_id)
+
+    def _topology_node_names(self) -> list[str]:
+        return [
+            self._friendly_name(node_id) for node_id in self.state.topology.list_nodes()
+        ]
 
     async def _handle_traces_collected(self, event: TracesCollected) -> None:
         task_id = event.task_id

--- a/src/exo/routing/event_router.py
+++ b/src/exo/routing/event_router.py
@@ -42,6 +42,7 @@ class EventRouter:
     _nack_attempts: int = field(init=False, default=0)
     _nack_base_seconds: float = field(init=False, default=0.5)
     _nack_cap_seconds: float = field(init=False, default=10.0)
+    _last_outbound_warning_size: int = field(init=False, default=0)
 
     async def run(self):
         try:
@@ -61,6 +62,12 @@ class EventRouter:
             for e_id, (time, event) in list(self.out_for_delivery.items()):
                 if anyio.current_time() > time + 5:
                     self.out_for_delivery[e_id] = (anyio.current_time(), event)
+                    logger.debug(
+                        "Retrying unacknowledged local event "
+                        f"event_id={e_id} origin_idx={event.origin_idx} "
+                        f"event_type={type(event.event).__name__} "
+                        f"out_for_delivery={len(self.out_for_delivery)}"
+                    )
                     await self.external_outbound.send(event)
 
     def sender(self) -> Sender[Event]:
@@ -93,6 +100,7 @@ class EventRouter:
                 idx += 1
                 await self.external_outbound.send(f_ev)
                 self.out_for_delivery[event.event_id] = (anyio.current_time(), f_ev)
+                self._log_outbound_pressure()
 
     async def _run_ext_in(self):
         buf = OrderedBuffer[Event]()
@@ -107,6 +115,11 @@ class EventRouter:
                 event_id = event.event.event_id
                 if event_id in self.out_for_delivery:
                     self.out_for_delivery.pop(event_id)
+                    logger.debug(
+                        "Acknowledged local event from global stream "
+                        f"event_id={event_id} origin_idx={event.origin_idx} "
+                        f"remaining_out_for_delivery={len(self.out_for_delivery)}"
+                    )
 
                 drained = buf.drain_indexed()
                 if drained:
@@ -118,6 +131,12 @@ class EventRouter:
                     self._nack_cancel_scope is None
                     or self._nack_cancel_scope.cancel_called
                 ):
+                    logger.warning(
+                        "Global event stream gap detected "
+                        f"received_idx={event.origin_idx} "
+                        f"next_expected_idx={buf.next_idx_to_release} "
+                        f"event_type={type(event.event).__name__}"
+                    )
                     # Request the next index.
                     self._tg.start_soon(self._nack_request, buf.next_idx_to_release)
                     continue
@@ -149,7 +168,10 @@ class EventRouter:
             try:
                 await anyio.sleep(delay)
                 logger.info(
-                    f"Nack attempt {self._nack_attempts}: Requesting Event Log from {since_idx}"
+                    "Requesting event log replay "
+                    f"nack_attempt={self._nack_attempts} since_idx={since_idx} "
+                    f"session={self.session_id} "
+                    f"out_for_delivery={len(self.out_for_delivery)}"
                 )
                 await self.command_sender.send(
                     ForwarderCommand(
@@ -160,3 +182,15 @@ class EventRouter:
             finally:
                 if self._nack_cancel_scope is scope:
                     self._nack_cancel_scope = None
+
+    def _log_outbound_pressure(self) -> None:
+        size = len(self.out_for_delivery)
+        if size < 10:
+            self._last_outbound_warning_size = 0
+            return
+        if size >= self._last_outbound_warning_size + 10:
+            self._last_outbound_warning_size = size
+            logger.warning(
+                "Local events awaiting master acknowledgement "
+                f"out_for_delivery={size} session={self.session_id}"
+            )

--- a/src/exo/routing/router.py
+++ b/src/exo/routing/router.py
@@ -9,6 +9,7 @@ from typing import cast
 from anyio import (
     BrokenResourceError,
     ClosedResourceError,
+    current_time,
     move_on_after,
     sleep_forever,
 )
@@ -121,6 +122,8 @@ class Router:
         self._tmp_networking_sender: Sender[tuple[str, bytes]] | None = send
         self._id_count = count()
         self._tg: TaskGroup = TaskGroup()
+        self._publish_failure_counts: dict[str, int] = {}
+        self._publish_failure_first_seen: dict[str, float] = {}
 
     async def register_topic[T: FrozenModel](self, topic: TypedTopic[T]):
         send = self._tmp_networking_sender
@@ -229,17 +232,63 @@ class Router:
                     logger.trace(f"Sending message on {topic} with payload {data}")
                     if len(data) > 1024 * 1024:
                         logger.warning(
-                            "Sending overlarge payload, network performance may be temporarily degraded"
+                            "Sending overlarge payload, network performance may be "
+                            f"temporarily degraded topic={topic} payload_bytes={len(data)}"
                         )
                     await self._net.gossipsub_publish(topic, data)
+                    self._clear_publish_failures(topic)
                 except NoPeersSubscribedToTopicError:
-                    pass
-                except AllQueuesFullError:
-                    logger.warning(f"All peer queues full, dropping message on {topic}")
-                except MessageTooLargeError:
-                    logger.warning(
-                        f"Message too large for gossipsub on {topic} ({len(data)} bytes), dropping"
+                    self._record_publish_failure(
+                        topic=topic,
+                        payload_bytes=len(data),
+                        reason="no_peers_subscribed",
+                        log_level="DEBUG",
                     )
+                except AllQueuesFullError:
+                    self._record_publish_failure(
+                        topic=topic,
+                        payload_bytes=len(data),
+                        reason="all_peer_queues_full",
+                        log_level="WARNING",
+                    )
+                except MessageTooLargeError:
+                    self._record_publish_failure(
+                        topic=topic,
+                        payload_bytes=len(data),
+                        reason="message_too_large",
+                        log_level="WARNING",
+                    )
+
+    def _record_publish_failure(
+        self, *, topic: str, payload_bytes: int, reason: str, log_level: str
+    ) -> None:
+        key = f"{topic}:{reason}"
+        count = self._publish_failure_counts.get(key, 0) + 1
+        self._publish_failure_counts[key] = count
+        first_seen = self._publish_failure_first_seen.setdefault(key, current_time())
+        elapsed_seconds = current_time() - first_seen
+        if count == 1 or count % 10 == 0:
+            logger.log(
+                log_level,
+                "Gossipsub publish failed "
+                f"topic={topic} reason={reason} payload_bytes={payload_bytes} "
+                f"consecutive_failures={count} "
+                f"failure_window_seconds={elapsed_seconds:.3f}",
+            )
+
+    def _clear_publish_failures(self, topic: str) -> None:
+        cleared = [
+            key for key in self._publish_failure_counts if key.startswith(f"{topic}:")
+        ]
+        for key in cleared:
+            count = self._publish_failure_counts.pop(key)
+            first_seen = self._publish_failure_first_seen.pop(key, current_time())
+            logger.info(
+                "Gossipsub publish recovered "
+                f"topic={topic} reason={key.removeprefix(f'{topic}:')} "
+                f"previous_failures={count} "
+                f"failure_window_seconds={current_time() - first_seen:.3f}"
+            )
 
 
 def get_node_id_keypair(

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -1,7 +1,10 @@
 import logging
+import os
+import socket
 import sys
-from collections.abc import Iterator
+from datetime import datetime, timezone
 from pathlib import Path
+from uuid import uuid4
 
 import zstandard
 from hypercorn import Config
@@ -9,6 +12,18 @@ from hypercorn.logging import Logger as HypercornLogger
 from loguru import logger
 
 _MAX_LOG_ARCHIVES = 5
+_DEFAULT_LOG_ROTATION = "100 MB"
+_DEFAULT_LOG_RETENTION = "7 days"
+
+_LOG_CONTEXT: dict[str, object] = {
+    "run_id": os.environ.get("EXO_RUN_ID", str(uuid4())),
+    "node_id": "unknown",
+    "hostname": socket.gethostname(),
+    "pid": os.getpid(),
+    "role": "startup",
+    "session_id": "unknown",
+    "git_commit": os.environ.get("EXO_GIT_COMMIT", "unknown"),
+}
 
 
 def _zstd_compress(filepath: str) -> None:
@@ -20,10 +35,22 @@ def _zstd_compress(filepath: str) -> None:
     source.unlink()
 
 
-def _once_then_never() -> Iterator[bool]:
-    yield True
-    while True:
-        yield False
+def _context_format(message_format: str) -> str:
+    return (
+        "[ {time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | "
+        "run={extra[run_id]} node={extra[node_id]} host={extra[hostname]} "
+        "pid={extra[pid]} role={extra[role]} session={extra[session_id]} "
+        "git={extra[git_commit]} | {name}:{function}:{line} ] "
+        f"{message_format}"
+    )
+
+
+def logger_set_context(**updates: object) -> None:
+    """Update process-wide log context for subsequent log records."""
+    _LOG_CONTEXT.update(
+        {key: value for key, value in updates.items() if value is not None}
+    )
+    logger.configure(extra=_LOG_CONTEXT)
 
 
 class InterceptLogger(HypercornLogger):
@@ -51,37 +78,67 @@ def logger_setup(log_file: Path | None, verbosity: int = 0):
     logging.getLogger("httpcore").setLevel(logging.WARNING)
 
     logger.remove()
+    logger.configure(extra=_LOG_CONTEXT)
 
     # replace all stdlib loggers with _InterceptHandlers that log to loguru
     logging.basicConfig(handlers=[_InterceptHandler()], level=0)
 
+    console_level = "INFO" if verbosity == 0 else "DEBUG"
     if verbosity == 0:
         logger.add(
             sys.__stderr__,  # type: ignore
             format="[ {time:hh:mm:ss.SSSSA} | <level>{level: <8}</level>] <level>{message}</level>",
-            level="INFO",
+            level=console_level,
             colorize=True,
             enqueue=True,
         )
     else:
         logger.add(
             sys.__stderr__,  # type: ignore
-            format="[ {time:YYYY-MM-DD HH:mm:ss.SSS} | <level>{level: <8}</level> | {name}:{function}:{line} ] <level>{message}</level>",
-            level="DEBUG",
+            format=_context_format("<level>{message}</level>"),
+            level=console_level,
             colorize=True,
             enqueue=True,
         )
     if log_file:
-        rotate_once = _once_then_never()
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        run_dir = log_file.parent / "runs"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        run_name = (
+            f"{timestamp}-{_LOG_CONTEXT['hostname']}-{_LOG_CONTEXT['pid']}-"
+            f"{_LOG_CONTEXT['run_id']}"
+        )
+        run_text_log = run_dir / f"{run_name}.log"
+        run_json_log = run_dir / f"{run_name}.jsonl"
+        rotation = os.environ.get("EXO_LOG_ROTATION", _DEFAULT_LOG_ROTATION)
+        retention = os.environ.get("EXO_LOG_RETENTION", _DEFAULT_LOG_RETENTION)
+
         logger.add(
             log_file,
-            format="[ {time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} ] {message}",
+            format=_context_format("{message}"),
             level="DEBUG" if verbosity > 0 else "INFO",
             colorize=False,
             enqueue=True,
-            rotation=lambda _, __: next(rotate_once),
+            rotation=rotation,
             retention=_MAX_LOG_ARCHIVES,
             compression=_zstd_compress,
+        )
+        for destination, serialize in ((run_text_log, False), (run_json_log, True)):
+            logger.add(
+                destination,
+                format=_context_format("{message}"),
+                level="DEBUG",
+                colorize=False,
+                enqueue=True,
+                rotation=rotation,
+                retention=retention,
+                compression=_zstd_compress,
+                serialize=serialize,
+            )
+        logger.info(
+            f"Per-run logs enabled text_log={run_text_log} json_log={run_json_log} "
+            f"rotation={rotation} retention={retention}"
         )
 
 

--- a/src/exo/shared/tests/test_diagnostic_snapshot_config.py
+++ b/src/exo/shared/tests/test_diagnostic_snapshot_config.py
@@ -1,0 +1,42 @@
+from typing import cast
+
+import pytest
+
+from exo.main import Node
+
+
+@pytest.mark.asyncio
+async def test_invalid_diagnostic_snapshot_interval_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXO_DIAGNOSTIC_SNAPSHOT_SECONDS", "15s")
+    snapshots = 0
+
+    async def stop_after_first_sleep(_seconds: float) -> None:
+        raise RuntimeError("stop")
+
+    def count_snapshot(_self: Node) -> None:
+        nonlocal snapshots
+        snapshots += 1
+
+    monkeypatch.setattr("exo.main.anyio.sleep", stop_after_first_sleep)
+    monkeypatch.setattr(Node, "_log_diagnostic_snapshot", count_snapshot)
+
+    with pytest.raises(RuntimeError, match="stop"):
+        await Node._diagnostic_snapshot_loop(cast(Node, cast(object, None)))  # pyright: ignore[reportPrivateUsage]
+
+    assert snapshots == 0
+
+
+@pytest.mark.asyncio
+async def test_non_positive_diagnostic_snapshot_interval_disables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXO_DIAGNOSTIC_SNAPSHOT_SECONDS", "0")
+
+    async def fail_sleep(_seconds: float) -> None:
+        raise AssertionError("diagnostic loop should not sleep when disabled")
+
+    monkeypatch.setattr("exo.main.anyio.sleep", fail_sleep)
+
+    await Node._diagnostic_snapshot_loop(cast(Node, cast(object, None)))  # pyright: ignore[reportPrivateUsage]

--- a/src/exo/worker/runner/bootstrap.py
+++ b/src/exo/worker/runner/bootstrap.py
@@ -32,7 +32,16 @@ def entrypoint(
     else:
         os.environ["MLX_METAL_FAST_SYNCH"] = "1"
 
-    logger.info(f"Fast synch flag: {os.environ['MLX_METAL_FAST_SYNCH']}")
+    runner_context = (
+        f"instance_id={bound_instance.instance.instance_id} "
+        f"runner_id={bound_instance.bound_runner_id} "
+        f"node_id={bound_instance.bound_node_id} "
+        f"model_id={bound_instance.bound_shard.model_card.model_id}"
+    )
+    logger.info(
+        f"Runner bootstrap starting {runner_context} "
+        f"fast_synch={os.environ['MLX_METAL_FAST_SYNCH']}"
+    )
 
     # Import main after setting global logger - this lets us just import logger from this module
     try:
@@ -61,13 +70,16 @@ def entrypoint(
             )
 
         runner = Runner(bound_instance, builder, event_sender, task_receiver)
+        runner_kind = "image" if bound_instance.is_image_model else "text"
+        logger.info(f"Starting {runner_kind} runner main loop {runner_context}")
         runner.main()
 
     except ClosedResourceError:
         logger.warning("Runner communication closed unexpectedly")
     except Exception as e:
         logger.opt(exception=e).warning(
-            f"Runner {bound_instance.bound_runner_id} crashed with critical exception {e}"
+            f"Runner {bound_instance.bound_runner_id} crashed with critical exception {e} "
+            f"{runner_context}"
         )
         event_sender.send(
             RunnerStatusUpdated(
@@ -82,4 +94,4 @@ def entrypoint(
         finally:
             event_sender.join()
             task_receiver.join()
-            logger.info("bye from the runner")
+            logger.info(f"bye from the runner {runner_context}")

--- a/src/exo/worker/runner/supervisor.py
+++ b/src/exo/worker/runner/supervisor.py
@@ -5,9 +5,11 @@ from dataclasses import dataclass, field
 from typing import Self
 
 import anyio
+import psutil
 from anyio import (
     BrokenResourceError,
     ClosedResourceError,
+    current_time,
     to_thread,
 )
 from loguru import logger
@@ -65,6 +67,7 @@ class RunnerSupervisor:
     in_progress: dict[TaskId, Task] = field(default_factory=dict, init=False)
     completed: set[TaskId] = field(default_factory=set, init=False)
     cancelled: set[TaskId] = field(default_factory=set, init=False)
+    _started_at: float | None = field(default=None, init=False)
     _cancel_watch_runner: anyio.CancelScope = field(
         default_factory=anyio.CancelScope, init=False
     )
@@ -105,17 +108,31 @@ class RunnerSupervisor:
             _cancel_sender=cancel_sender,
             _event_sender=event_sender,
         )
+        logger.info(
+            "Created runner supervisor "
+            f"{self._runner_context()} model_id={self.shard_metadata.model_card.model_id}"
+        )
 
         return self
 
     async def run(self):
         self.runner_process.start()
+        self._started_at = current_time()
+        logger.info(
+            "Runner process started "
+            f"{self._runner_context()} pid={self.runner_process.pid} "
+            f"model_id={self.shard_metadata.model_card.model_id}"
+        )
         try:
             async with self._tg as tg:
                 tg.start_soon(self._watch_runner)
                 tg.start_soon(self._forward_events)
         finally:
-            logger.info("Runner supervisor shutting down")
+            logger.info(
+                "Runner supervisor shutting down "
+                f"{self._runner_context()} pid={self.runner_process.pid} "
+                f"rss_mb={self._runner_rss_mb()}"
+            )
             if not self._cancel_watch_runner.cancel_called:
                 self._cancel_watch_runner.cancel()
             with contextlib.suppress(ClosedResourceError):
@@ -133,13 +150,18 @@ class RunnerSupervisor:
 
             if self.runner_process.is_alive():
                 logger.warning(
-                    "Runner process didn't shutdown succesfully, terminating"
+                    "Runner process did not shutdown successfully, terminating "
+                    f"{self._runner_context()} pid={self.runner_process.pid} "
+                    f"rss_mb={self._runner_rss_mb()}"
                 )
                 self.runner_process.terminate()
                 self.runner_process.join(timeout=10)
 
                 if not self.runner_process.is_alive():
-                    logger.warning("Terminated nicely in the first attempt!")
+                    logger.warning(
+                        "Runner terminated after first SIGTERM "
+                        f"{self._runner_context()} pid={self.runner_process.pid}"
+                    )
 
                 else:
                     # Try really hard to terminate
@@ -147,21 +169,35 @@ class RunnerSupervisor:
                         self.runner_process.terminate()
                         self.runner_process.join(timeout=2)
                         if not self.runner_process.is_alive():
-                            logger.warning(f"That took {i} attempts :)")
+                            logger.warning(
+                                "Runner terminated after repeated SIGTERM "
+                                f"{self._runner_context()} attempts={i} "
+                                f"pid={self.runner_process.pid}"
+                            )
                             break
                     # Try even harder to kill
                     else:
                         logger.critical(
-                            "Runner process didn't respond to SIGTERM, killing"
+                            "Runner process did not respond to SIGTERM, killing "
+                            f"{self._runner_context()} pid={self.runner_process.pid} "
+                            f"rss_mb={self._runner_rss_mb()}"
                         )
                         j = 0
                         while self.runner_process.is_alive():
                             j += 1
                             self.runner_process.kill()
                             self.runner_process.join(timeout=5)
-                            logger.warning(f"That took {j} attempts :(")
+                            logger.warning(
+                                "Runner kill attempt completed "
+                                f"{self._runner_context()} attempts={j} "
+                                f"pid={self.runner_process.pid}"
+                            )
             else:
-                logger.info("Runner process succesfully terminated")
+                logger.info(
+                    "Runner process successfully terminated "
+                    f"{self._runner_context()} exitcode={self.runner_process.exitcode} "
+                    f"runtime_seconds={self._runtime_seconds()}"
+                )
 
             self.runner_process.close()
 
@@ -179,7 +215,11 @@ class RunnerSupervisor:
                 f"Skipping invalid task {task} as it has already been completed"
             )
             return
-        logger.info(f"Starting task {task}")
+        logger.info(
+            "Starting runner task "
+            f"{self._runner_context()} task_id={task.task_id} "
+            f"task_type={type(task).__name__} status={type(self.status).__name__}"
+        )
         event = anyio.Event()
         self.pending[task.task_id] = event
         self.in_progress[task.task_id] = task
@@ -214,6 +254,13 @@ class RunnerSupervisor:
             with self._ev_recv as events:
                 async for event in events:
                     if isinstance(event, RunnerStatusUpdated):
+                        logger.info(
+                            "Runner status update "
+                            f"{self._runner_context()} "
+                            f"old_status={type(self.status).__name__} "
+                            f"new_status={type(event.runner_status).__name__} "
+                            f"pid={self.runner_process.pid} rss_mb={self._runner_rss_mb()}"
+                        )
                         self.status = event.runner_status
                     if isinstance(event, TaskAcknowledged):
                         self.pending.pop(event.task_id).set()
@@ -252,12 +299,23 @@ class RunnerSupervisor:
     async def _check_runner(self, e: Exception) -> None:
         if not self._cancel_watch_runner.cancel_called:
             self._cancel_watch_runner.cancel()
-        logger.info("Checking runner's status")
+        logger.info(
+            "Checking runner status "
+            f"{self._runner_context()} pid={self.runner_process.pid} "
+            f"rss_mb={self._runner_rss_mb()}"
+        )
         if self.runner_process.is_alive():
-            logger.info("Runner was found to be alive, attempting to join process")
+            logger.info(
+                "Runner was found alive, attempting to join process "
+                f"{self._runner_context()} pid={self.runner_process.pid}"
+            )
             await to_thread.run_sync(self.runner_process.join, 5)
         rc = self.runner_process.exitcode
-        logger.info(f"Runner exited with exit code {rc}")
+        logger.info(
+            "Runner exited "
+            f"{self._runner_context()} exitcode={rc} "
+            f"runtime_seconds={self._runtime_seconds()}"
+        )
         if rc == 0:
             return
 
@@ -270,7 +328,9 @@ class RunnerSupervisor:
         else:
             cause = f"exitcode={rc}"
 
-        logger.opt(exception=e).error(f"Runner terminated with {cause}")
+        logger.opt(exception=e).error(
+            f"Runner terminated with {cause} {self._runner_context()}"
+        )
 
         for task in self.in_progress.values():
             if isinstance(task, (TextGeneration, ImageGeneration, ImageEdits)):
@@ -302,3 +362,24 @@ class RunnerSupervisor:
                 "Event sender already closed, unable to report runner failure"
             )
         self.shutdown()
+
+    def _runner_context(self) -> str:
+        return (
+            f"instance_id={self.bound_instance.instance.instance_id} "
+            f"runner_id={self.bound_instance.bound_runner_id} "
+            f"node_id={self.bound_instance.bound_node_id}"
+        )
+
+    def _runner_rss_mb(self) -> float | None:
+        pid = self.runner_process.pid
+        if pid is None:
+            return None
+        try:
+            return round(psutil.Process(pid).memory_info().rss / (1024 * 1024), 3)
+        except psutil.Error:
+            return None
+
+    def _runtime_seconds(self) -> float | None:
+        if self._started_at is None:
+            return None
+        return round(current_time() - self._started_at, 3)


### PR DESCRIPTION
## Motivation

When something goes wrong on a multi-node exo cluster (master flap, runner crash, RDMA failure to come up), you typically want a single artifact that captures \"what was the cluster doing right before this broke\" — so you can attach it to a bug report or a postmortem without having to ssh around to every node and grep through logs.

Two complementary additions:

1. **\`exo-diagnostics\` CLI** — collects an HTTP snapshot from the API, sysinfo (\`ps\`, \`vm_stat\`, \`netstat\`, etc.), and existing log directories into a single timestamped tarball. Designed to be run on a node when you want to attach state to a bug report.

2. **Diagnostic snapshot loop** — opt-in periodic \`Node._log_diagnostic_snapshot()\` invocation gated by \`EXO_DIAGNOSTIC_SNAPSHOT_SECONDS\`. When set to a positive integer, the master logs a structured snapshot of cluster state on that cadence so post-hoc forensics on a flap is much easier. Invalid or non-positive values fall back to no-op.

## Changes

### \`exo/diagnostics.py\` (new, 194 lines)

\`exo-diagnostics\` CLI registered as a console script. Subcommands:
- \`collect\` (default): writes \`exo-diagnostics-<timestamp>.tar.gz\` containing:
  - \`api/\`: \`/api/health\`, \`/topology\`, \`/state\`, \`/runners\`, \`/instances\` JSON snapshots from the API.
  - \`processes/\`: \`ps -ef | grep exo\`, \`netstat -an | grep 52\` filtered exo ports.
  - \`memory/\`: \`vm_stat\` (macOS), \`/proc/meminfo\` (Linux), peak/current MLX memory if available.
  - \`logs/\`: best-effort copy of \`~/.local/share/exo/logs\` and \`~/.cache/exo/logs\`.
  - \`manifest.json\`: timestamp, base URL used, host, OS.

### \`exo/main.py\` — diagnostic snapshot loop
- New private \`_diagnostic_snapshot_loop()\` async task started in \`Node.start()\` if \`EXO_DIAGNOSTIC_SNAPSHOT_SECONDS\` parses to a positive int.
- Calls \`_log_diagnostic_snapshot()\` (which logs a structured \`{topology, runners, instances, queue_depth}\` event) on that cadence.
- Invalid string values (e.g. \"15s\") log a warning and disable the loop; non-positive numbers also disable.

### \`exo/master/main.py\`, \`exo/routing/{router,event_router}.py\`, \`exo/shared/logging.py\`, \`exo/worker/runner/{bootstrap,supervisor}.py\` — light instrumentation hooks
- Add structured-log entry/exit points on the master event-apply loop, runner bootstrap, and runner supervisor lifecycle so the snapshot has more context to dump. No behavior changes.

### \`pyproject.toml\` — register the CLI
\`\`\`toml
[project.scripts]
exo-diagnostics = \"exo.diagnostics:main\"
\`\`\`

### Tests
- \`src/exo/shared/tests/test_diagnostic_snapshot_config.py\`: covers (1) invalid \`EXO_DIAGNOSTIC_SNAPSHOT_SECONDS\` falls back to no-op; (2) zero/non-positive values disable the sleep loop entirely.

## Why It Works

Both pieces are read-only / log-only — no behavior change unless explicitly opted in (\`exo-diagnostics\` is a CLI you invoke; \`EXO_DIAGNOSTIC_SNAPSHOT_SECONDS\` defaults unset).

The diagnostic snapshot loop uses \`anyio.sleep\` so it cooperates with the task group cancellation and doesn't leak threads. The fallback paths for invalid input (warn-and-disable rather than crash-and-take-down-the-master) are tested.

The CLI uses standard library only (\`argparse\`, \`subprocess\`, \`urllib\`, \`tarfile\`) so it has no new external dependencies.

## Test Plan

### Automated Testing

\`\`\`
src/exo/shared/tests/test_diagnostic_snapshot_config.py ..
=== 2 passed in 0.26s ===
\`\`\`

\`uv run basedpyright\` and \`uv run ruff check\` both clean.

### Manual Testing

Hardware: 4-node Apple Silicon cluster.

- Ran \`uv run exo-diagnostics collect --output /tmp/diag.tar.gz\`. Tarball contains all expected sections, all API endpoints captured, sysinfo present, existing logs copied. Total size ~600 KB on a normal cluster.
- Set \`EXO_DIAGNOSTIC_SNAPSHOT_SECONDS=30\` on the master and verified periodic structured snapshots appear in master logs. Disabled by setting to \`0\` — no entries.
- Tested invalid value \`EXO_DIAGNOSTIC_SNAPSHOT_SECONDS=15s\`: master logs a single warning and the loop never starts.

## Notes for reviewers

- \`exo-diagnostics\` shells out for sysinfo via \`subprocess.run([...], check=False)\` — failures of any one collector don't break the bundle, the affected section just records its stderr.
- The snapshot loop runs on the master only — workers don't currently emit structured snapshots since the master already aggregates their state.
- The two test cases use \`pytest.MonkeyPatch\` and access the private \`_diagnostic_snapshot_loop\` (with a scoped \`# pyright: ignore[reportPrivateUsage]\`) since the loop is intentionally internal to \`Node\`.