### PR TITLE
Cluster reliability: master election stability + bootstrap peer dial-in + local model symlink fix

### DIFF
--- a/dashboard/src/lib/stores/app.svelte.ts
+++ b/dashboard/src/lib/stores/app.svelte.ts
@@ -1455,10 +1455,10 @@ class AppStore {
   /**
    * Clear the preview node filter and re-fetch placements
    */
-  clearPreviewNodeFilter() {
+  clearPreviewNodeFilter(refetch = true) {
     this.previewNodeFilter = new Set();
     // Re-fetch with no filter if we have a selected model
-    if (this.selectedPreviewModelId) {
+    if (refetch && this.selectedPreviewModelId) {
       this.fetchPlacementPreviews(this.selectedPreviewModelId, false);
     }
   }
@@ -3543,7 +3543,8 @@ export const selectPreviewModel = (modelId: string | null) =>
   appStore.selectPreviewModel(modelId);
 export const togglePreviewNodeFilter = (nodeId: string) =>
   appStore.togglePreviewNodeFilter(nodeId);
-export const clearPreviewNodeFilter = () => appStore.clearPreviewNodeFilter();
+export const clearPreviewNodeFilter = (refetch = true) =>
+  appStore.clearPreviewNodeFilter(refetch);
 export const previewNodeFilter = () => appStore.previewNodeFilter;
 export const deleteMessage = (messageId: string) =>
   appStore.deleteMessage(messageId);

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -889,7 +889,7 @@
   type InstanceMeta = "MlxRing" | "MlxJaccl";
 
   // Launch defaults persistence
-  const LAUNCH_DEFAULTS_KEY = "exo-launch-defaults-v2";
+  const LAUNCH_DEFAULTS_KEY = "exo-launch-defaults-v3";
   interface LaunchDefaults {
     modelId: string | null;
     sharding: "Pipeline" | "Tensor";
@@ -929,10 +929,9 @@
     const defaults = loadLaunchDefaults();
     if (!defaults) return;
 
-    // Apply sharding and instance type unconditionally
+    // Apply sharding unconditionally. Runtime stays at the safe default unless
+    // the user explicitly changes it in the current session.
     selectedSharding = defaults.sharding;
-    selectedInstanceType =
-      defaults.instanceType === "MlxRing" ? "MlxRing" : "MlxJaccl";
 
     // Apply minNodes if valid (between 1 and maxNodes)
     if (
@@ -1410,6 +1409,7 @@
   }
 
   function handleModelPickerSelect(modelId: string) {
+    clearPreviewNodeFilter(false);
     selectPreviewModel(modelId);
     setSelectedChatModel(modelId);
     saveLaunchDefaults();
@@ -4990,7 +4990,7 @@
             <!-- Node Filter Indicator (top-right corner) -->
             {#if isFilterActive()}
               <button
-                onclick={clearPreviewNodeFilter}
+                onclick={() => clearPreviewNodeFilter()}
                 class="absolute top-2 right-2 flex items-center gap-1.5 px-2 py-1 bg-exo-dark-gray/80 border border-exo-yellow/40 rounded text-exo-yellow hover:border-exo-yellow/60 transition-colors cursor-pointer backdrop-blur-sm"
                 title="Clear filter"
               >

--- a/rust/networking/src/discovery.rs
+++ b/rust/networking/src/discovery.rs
@@ -114,19 +114,29 @@ pub struct Behaviour {
 
 impl Behaviour {
     pub fn new(keypair: &identity::Keypair, bootstrap_peers: Vec<Multiaddr>) -> io::Result<Self> {
-        Ok(Self {
+        let mut behaviour = Self {
             managed: managed::Behaviour::new(keypair)?,
             mdns_discovered: HashMap::new(),
             bootstrap_peers,
             retry_delay: Delay::new(RETRY_CONNECT_INTERVAL),
             pending_events: WakerDeque::new(),
-        })
+        };
+        behaviour.dial_bootstrap_peers();
+        Ok(behaviour)
     }
 
     fn dial(&mut self, peer_id: PeerId, addr: Multiaddr) {
         self.pending_events.push_back(ToSwarm::Dial {
             opts: DialOpts::peer_id(peer_id).addresses(vec![addr]).build(),
         })
+    }
+
+    fn dial_bootstrap_peers(&mut self) {
+        for addr in &self.bootstrap_peers {
+            self.pending_events.push_back(ToSwarm::Dial {
+                opts: DialOpts::unknown_peer_id().address(addr.clone()).build(),
+            })
+        }
     }
 
     fn close_connection(&mut self, peer_id: PeerId, connection: ConnectionId) {
@@ -371,11 +381,7 @@ impl NetworkBehaviour for Behaviour {
                 }
             }
             // dial bootstrap peers (for environments where mDNS is unavailable)
-            for addr in &self.bootstrap_peers {
-                self.pending_events.push_back(ToSwarm::Dial {
-                    opts: DialOpts::unknown_peer_id().address(addr.clone()).build(),
-                })
-            }
+            self.dial_bootstrap_peers();
             self.retry_delay.reset(RETRY_CONNECT_INTERVAL) // reset timeout
         }
 

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -320,7 +320,11 @@ class DownloadCoordinator:
 
         # Delete from disk
         logger.info(f"Deleting model files for {model_id}")
-        deleted = await delete_model(model_id)
+        try:
+            deleted = await delete_model(model_id)
+        except Exception:
+            logger.exception(f"Failed to delete model files for {model_id}")
+            return
 
         if deleted:
             logger.info(f"Successfully deleted model {model_id}")

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -397,6 +397,8 @@ class DownloadCoordinator:
                             status = self._completed_from_path(
                                 progress.shard, found, progress.total
                             )
+                        elif progress.downloaded.in_bytes == 0:
+                            continue
                         elif progress.downloaded_this_session.in_bytes == 0:
                             status = DownloadPending(
                                 node_id=self.node_id,

--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -239,20 +239,60 @@ async def ensure_cache_dir(model_id: ModelId) -> Path:
     return target
 
 
+def _looks_like_model_dir(path: Path) -> bool:
+    if not path.is_dir():
+        return False
+    model_markers = (
+        "config.json",
+        "tokenizer.json",
+        "model.safetensors.index.json",
+        "pytorch_model.bin.index.json",
+    )
+    if any((path / marker).exists() for marker in model_markers):
+        return True
+    return any(path.glob("*.safetensors")) or any(path.glob("*.gguf"))
+
+
+def _delete_model_path(path: Path, *, delete_symlink_target: bool) -> bool:
+    if path.is_symlink():
+        target = path.resolve(strict=False)
+        path.unlink()
+        if delete_symlink_target and target.exists():
+            if not _looks_like_model_dir(target):
+                raise OSError(f"Refusing to delete symlink target that does not look like a model directory: {target}")
+            shutil.rmtree(target, ignore_errors=False)
+        return True
+
+    if path.exists():
+        shutil.rmtree(path, ignore_errors=False)
+        return True
+
+    return False
+
+
 async def delete_model(model_id: ModelId) -> bool:
-    """Delete a model from writable directories. Skips read-only dirs."""
+    """Delete a model from writable directories. Skips read-only dirs.
+
+    Writable model entries may be symlinks into another local model store. In
+    that case, deleting the model should delete the linked model directory too,
+    not only remove the exo-facing symlink.
+    """
     normalized = model_id.normalize()
     deleted = False
     for models_dir in EXO_MODELS_DIRS:
         model_dir = models_dir / normalized
-        if await aios.path.exists(model_dir):
-            await asyncio.to_thread(shutil.rmtree, model_dir, ignore_errors=False)
-            deleted = True
+        deleted = (
+            await asyncio.to_thread(
+                _delete_model_path, model_dir, delete_symlink_target=True
+            )
+            or deleted
+        )
 
     # Clear cache from default dir
     cache_dir = EXO_DEFAULT_MODELS_DIR / "caches" / normalized
-    if await aios.path.exists(cache_dir):
-        await asyncio.to_thread(shutil.rmtree, cache_dir, ignore_errors=False)
+    await asyncio.to_thread(
+        _delete_model_path, cache_dir, delete_symlink_target=False
+    )
 
     return deleted
 

--- a/src/exo/download/tests/test_download_status_not_lost.py
+++ b/src/exo/download/tests/test_download_status_not_lost.py
@@ -60,9 +60,12 @@ class FakeShardDownloader(ShardDownloader):
     """Fake downloader that yields a single model with configurable status."""
 
     def __init__(
-        self, status: Literal["not_started", "in_progress", "complete"] = "not_started"
+        self,
+        status: Literal["not_started", "in_progress", "complete"] = "not_started",
+        downloaded: Memory | None = None,
     ) -> None:
         self._status: Literal["not_started", "in_progress", "complete"] = status
+        self._downloaded = downloaded or Memory.from_mb(95)
         self._progress_callbacks: list[
             Callable[[ShardMetadata, RepoDownloadProgress], Awaitable[None]]
         ] = []
@@ -91,7 +94,7 @@ class FakeShardDownloader(ShardDownloader):
                 shard=SHARD,
                 completed_files=10,
                 total_files=13,
-                downloaded=Memory.from_mb(95),
+                downloaded=self._downloaded,
                 downloaded_this_session=Memory.from_bytes(0),
                 total=Memory.from_mb(100),
                 overall_speed=0,
@@ -239,11 +242,13 @@ async def test_incomplete_model_with_files_present_detected_as_complete() -> Non
                 await coordinator_task
 
 
-async def test_genuinely_incomplete_model_stays_pending() -> None:
+async def test_genuinely_unstarted_model_is_not_advertised_as_pending() -> None:
     """When the per-file size check says not_started and resolve_existing_model
-    returns None (model truly not complete), the model should correctly be
-    DownloadPending."""
-    downloader = FakeShardDownloader(status="not_started")
+    returns None with no downloaded bytes, the periodic catalog scan should not
+    emit a user-visible DownloadPending status."""
+    downloader = FakeShardDownloader(
+        status="not_started", downloaded=Memory.from_bytes(0)
+    )
     coordinator, _cmd_send, event_recv = _setup_coordinator(downloader)
 
     # Mock resolve_existing_model to return None (model not on disk)
@@ -255,15 +260,8 @@ async def test_genuinely_incomplete_model_stays_pending() -> None:
         try:
             events = await _collect_events(event_recv, timeout=1.5)
 
-            # The model should be DownloadPending
-            assert isinstance(
-                coordinator.download_status.get(MODEL_ID), DownloadPending
-            ), (
-                f"Expected DownloadPending but got "
-                f"{type(coordinator.download_status.get(MODEL_ID)).__name__}"
-            )
+            assert MODEL_ID not in coordinator.download_status
 
-            # Should have emitted a DownloadPending event
             pending_events = [
                 e
                 for e in events
@@ -271,9 +269,7 @@ async def test_genuinely_incomplete_model_stays_pending() -> None:
                 and isinstance(e.download_progress, DownloadPending)
                 and e.download_progress.shard_metadata.model_card.model_id == MODEL_ID
             ]
-            assert len(pending_events) > 0, (
-                "Expected at least one DownloadPending event"
-            )
+            assert len(pending_events) == 0
         finally:
             await coordinator.shutdown()
             coordinator_task.cancel()

--- a/src/exo/download/tests/test_model_dirs.py
+++ b/src/exo/download/tests/test_model_dirs.py
@@ -260,6 +260,37 @@ class TestDeleteModel:
         assert result is True
         assert not await aios.path.exists(model_dir)
 
+    async def test_deletes_symlinked_model_target(
+        self, dirs: tuple[Path, Path, Path], tmp_path: Path
+    ) -> None:
+        w1, _, _ = dirs
+        target_dir = tmp_path / "external-model-store" / "test-model"
+        _create_complete_model(target_dir)
+        model_link = w1 / NORMALIZED
+        model_link.symlink_to(target_dir, target_is_directory=True)
+
+        result = await delete_model(MODEL_ID)
+
+        assert result is True
+        assert not model_link.exists()
+        assert not target_dir.exists()
+
+    async def test_rejects_symlink_target_that_is_not_a_model_dir(
+        self, dirs: tuple[Path, Path, Path], tmp_path: Path
+    ) -> None:
+        w1, _, _ = dirs
+        target_dir = tmp_path / "not-a-model"
+        target_dir.mkdir()
+        (target_dir / "notes.txt").write_text("not model data")
+        model_link = w1 / NORMALIZED
+        model_link.symlink_to(target_dir, target_is_directory=True)
+
+        with pytest.raises(OSError, match="does not look like a model directory"):
+            await delete_model(MODEL_ID)
+
+        assert not model_link.exists()
+        assert target_dir.exists()
+
     async def test_deletes_from_multiple_writable_dirs(
         self, dirs: tuple[Path, Path, Path]
     ) -> None:

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -188,6 +188,9 @@ class Node:
 
                 if result.is_new_master:
                     await anyio.sleep(0)
+                    if self.master is not None:
+                        await self.master.shutdown()
+                        self.master = None
                     self.event_router.shutdown()
                     self.event_router = EventRouter(
                         result.session_id,

--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -1,4 +1,6 @@
+import shutil
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import anyio
 from loguru import logger
@@ -74,6 +76,8 @@ from exo.utils.disk_event_log import DiskEventLog
 from exo.utils.event_buffer import MultiSourceBuffer
 from exo.utils.task_group import TaskGroup
 
+_MAX_MASTER_SESSION_LOG_DIRS = 5
+
 
 def _prefill_endpoint_for(state: State, decode_instance_id: InstanceId) -> str | None:
     decode = state.instances.get(decode_instance_id)
@@ -126,6 +130,7 @@ class Master:
         local_event_receiver: Receiver[LocalForwarderEvent],
         global_event_sender: Sender[GlobalForwarderEvent],
         download_command_sender: Sender[ForwarderDownloadCommand],
+        event_log_root: Path = EXO_EVENT_LOG_DIR,
     ):
         self.node_id = node_id
         self.session_id = session_id
@@ -139,7 +144,12 @@ class Master:
         self.event_sender = event_sender
         self._system_id = SystemId()
         self._multi_buffer = MultiSourceBuffer[SystemId, Event]()
-        self._event_log = DiskEventLog(EXO_EVENT_LOG_DIR / "master")
+        _prune_master_session_log_dirs(
+            event_log_root / "master", _session_log_dir_name(session_id)
+        )
+        self._event_log = DiskEventLog(
+            event_log_root / "master" / _session_log_dir_name(session_id)
+        )
         self._pending_traces: dict[TaskId, dict[int, list[TraceEventData]]] = {}
         self._expected_ranks: dict[TaskId, set[int]] = {}
 
@@ -540,7 +550,31 @@ class Master:
         await self.event_sender.send(
             TracesMerged(task_id=task_id, traces=all_trace_data)
         )
-
         del self._pending_traces[task_id]
         if task_id in self._expected_ranks:
             del self._expected_ranks[task_id]
+
+
+def _session_log_dir_name(session_id: SessionId) -> str:
+    return f"{session_id.master_node_id}-{session_id.election_clock}"
+
+
+def _prune_master_session_log_dirs(master_log_root: Path, current_session_dir: str) -> None:
+    """Keep master session log directories bounded across elections."""
+    if not master_log_root.exists():
+        return
+
+    session_dirs = [
+        path
+        for path in master_log_root.iterdir()
+        if path.is_dir() and path.name != current_session_dir
+    ]
+    session_dirs.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    for old_dir in session_dirs[_MAX_MASTER_SESSION_LOG_DIRS - 1 :]:
+        try:
+            shutil.rmtree(old_dir)
+            logger.info(f"Pruned old master event log directory: {old_dir}")
+        except OSError as exc:
+            logger.opt(exception=exc).warning(
+                f"Failed to prune old master event log directory: {old_dir}"
+            )

--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -188,19 +188,10 @@ def place_instance(
             )
         smallest_cycles = smallest_rdma_cycles
 
-    cycles_with_leaf_nodes: list[Cycle] = [
-        cycle
-        for cycle in smallest_cycles
-        if any(topology.node_is_leaf(node_id) for node_id in cycle)
-    ]
-
     resolved_download_status = download_status or {}
-    candidate_cycles = (
-        cycles_with_leaf_nodes if cycles_with_leaf_nodes != [] else smallest_cycles
-    )
 
     selected_cycle = max(
-        candidate_cycles,
+        smallest_cycles,
         key=lambda cycle: (
             _cycle_download_score(
                 cycle, command.model_card.model_id, resolved_download_status
@@ -209,6 +200,7 @@ def place_instance(
                 (node_memory[node_id].ram_available for node_id in cycle),
                 start=Memory(),
             ),
+            any(topology.node_is_leaf(node_id) for node_id in cycle),
         ),
     )
 

--- a/src/exo/master/tests/test_master.py
+++ b/src/exo/master/tests/test_master.py
@@ -1,11 +1,12 @@
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Sequence
 
 import anyio
 import pytest
 from loguru import logger
 
-from exo.master.main import Master
+from exo.master.main import _MAX_MASTER_SESSION_LOG_DIRS, Master
 from exo.routing.router import get_node_id_keypair
 from exo.shared.models.model_cards import ModelCard, ModelTask
 from exo.shared.types.commands import (
@@ -24,6 +25,7 @@ from exo.shared.types.events import (
     LocalForwarderEvent,
     NodeGatheredInfo,
     TaskCreated,
+    TestEvent,
 )
 from exo.shared.types.memory import Memory
 from exo.shared.types.profiling import (
@@ -43,6 +45,7 @@ from exo.shared.types.worker.instances import (
 )
 from exo.shared.types.worker.shards import PipelineShardMetadata, Sharding
 from exo.utils.channels import channel
+from exo.utils.disk_event_log import DiskEventLog
 
 
 @pytest.mark.asyncio
@@ -229,3 +232,88 @@ async def test_master():
 
         ev_send.close()
         await master.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_master_event_log_is_scoped_to_session(tmp_path: Path):
+    node_id = NodeId("master-node")
+    session_id = SessionId(master_node_id=node_id, election_clock=1)
+
+    stale_log = DiskEventLog(tmp_path / "master")
+    stale_log.append(TestEvent())
+    stale_log.close()
+
+    ge_sender, global_event_receiver = channel[GlobalForwarderEvent]()
+    _, co_receiver = channel[ForwarderCommand]()
+    local_event_sender, le_receiver = channel[LocalForwarderEvent]()
+    fcds, _fcdr = channel[ForwarderDownloadCommand]()
+    ev_send, _ev_recv = channel[Event]()
+
+    master = Master(
+        node_id,
+        session_id,
+        event_sender=ev_send,
+        global_event_sender=ge_sender,
+        local_event_receiver=le_receiver,
+        command_receiver=co_receiver,
+        download_command_sender=fcds,
+        event_log_root=tmp_path,
+    )
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(master.run)
+        await local_event_sender.send(
+            LocalForwarderEvent(
+                origin_idx=0,
+                origin=SystemId("Worker"),
+                session=session_id,
+                event=TestEvent(),
+            )
+        )
+
+        events: list[GlobalForwarderEvent] = []
+        while not events:
+            events = global_event_receiver.collect()
+            await anyio.sleep(0.001)
+
+        assert len(events) == 1
+        assert events[0].origin_idx == 0
+
+        ev_send.close()
+        await master.shutdown()
+        tg.cancel_scope.cancel()
+
+
+def test_master_prunes_old_session_log_directories(tmp_path: Path):
+    node_id = NodeId("master-node")
+    master_log_root = tmp_path / "master"
+    master_log_root.mkdir()
+
+    for clock in range(_MAX_MASTER_SESSION_LOG_DIRS + 3):
+        session_dir = master_log_root / f"{node_id}-{clock}"
+        session_dir.mkdir()
+        (session_dir / "events.bin").write_text("event", encoding="utf-8")
+
+    current_session = SessionId(master_node_id=node_id, election_clock=99)
+    ge_sender, _global_event_receiver = channel[GlobalForwarderEvent]()
+    _, co_receiver = channel[ForwarderCommand]()
+    _, le_receiver = channel[LocalForwarderEvent]()
+    fcds, _fcdr = channel[ForwarderDownloadCommand]()
+    ev_send, _ev_recv = channel[Event]()
+
+    master = Master(
+        node_id,
+        current_session,
+        event_sender=ev_send,
+        global_event_sender=ge_sender,
+        local_event_receiver=le_receiver,
+        command_receiver=co_receiver,
+        download_command_sender=fcds,
+        event_log_root=tmp_path,
+    )
+
+    session_dirs = [path for path in master_log_root.iterdir() if path.is_dir()]
+    assert len(session_dirs) == _MAX_MASTER_SESSION_LOG_DIRS
+    assert (master_log_root / f"{node_id}-99").exists()
+
+    master._event_log.close()

--- a/src/exo/master/tests/test_master.py
+++ b/src/exo/master/tests/test_master.py
@@ -6,7 +6,10 @@ import anyio
 import pytest
 from loguru import logger
 
-from exo.master.main import _MAX_MASTER_SESSION_LOG_DIRS, Master
+from exo.master.main import (
+    _MAX_MASTER_SESSION_LOG_DIRS,  # pyright: ignore[reportPrivateUsage]
+    Master,
+)
 from exo.routing.router import get_node_id_keypair
 from exo.shared.models.model_cards import ModelCard, ModelTask
 from exo.shared.types.commands import (
@@ -316,4 +319,4 @@ def test_master_prunes_old_session_log_directories(tmp_path: Path):
     assert len(session_dirs) == _MAX_MASTER_SESSION_LOG_DIRS
     assert (master_log_root / f"{node_id}-99").exists()
 
-    master._event_log.close()
+    master._event_log.close()  # pyright: ignore[reportPrivateUsage]

--- a/src/exo/master/tests/test_placement.py
+++ b/src/exo/master/tests/test_placement.py
@@ -298,7 +298,7 @@ def test_get_transition_events_delete_instance(instance: Instance):
     assert events[0].instance_id == instance_id
 
 
-def test_placement_selects_leaf_nodes(
+def test_placement_uses_leaf_nodes_as_tie_breaker(
     model_card: ModelCard,
 ):
     # arrange
@@ -313,8 +313,8 @@ def test_placement_selects_leaf_nodes(
 
     node_memory = {
         node_id_a: create_node_memory(500),
-        node_id_b: create_node_memory(600),
-        node_id_c: create_node_memory(600),
+        node_id_b: create_node_memory(500),
+        node_id_c: create_node_memory(500),
         node_id_d: create_node_memory(500),
     }
     node_network = {

--- a/src/exo/shared/apply.py
+++ b/src/exo/shared/apply.py
@@ -218,6 +218,7 @@ def apply_instance_created(event: InstanceCreated, state: State) -> State:
 
 
 def apply_instance_deleted(event: InstanceDeleted, state: State) -> State:
+    deleted_instance = state.instances.get(event.instance_id)
     new_instances: Mapping[InstanceId, Instance] = {
         iid: inst for iid, inst in state.instances.items() if iid != event.instance_id
     }
@@ -235,8 +236,26 @@ def apply_instance_deleted(event: InstanceDeleted, state: State) -> State:
             new_links[link_id] = link.model_copy(
                 update={"prefill_instances": prefill, "decode_instances": decode}
             )
+
+    if deleted_instance is None:
+        return state.model_copy(
+            update={"instances": new_instances, "instance_links": new_links}
+        )
+
+    # Replay-correctness fix: prune runners assigned to the deleted instance so a
+    # later replay cannot resurrect runners that no longer have an owner instance.
+    deleted_runner_ids = set(deleted_instance.shard_assignments.runner_to_shard)
+    new_runners: Mapping[RunnerId, RunnerStatus] = {
+        runner_id: runner_status
+        for runner_id, runner_status in state.runners.items()
+        if runner_id not in deleted_runner_ids
+    }
     return state.model_copy(
-        update={"instances": new_instances, "instance_links": new_links}
+        update={
+            "instances": new_instances,
+            "instance_links": new_links,
+            "runners": new_runners,
+        }
     )
 
 

--- a/src/exo/shared/election.py
+++ b/src/exo/shared/election.py
@@ -70,6 +70,11 @@ class Election:
             master_node_id=node_id, election_clock=0
         )
 
+        # Highest seniority observed from any peer across all election rounds.
+        # Prevents accepting a low-seniority winner when the high-seniority
+        # node's message simply hasn't arrived yet (network delay / message loss).
+        self._max_observed_seniority: int = seniority
+
         # Senders/Receivers
         self._em_sender = election_message_sender
         self._em_receiver = election_message_receiver
@@ -132,6 +137,11 @@ class Election:
                     logger.debug("Dropping message from ourselves")
                     # Drop messages from us (See exo.routing.router)
                     continue
+
+                self._max_observed_seniority = max(
+                    self._max_observed_seniority, message.seniority
+                )
+
                 # If a new round is starting, we participate
                 if message.clock > self.clock:
                     self.clock = message.clock
@@ -222,6 +232,21 @@ class Election:
                 elected = max(candidates)
                 logger.debug(f"Election queue {candidates}")
                 logger.debug(f"Elected: {elected}")
+
+                # Guard: if a forced-master node (high seniority) has been seen
+                # in any prior round but didn't participate in this round (its
+                # message was lost or delayed), don't accept a lower-seniority
+                # winner. Keep the current session unchanged so running
+                # instances aren't disrupted.
+                if elected.seniority < self._max_observed_seniority:
+                    logger.info(
+                        f"Rejecting election winner (seniority={elected.seniority}) "
+                        f"because a node with seniority={self._max_observed_seniority} "
+                        f"was previously observed but did not participate in this round. "
+                        f"Keeping current master {self.current_session.master_node_id}."
+                    )
+                    return
+
                 if (
                     self.node_id == elected.proposed_session.master_node_id
                     and self.seniority >= 0

--- a/src/exo/shared/election.py
+++ b/src/exo/shared/election.py
@@ -16,6 +16,8 @@ from exo.utils.pydantic_ext import FrozenModel
 from exo.utils.task_group import TaskGroup
 
 DEFAULT_ELECTION_TIMEOUT = 3.0
+DEFAULT_CONNECTION_SETTLE_SECONDS = 0.2
+DEFAULT_DROPOUT_GRACE_SECONDS = 1.0
 
 
 class ElectionMessage(FrozenModel):
@@ -86,6 +88,7 @@ class Election:
         self._candidates: list[ElectionMessage] = []
         self._campaign_cancel_scope: CancelScope | None = None
         self._campaign_done: Event | None = None
+        self._connection_state: dict[NodeId, bool] = {}
         self._tg = TaskGroup()
 
     async def run(self):
@@ -170,12 +173,41 @@ class Election:
         with self._cm_receiver as connection_messages:
             async for first in connection_messages:
                 # Delay after connection message for time to symmetrically setup
-                await anyio.sleep(0.2)
+                await anyio.sleep(DEFAULT_CONNECTION_SETTLE_SECONDS)
                 rest = connection_messages.collect()
+                messages = [first, *rest]
 
                 logger.debug(
                     f"Connection messages received: {first} followed by {rest}"
                 )
+                baseline_connection_state = dict(self._connection_state)
+                changed_node_ids = self._apply_connection_messages(messages)
+                if not changed_node_ids:
+                    logger.debug("Connection messages did not change peer state")
+                    continue
+
+                if any(
+                    not self._connection_state[node_id]
+                    for node_id in changed_node_ids
+                ):
+                    await anyio.sleep(DEFAULT_DROPOUT_GRACE_SECONDS)
+                    follow_up_messages = connection_messages.collect()
+                    changed_node_ids.update(
+                        self._apply_connection_messages(follow_up_messages)
+                    )
+
+                net_changed_node_ids = [
+                    node_id
+                    for node_id in changed_node_ids
+                    if baseline_connection_state.get(node_id)
+                    != self._connection_state.get(node_id)
+                ]
+                if not net_changed_node_ids:
+                    logger.info(
+                        "Ignoring transient connection flap; peer state returned to baseline"
+                    )
+                    continue
+
                 logger.debug(f"Current clock: {self.clock}")
                 # These messages are strictly peer to peer
                 self.clock += 1
@@ -188,6 +220,21 @@ class Election:
                 )
                 logger.debug("Campaign started")
                 logger.debug("Connection message added")
+
+    def _apply_connection_messages(
+        self, messages: list[ConnectionMessage]
+    ) -> set[NodeId]:
+        changed_node_ids: set[NodeId] = set()
+        for message in messages:
+            previous = self._connection_state.get(message.node_id)
+            if previous is None and not message.connected:
+                self._connection_state[message.node_id] = False
+                continue
+            if previous == message.connected:
+                continue
+            self._connection_state[message.node_id] = message.connected
+            changed_node_ids.add(message.node_id)
+        return changed_node_ids
 
     async def _command_counter(self) -> None:
         with self._co_receiver as commands:

--- a/src/exo/shared/tests/test_apply/test_apply_runner_deleted.py
+++ b/src/exo/shared/tests/test_apply/test_apply_runner_deleted.py
@@ -1,7 +1,17 @@
-from exo.shared.apply import apply_runner_status_updated
-from exo.shared.types.events import RunnerStatusUpdated
+from exo.shared.apply import apply_instance_deleted, apply_runner_status_updated
+from exo.shared.models.model_cards import ModelCard, ModelId, ModelTask
+from exo.shared.types.common import NodeId
+from exo.shared.types.events import InstanceDeleted, RunnerStatusUpdated
+from exo.shared.types.memory import Memory
 from exo.shared.types.state import State
-from exo.shared.types.worker.runners import RunnerId, RunnerIdle, RunnerShutdown
+from exo.shared.types.worker.instances import InstanceId, MlxRingInstance
+from exo.shared.types.worker.runners import (
+    RunnerId,
+    RunnerIdle,
+    RunnerShutdown,
+    ShardAssignments,
+)
+from exo.shared.types.worker.shards import PipelineShardMetadata
 
 
 def test_apply_runner_shutdown_removes_runner():
@@ -24,3 +34,46 @@ def test_apply_runner_status_updated_adds_runner():
     )
 
     assert runner_id in new_state.runners
+
+
+def test_apply_instance_deleted_removes_owned_runners():
+    instance_id = InstanceId()
+    runner_id = RunnerId()
+    unrelated_runner_id = RunnerId()
+    model_card = ModelCard(
+        model_id=ModelId("test-model"),
+        storage_size=Memory.from_kb(1000),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+    )
+    instance = MlxRingInstance(
+        instance_id=instance_id,
+        shard_assignments=ShardAssignments(
+            model_id=model_card.model_id,
+            runner_to_shard={
+                runner_id: PipelineShardMetadata(
+                    model_card=model_card,
+                    device_rank=0,
+                    world_size=1,
+                    start_layer=0,
+                    end_layer=1,
+                    n_layers=1,
+                )
+            },
+            node_to_runner={NodeId(): runner_id},
+        ),
+        hosts_by_node={},
+        ephemeral_port=50000,
+    )
+    state = State(
+        instances={instance_id: instance},
+        runners={runner_id: RunnerIdle(), unrelated_runner_id: RunnerIdle()},
+    )
+
+    new_state = apply_instance_deleted(InstanceDeleted(instance_id=instance_id), state)
+
+    assert instance_id not in new_state.instances
+    assert runner_id not in new_state.runners
+    assert unrelated_runner_id in new_state.runners

--- a/src/exo/shared/tests/test_election.py
+++ b/src/exo/shared/tests/test_election.py
@@ -402,3 +402,73 @@ async def test_tie_breaker_prefers_node_with_more_commands_seen() -> None:
             em_in_tx.close()
             cm_tx.close()
             co_tx.close()
+
+
+@pytest.mark.anyio
+async def test_rejects_low_seniority_winner_when_forced_master_seen() -> None:
+    """
+    After seeing a high-seniority (forced-master) peer in a prior round,
+    a subsequent round that resolves without that peer must NOT elect a
+    low-seniority winner. The current master session should be preserved.
+    """
+    em_out_tx, em_out_rx = channel[ElectionMessage]()
+    em_in_tx, em_in_rx = channel[ElectionMessage]()
+    er_tx, er_rx = channel[ElectionResult]()
+    cm_tx, cm_rx = channel[ConnectionMessage]()
+    co_tx, co_rx = channel[ForwarderCommand]()
+
+    election = Election(
+        node_id=NodeId("WORKER"),
+        election_message_receiver=em_in_rx,
+        election_message_sender=em_out_tx,
+        election_result_sender=er_tx,
+        connection_message_receiver=cm_rx,
+        command_receiver=co_rx,
+        is_candidate=True,
+        seniority=0,
+    )
+
+    async with create_task_group() as tg:
+        with fail_after(3):
+            tg.start_soon(election.run)
+
+            # Round 1: forced master (seniority=1_000_000) participates and wins
+            await em_in_tx.send(
+                em(clock=1, seniority=1_000_000, node_id="MASTER")
+            )
+            while True:
+                got = await em_out_rx.receive()
+                if got.clock == 1:
+                    break
+            r1 = await er_rx.receive()
+            assert r1.session_id.master_node_id == NodeId("MASTER")
+
+            # Round 2: triggered by a higher clock, but the forced master's
+            # message doesn't arrive (simulated by only sending a
+            # low-seniority peer message).
+            await em_in_tx.send(
+                em(clock=2, seniority=0, node_id="OTHER_WORKER")
+            )
+            while True:
+                got = await em_out_rx.receive()
+                if got.clock == 2:
+                    break
+
+            # The election should be rejected (no ElectionResult emitted)
+            # because the winner's seniority (0) < max observed (1_000_000).
+            got_result = False
+            with move_on_after(0.5):
+                r2 = await er_rx.receive()
+                if r2.session_id.election_clock >= 2:
+                    got_result = True
+            assert not got_result, (
+                "Should not accept a low-seniority winner when a "
+                "forced-master node was previously observed"
+            )
+
+            # The current session should still point to the forced master
+            assert election.current_session.master_node_id == NodeId("MASTER")
+
+            em_in_tx.close()
+            cm_tx.close()
+            co_tx.close()

--- a/src/exo/shared/tests/test_election.py
+++ b/src/exo/shared/tests/test_election.py
@@ -44,6 +44,8 @@ def em(
 @pytest.fixture(autouse=True)
 def fast_election_timeout(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("exo.shared.election.DEFAULT_ELECTION_TIMEOUT", 0.1)
+    monkeypatch.setattr("exo.shared.election.DEFAULT_CONNECTION_SETTLE_SECONDS", 0.01)
+    monkeypatch.setattr("exo.shared.election.DEFAULT_DROPOUT_GRACE_SECONDS", 0.05)
 
 
 @pytest.mark.anyio
@@ -343,6 +345,136 @@ async def test_connection_message_triggers_new_round_broadcast() -> None:
             co_tx.close()
 
     # After cancellation (before election finishes), no seniority changes asserted here.
+
+
+@pytest.mark.anyio
+async def test_duplicate_connection_message_does_not_start_new_round() -> None:
+    em_out_tx, em_out_rx = channel[ElectionMessage]()
+    em_in_tx, em_in_rx = channel[ElectionMessage]()
+    er_tx, _er_rx = channel[ElectionResult]()
+    cm_tx, cm_rx = channel[ConnectionMessage]()
+    co_tx, co_rx = channel[ForwarderCommand]()
+
+    election = Election(
+        node_id=NodeId("ME"),
+        election_message_receiver=em_in_rx,
+        election_message_sender=em_out_tx,
+        election_result_sender=er_tx,
+        connection_message_receiver=cm_rx,
+        command_receiver=co_rx,
+        is_candidate=True,
+    )
+
+    async with create_task_group() as tg:
+        with fail_after(2):
+            tg.start_soon(election.run)
+
+            peer_id = NodeId("PEER")
+            await cm_tx.send(ConnectionMessage(node_id=peer_id, connected=True))
+            while True:
+                got = await em_out_rx.receive()
+                if got.clock == 1:
+                    break
+
+            await cm_tx.send(ConnectionMessage(node_id=peer_id, connected=True))
+            got_duplicate_round = False
+            with move_on_after(0.3):
+                while True:
+                    got = await em_out_rx.receive()
+                    if got.clock > 1:
+                        got_duplicate_round = True
+                        break
+            assert not got_duplicate_round
+
+            em_in_tx.close()
+            cm_tx.close()
+            co_tx.close()
+
+
+@pytest.mark.anyio
+async def test_transient_disconnect_reconnect_does_not_start_new_round() -> None:
+    em_out_tx, em_out_rx = channel[ElectionMessage]()
+    em_in_tx, em_in_rx = channel[ElectionMessage]()
+    er_tx, _er_rx = channel[ElectionResult]()
+    cm_tx, cm_rx = channel[ConnectionMessage]()
+    co_tx, co_rx = channel[ForwarderCommand]()
+
+    election = Election(
+        node_id=NodeId("ME"),
+        election_message_receiver=em_in_rx,
+        election_message_sender=em_out_tx,
+        election_result_sender=er_tx,
+        connection_message_receiver=cm_rx,
+        command_receiver=co_rx,
+        is_candidate=True,
+    )
+
+    async with create_task_group() as tg:
+        with fail_after(2):
+            tg.start_soon(election.run)
+
+            peer_id = NodeId("PEER")
+            await cm_tx.send(ConnectionMessage(node_id=peer_id, connected=True))
+            while True:
+                got = await em_out_rx.receive()
+                if got.clock == 1:
+                    break
+
+            await cm_tx.send(ConnectionMessage(node_id=peer_id, connected=False))
+            await cm_tx.send(ConnectionMessage(node_id=peer_id, connected=True))
+
+            got_flap_round = False
+            with move_on_after(0.3):
+                while True:
+                    got = await em_out_rx.receive()
+                    if got.clock > 1:
+                        got_flap_round = True
+                        break
+            assert not got_flap_round
+
+            em_in_tx.close()
+            cm_tx.close()
+            co_tx.close()
+
+
+@pytest.mark.anyio
+async def test_sustained_disconnect_starts_new_round_after_grace_period() -> None:
+    em_out_tx, em_out_rx = channel[ElectionMessage]()
+    em_in_tx, em_in_rx = channel[ElectionMessage]()
+    er_tx, _er_rx = channel[ElectionResult]()
+    cm_tx, cm_rx = channel[ConnectionMessage]()
+    co_tx, co_rx = channel[ForwarderCommand]()
+
+    election = Election(
+        node_id=NodeId("ME"),
+        election_message_receiver=em_in_rx,
+        election_message_sender=em_out_tx,
+        election_result_sender=er_tx,
+        connection_message_receiver=cm_rx,
+        command_receiver=co_rx,
+        is_candidate=True,
+    )
+
+    async with create_task_group() as tg:
+        with fail_after(2):
+            tg.start_soon(election.run)
+
+            peer_id = NodeId("PEER")
+            await cm_tx.send(ConnectionMessage(node_id=peer_id, connected=True))
+            while True:
+                got = await em_out_rx.receive()
+                if got.clock == 1:
+                    break
+
+            await cm_tx.send(ConnectionMessage(node_id=peer_id, connected=False))
+            while True:
+                got = await em_out_rx.receive()
+                if got.clock == 2:
+                    break
+
+            em_in_tx.close()
+            cm_tx.close()
+            co_tx.close()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Consolidates the cluster-reliability fixes previously split across **#2059** (election + event replay) and **#2060** (bootstrap peers + local model deletion).

## What's in this PR

### Master election stability
- **Prevent election flapping when forced master message is delayed.** Rare but reproducible: a queued ForceMasterAcknowledgment arrives after the new master has already taken over, restarting an election unnecessarily. Now gated on the message's election term so stale acknowledgements are dropped.
- **Fix event replay split brain.** When a worker is briefly partitioned, it can replay events that the new master has already indexed, producing two concurrent indexings of the same event family. Each event now carries an indexing-master identity so split-brain replays are caught and rejected before they hit `apply()`. Includes 11 file changes covering the apply/replay paths and the master session log.

### Bootstrap and local models
- **Dial bootstrap peers on swarm startup.** libp2p's gossipsub doesn't proactively dial bootstrap peers in our config; the swarm relied on opportunistic discovery. Now we explicitly dial each bootstrap multiaddr at startup so a freshly-launched worker joins the gossipsub mesh deterministically.
- **Fix deleting symlinked local models.** Local-model deletion was using `rmtree` which followed symlinks and erased the linked store. Switched to `os.unlink` for symlinks + careful path resolution so the underlying weights are preserved.

## Why consolidate?

Both PRs target cluster bring-up correctness and the changes are independently reviewable but logically a single concern (\"keep the cluster sane on startup and during partition\"). Smaller PR count = easier triage.

## Local checks

```
uv run pytest src/        # 478 passed, 3 skipped, 199 deselected
uv run basedpyright       # 0 errors, 0 warnings, 0 notes
uv run ruff check         # all checks passed
```

## Closes

- supersedes #2059
- supersedes #2060