### PR TITLE
fix: drop undeserializable gossip messages instead of crashing the node

### DIFF
--- a/src/exo/routing/router.py
+++ b/src/exo/routing/router.py
@@ -22,6 +22,7 @@ from exo_pyo3_bindings import (
 )
 from filelock import FileLock
 from loguru import logger
+from pydantic import ValidationError
 
 from exo.shared.constants import EXO_NODE_ID_KEYPAIR
 from exo.utils.channels import Receiver, Sender, channel
@@ -201,7 +202,17 @@ class Router:
                             )
                             continue
                         router = self.topic_routers[topic]
-                        await router.publish_bytes(data)
+                        try:
+                            await router.publish_bytes(data)
+                        except ValidationError as exception:
+                            # A peer on an incompatible version (or a corrupt
+                            # packet) can produce undeserializable payloads.
+                            # Drop the message rather than killing the node.
+                            logger.warning(
+                                f"Dropping undeserializable message on {topic} "
+                                f"from {origin}: {exception.error_count()} validation errors"
+                            )
+                            continue
                     case PyFromSwarm.Connection():
                         message = ConnectionMessage.from_update(from_swarm)
                         logger.trace(

--- a/src/exo/routing/tests/test_router_recv.py
+++ b/src/exo/routing/tests/test_router_recv.py
@@ -1,0 +1,65 @@
+from typing import cast
+
+import anyio
+import pytest
+from exo_pyo3_bindings import NetworkingHandle, PyFromSwarm
+
+from exo.routing.router import Router
+from exo.routing.topics import LOCAL_EVENTS
+from exo.shared.types.common import NodeId, SessionId, SystemId
+from exo.shared.types.events import LocalForwarderEvent, TestEvent
+
+
+def _good_event() -> LocalForwarderEvent:
+    return LocalForwarderEvent(
+        origin_idx=0,
+        origin=SystemId("system-under-test"),
+        session=SessionId(master_node_id=NodeId("master"), election_clock=0),
+        event=TestEvent(),
+    )
+
+
+class _FakeNet:
+    """Yields a fixed sequence of swarm messages, then blocks forever.
+
+    Stands in for NetworkingHandle so we can drive _networking_recv directly.
+    """
+
+    def __init__(self, messages: list[PyFromSwarm]):
+        self._messages = messages
+        self._index = 0
+
+    async def recv(self) -> PyFromSwarm:
+        if self._index < len(self._messages):
+            message = self._messages[self._index]
+            self._index += 1
+            return message
+        await anyio.sleep_forever()
+        raise AssertionError("unreachable")
+
+
+@pytest.mark.asyncio
+async def test_undeserializable_message_is_dropped_not_fatal():
+    """An undeserializable gossip message (e.g. a peer on an incompatible
+    version) must be dropped, leaving the receive loop alive to process
+    subsequent valid messages — not crash the whole node."""
+    good = _good_event()
+    fake_net = _FakeNet(
+        [
+            PyFromSwarm.Message("peer-on-old-version", LOCAL_EVENTS.topic, b"{}"),
+            PyFromSwarm.Message(
+                "peer-on-this-version", LOCAL_EVENTS.topic, LOCAL_EVENTS.serialize(good)
+            ),
+        ]
+    )
+
+    router = Router(cast(NetworkingHandle, cast(object, fake_net)))
+    await router.register_topic(LOCAL_EVENTS)
+    receiver = router.receiver(LOCAL_EVENTS)
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(router._networking_recv)  # pyright: ignore[reportPrivateUsage]
+        with anyio.fail_after(5):
+            received = await receiver.receive()
+        assert received == good
+        task_group.cancel_scope.cancel()


### PR DESCRIPTION
## Problem

A single gossip message that fails to deserialize crashes the **entire receiving node**.

`Router._networking_recv` calls `router.publish_bytes(data)` → `topic.deserialize(data)` → `model_validate_json`. A `pydantic.ValidationError` there propagates out of the `while True` loop, tears down the receive loop's task group, and brings the whole node down (observed as a `BaseExceptionGroup` cascade, with a collateral `BrokenResourceError` in `event_router._ingest`).

In effect this is a **remote node-kill**: any peer publishing a payload this node can't deserialize takes the node offline.

## Why it isn't widely reported

It only triggers on **schema/version skew between nodes on the same network**. Same-version peers serialize identically and round-trip fine (`FrozenModel` uses `alias_generator=to_camel` + `validate_by_name=True`). The failure appears when two nodes run different commits — exactly what happens during a **rolling upgrade** (update one node, the others are briefly still on the old build) or when separate machines are updated at different times. The event/model-card schema changes often enough that any mismatched pair on a LAN will hit it.

Reproduced in the wild with two checkouts ~4 weeks apart auto-discovering each other: each node floods the other with events it rejects (`NodeDownloadProgress`, `NodeGatheredInfo`), and both die — one crash-loops under its launchd `KeepAlive`.

## Fix

Catch `ValidationError` around the per-message `publish_bytes` call, log a warning naming the origin peer, and `continue`.

The outer `except Exception: … raise` added in #1621 (to surface silent shutdowns from e.g. a Rust-layer `ConnectionError` on a closed channel) is **preserved**. This change only makes *untrusted peer input* non-fatal — it narrows the fatal set rather than silencing genuine loop failures.

## Test plan

- New unit test `test_router_recv.py::test_undeserializable_message_is_dropped_not_fatal`: drives a bad message followed by a valid one through `_networking_recv`, asserts the valid one is still delivered (i.e. the loop survived the bad one). Fails without the fix.
- `uv run pytest src/exo/routing/` — 9 passed
- `uv run basedpyright` — 0 errors
- `uv run ruff check` / `ruff format --check` — clean
- Verified live: a patched node stays up and serving (API 200) while logging `Dropping undeserializable message on local_events from <peer>: 83 validation errors`; bringing the stale node up to the same commit eliminated the errors entirely in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)