### PR TITLE
fix: Create directory for PID file if it doesn't exist

### DIFF
--- a/src/exo/utils/pidfile.py
+++ b/src/exo/utils/pidfile.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Final
-
 import os
+from typing import Final
 
 from exo_pyo3_bindings import Pidfile, PidfileError
 

--- a/src/exo/utils/pidfile.py
+++ b/src/exo/utils/pidfile.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Final
 
+import os
+
 from exo_pyo3_bindings import Pidfile, PidfileError
 
 from exo.shared.constants import EXO_PID_FILE
@@ -15,6 +17,7 @@ class PidfileLockError(RuntimeError):
 
 def acquire_exo_pidfile() -> Pidfile:
     path = EXO_PID_FILE
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     try:
         pidfile = Pidfile(path, _PIDFILE_MODE)
         pidfile.write()


### PR DESCRIPTION
Ensure the directory for the PID file exists before creating it.

## Motivation

Fixes https://github.com/exo-explore/exo/issues/2074

## Changes

<!-- Describe what you changed in detail -->

## Why It Works

<!-- Explain why your approach solves the problem -->

## Test Plan

### Manual Testing
<!-- Hardware: (e.g., MacBook Pro M1 Max 32GB, Mac Mini M2 16GB, connected via Thunderbolt 4) -->
<!-- What you did: -->
<!-- - -->

### Automated Testing
<!-- Describe changes to automated tests, or how existing tests cover this change -->
<!-- - -->
