### PR TITLE
feat: 3-node heterogeneous cluster support (Metal + CUDA)

### DIFF
--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -107,29 +107,65 @@ def _rotate_metal_to_middle(
     cycle: Cycle,
     node_backends: Mapping[NodeId, list[Backend]],
 ) -> Cycle:
-    """Rotate a 3-node Pipeline cycle so the Metal node sits at rank 1 (middle).
+    """Rotate a Pipeline cycle so Metal nodes are evenly spaced between CUDA nodes.
 
-    Ensures all pipeline send/recv go through Metal↔CUDA links (which work)
-    instead of CUDA↔CUDA links (which hang in MLX 0.32.0 ring backend).
+    For 3 nodes: Metal in the middle rank (index 1).
+    For 5+ nodes: Metal nodes distributed to minimize consecutive CUDA↔CUDA links.
+    This avoids CUDA↔CUDA send/recv which hang in MLX 0.32.0 ring backend.
     """
-    if len(cycle) != 3:
+    n = len(cycle)
+    if n < 3:
         return cycle
 
-    for i, node_id in enumerate(cycle):
-        if Backend.MlxMetal in set(node_backends.get(node_id, [])):
-            metal_idx = i
-            break
-    else:
+    metal_indices = [
+        i for i, nid in enumerate(cycle)
+        if Backend.MlxMetal in set(node_backends.get(nid, []))
+    ]
+    if not metal_indices:
         return cycle
 
-    if metal_idx == 1:
-        return cycle
-
+    # Check if Metal nodes are already well-distributed
+    # (no two consecutive CUDA-only spans longer than 1)
     nids = list(cycle.node_ids)
-    if metal_idx == 0:
-        rotated = [nids[2], nids[0], nids[1]]
-    else:
-        rotated = [nids[1], nids[2], nids[0]]
+
+    if n == 3:
+        target = 1  # middle
+        metal_idx = metal_indices[0]
+        if metal_idx == target:
+            return cycle
+        if metal_idx == 0:
+            rotated = [nids[2], nids[0], nids[1]]
+        else:
+            rotated = [nids[1], nids[2], nids[0]]
+        return Cycle(node_ids=rotated)
+
+    # General case: interleave Metal nodes evenly among CUDA nodes
+    metal_nodes = [nids[i] for i in metal_indices]
+    cuda_nodes = [nids[i] for i in range(n) if i not in metal_indices]
+
+    if not cuda_nodes:
+        return cycle  # all Metal, nothing to optimize
+
+    rotated = []
+    cuda_idx = 0
+    metal_idx = 0
+    # Place CUDA nodes, inserting a Metal node between every pair
+    cuda_gap = len(cuda_nodes) / (len(metal_nodes) + 1)
+    next_metal_at = cuda_gap
+    while cuda_idx < len(cuda_nodes) or metal_idx < len(metal_nodes):
+        if metal_idx < len(metal_nodes) and cuda_idx >= round(next_metal_at):
+            rotated.append(metal_nodes[metal_idx])
+            metal_idx += 1
+            next_metal_at += cuda_gap
+        elif cuda_idx < len(cuda_nodes):
+            rotated.append(cuda_nodes[cuda_idx])
+            cuda_idx += 1
+        else:
+            rotated.append(metal_nodes[metal_idx])
+            metal_idx += 1
+
+    if len(rotated) != n:
+        return cycle  # safety fallback
 
     return Cycle(node_ids=rotated)
 
@@ -277,7 +313,7 @@ def place_instance(
     # sits in the middle rank. This ensures all pipeline send/recv operations
     # go through Metal↔CUDA links (which work) instead of CUDA↔CUDA links
     # (which hang in MLX 0.32.0 aarch64 ring backend).
-    if command.sharding == Sharding.Pipeline and len(selected_cycle) == 3:
+    if command.sharding == Sharding.Pipeline and len(selected_cycle) >= 3:
         selected_cycle = _rotate_metal_to_middle(selected_cycle, node_backends)
 
     # Single-node: force Pipeline/Ring (Tensor and Jaccl require multi-node)

--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -103,6 +103,13 @@ def _cycle_download_score(
     )
 
 
+def _rotate_metal_to_middle(
+    cycle: Cycle,
+    node_backends: Mapping[NodeId, list[Backend]],
+) -> Cycle:
+    return cycle
+
+
 def place_instance(
     command: PlaceInstance,
     topology: Topology,
@@ -241,6 +248,13 @@ def place_instance(
             ),
         ),
     )
+
+    # For heterogeneous Metal+CUDA pipeline, rotate the cycle so the Metal node
+    # sits in the middle rank. This ensures all pipeline send/recv operations
+    # go through Metal↔CUDA links (which work) instead of CUDA↔CUDA links
+    # (which hang in MLX 0.32.0 aarch64 ring backend).
+    if command.sharding == Sharding.Pipeline and len(selected_cycle) == 3:
+        selected_cycle = _rotate_metal_to_middle(selected_cycle, node_backends)
 
     # Single-node: force Pipeline/Ring (Tensor and Jaccl require multi-node)
     if len(selected_cycle) == 1:

--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -107,7 +107,31 @@ def _rotate_metal_to_middle(
     cycle: Cycle,
     node_backends: Mapping[NodeId, list[Backend]],
 ) -> Cycle:
-    return cycle
+    """Rotate a 3-node Pipeline cycle so the Metal node sits at rank 1 (middle).
+
+    Ensures all pipeline send/recv go through Metal↔CUDA links (which work)
+    instead of CUDA↔CUDA links (which hang in MLX 0.32.0 ring backend).
+    """
+    if len(cycle) != 3:
+        return cycle
+
+    for i, node_id in enumerate(cycle):
+        if Backend.MlxMetal in set(node_backends.get(node_id, [])):
+            metal_idx = i
+            break
+    else:
+        return cycle
+
+    if metal_idx == 1:
+        return cycle
+
+    nids = list(cycle.node_ids)
+    if metal_idx == 0:
+        rotated = [nids[2], nids[0], nids[1]]
+    else:
+        rotated = [nids[1], nids[2], nids[0]]
+
+    return Cycle(node_ids=rotated)
 
 
 def place_instance(

--- a/src/exo/master/placement_utils.py
+++ b/src/exo/master/placement_utils.py
@@ -355,13 +355,11 @@ def find_ip_prioritised(
         iface.ip_address: iface.interface_type for iface in other_network.interfaces
     }
 
-    # Ring should prioritise fastest connection. As a best-effort, we prioritise TB.
-    # TODO: Profile and get actual connection speeds.
     if ring:
         priority = {
-            "thunderbolt": 0,
+            "ethernet": 0,
             "maybe_ethernet": 1,
-            "ethernet": 2,
+            "thunderbolt": 2,
             "wifi": 3,
             "unknown": 4,
         }

--- a/src/exo/utils/info_gatherer/system_info.py
+++ b/src/exo/utils/info_gatherer/system_info.py
@@ -1,4 +1,5 @@
 import platform
+import re
 import socket
 import sys
 from subprocess import CalledProcessError
@@ -7,6 +8,25 @@ import psutil
 from anyio import run_process
 
 from exo.shared.types.profiling import InterfaceType, NetworkInterfaceInfo
+
+
+def _linux_interface_types() -> dict[str, InterfaceType]:
+    """Infer interface types from names on Linux (no networksetup)."""
+    types: dict[str, InterfaceType] = {}
+    for iface, addrs in psutil.net_if_addrs().items():
+        if iface == "lo" or iface.startswith("docker") or iface.startswith("br-"):
+            continue
+        if iface.startswith("wl"):
+            types[iface] = "wifi"
+        elif re.match(r"enp\d+s\d+f\d+np\d+", iface):
+            types[iface] = "ethernet"
+        elif iface.startswith("en"):
+            types[iface] = "maybe_ethernet"
+        elif iface.startswith("tb"):
+            types[iface] = "thunderbolt"
+        else:
+            types[iface] = "unknown"
+    return types
 
 
 def get_os_version() -> str:
@@ -59,7 +79,7 @@ async def get_friendly_name() -> str:
 async def _get_interface_types_from_networksetup() -> dict[str, InterfaceType]:
     """Parse networksetup -listallhardwareports to get interface types."""
     if sys.platform != "darwin":
-        return {}
+        return _linux_interface_types()
 
     try:
         result = await run_process(["networksetup", "-listallhardwareports"])

--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -204,11 +204,11 @@ class TcpRelay:
 
         dtype_map = {
             np.float32: 0, np.float16: 1, np.int32: 2, np.int64: 3,
-            np.bool_: 4, np.uint8: 5,
+            np.bool_: 4, np.uint8: 5, np.bfloat16: 6,
         }
         dtype_code = dtype_map.get(x_np.dtype.type, 0)
 
-        data = x_np.astype(np.float32).tobytes()
+        data = x_np.tobytes()
         header = struct.pack("!IIIQ", len(x_np.shape), dtype_code, x_np.dtype.itemsize, len(data))
         shape_data = struct.pack(f"!{len(x_np.shape)}I", *x_np.shape)
 
@@ -258,12 +258,17 @@ class TcpRelay:
                 raise ConnectionError(f"TcpRelay accept from rank {src} timed out after 120 attempts")
 
         header = self._recv_exact(sock, 20)
-        ndim, _dtype_code, _itemsize, total = struct.unpack("!IIIQ", header)
+        ndim, dtype_code, itemsize, total = struct.unpack("!IIIQ", header)
         shape_data = self._recv_exact(sock, ndim * 4)
         shape = struct.unpack(f"!{ndim}I", shape_data)
 
         data = self._recv_exact(sock, total)
-        arr = np.frombuffer(data, dtype=np.float32).reshape(shape)
+        dtype_rmap = {
+            0: np.float32, 1: np.float16, 2: np.int32, 3: np.int64,
+            4: np.bool_, 5: np.uint8, 6: np.bfloat16,
+        }
+        np_dtype = dtype_rmap.get(dtype_code, np.float32)
+        arr = np.frombuffer(data, dtype=np_dtype).reshape(shape)
         return mx.array(arr)
 
     @staticmethod

--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -154,7 +154,6 @@ class TcpRelay:
                     s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
                     s.settimeout(3.0)
                     s.connect((ip, peer_port))
-                    # Send RST on close instead of FIN — server won't accept this
                     s.setsockopt(_socket.SOL_SOCKET, _socket.SO_LINGER,
                                  _struct.pack("ii", 1, 0))
                     s.close()
@@ -245,6 +244,19 @@ class TcpRelay:
                     self._server_socket.settimeout(5.0)
                     sock, _ = self._server_socket.accept()
                     self._server_socket.settimeout(120.0)
+                    # Probe for valid data — if the peer sent nothing, it's a
+                    # stale connection from the CUDA-detection probe (RST).
+                    # Discard it and accept again.
+                    sock.settimeout(2.0)
+                    try:
+                        peek = sock.recv(1, _socket.MSG_PEEK)
+                        if not peek:
+                            sock.close()
+                            continue
+                    except Exception:
+                        sock.close()
+                        continue
+                    sock.settimeout(120.0)
                     self._connections[src] = sock
                     break
                 except _socket.timeout:

--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -126,8 +126,8 @@ class TcpRelay:
         self.rank = int(os.environ.get("MLX_RANK", "0"))
         self.world_size = len(hosts)
 
-        # For direct TCP, use a dedicated port per rank to avoid conflicts
-        self._port_base = 40000
+        # Port configurable via env var, default 40000
+        self._port_base = int(os.environ.get("MLX_TCPRELAY_PORT", "40000"))
         self._tcp_port = self._port_base + self.rank
 
         # Build peer IP map: peer_ips[rank] = actual IP from hostfile
@@ -151,6 +151,14 @@ class TcpRelay:
             self._cuda_peers = {self.rank}
         else:
             self._cuda_peers = set()
+
+        # Dtype serialization maps (built once)
+        import numpy as _np
+        self._DTYPE_TO_CODE = {
+            _np.float32: 0, _np.float16: 1, _np.int32: 2, _np.int64: 3,
+            _np.bool_: 4, _np.uint8: 5, _np.bfloat16: 6,
+        }
+        self._CODE_TO_DTYPE = {v: k for k, v in self._DTYPE_TO_CODE.items()}
 
         self._server_socket: _socket.socket | None = None
         self._connections: dict[int, _socket.socket] = {}
@@ -193,10 +201,10 @@ class TcpRelay:
 
         import time
         last_err = None
-        for attempt in range(120):
+        for attempt in range(60):
             try:
                 sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
-                sock.settimeout(120.0)
+                sock.settimeout(60.0)
                 sock.connect((peer_ip, peer_port))
                 self._connections[dst_rank] = sock
                 return sock
@@ -205,7 +213,7 @@ class TcpRelay:
                 sock.close()
                 if attempt == 0 or attempt % 10 == 9:
                     from exo.worker.runner.bootstrap import logger
-                    logger.warning(f"TcpRelay connect({peer_ip}:{peer_port}) attempt {attempt+1}/120: {e}")
+                    logger.warning(f"TcpRelay connect({peer_ip}:{peer_port}) attempt {attempt+1}/60: {e}")
                 time.sleep(1)
         raise ConnectionError(f"Could not connect to rank {dst_rank} at {peer_ip}:{peer_port}") from last_err
 
@@ -218,11 +226,7 @@ class TcpRelay:
         x_np = np.array(x)
         mx.eval(x)
 
-        dtype_map = {
-            np.float32: 0, np.float16: 1, np.int32: 2, np.int64: 3,
-            np.bool_: 4, np.uint8: 5, np.bfloat16: 6,
-        }
-        dtype_code = dtype_map.get(x_np.dtype.type, 0)
+        dtype_code = self._DTYPE_TO_CODE.get(x_np.dtype.type, 0)
 
         data = x_np.tobytes()
         header = struct.pack("!IIIQ", len(x_np.shape), dtype_code, x_np.dtype.itemsize, len(data))
@@ -268,10 +272,10 @@ class TcpRelay:
                 except _socket.timeout:
                     if attempt % 10 == 0:
                         from exo.worker.runner.bootstrap import logger
-                        logger.warning(f"TcpRelay accept from rank {src} attempt {attempt+1}/120 timeout")
+                        logger.warning(f"TcpRelay accept from rank {src} attempt {attempt+1}/20 timeout")
                     time.sleep(1)
             else:
-                raise ConnectionError(f"TcpRelay accept from rank {src} timed out after 120 attempts")
+                raise ConnectionError(f"TcpRelay accept from rank {src} timed out after 20 attempts")
 
         header = self._recv_exact(sock, 20)
         ndim, dtype_code, itemsize, total = struct.unpack("!IIIQ", header)
@@ -279,11 +283,7 @@ class TcpRelay:
         shape = struct.unpack(f"!{ndim}I", shape_data)
 
         data = self._recv_exact(sock, total)
-        dtype_rmap = {
-            0: np.float32, 1: np.float16, 2: np.int32, 3: np.int64,
-            4: np.bool_, 5: np.uint8, 6: np.bfloat16,
-        }
-        np_dtype = dtype_rmap.get(dtype_code, np.float32)
+        np_dtype = self._CODE_TO_DTYPE.get(dtype_code, np.float32)
         arr = np.frombuffer(data, dtype=np_dtype).reshape(shape)
         return mx.array(arr)
 

--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -1,3 +1,4 @@
+import atexit as _atexit
 import socket as _socket
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator
@@ -166,6 +167,21 @@ class TcpRelay:
         self._server_socket.bind(("0.0.0.0", self._tcp_port))
         self._server_socket.listen(self.world_size)
         self._server_socket.settimeout(120.0)
+        _atexit.register(self.close)
+
+    def close(self) -> None:
+        for sock in self._connections.values():
+            try:
+                sock.close()
+            except Exception:
+                pass
+        self._connections.clear()
+        if self._server_socket is not None:
+            try:
+                self._server_socket.close()
+            except Exception:
+                pass
+            self._server_socket = None
 
     def _connect_to(self, dst_rank: int) -> _socket.socket:
         if dst_rank in self._connections:
@@ -273,13 +289,15 @@ class TcpRelay:
 
     @staticmethod
     def _recv_exact(sock: _socket.socket, n: int) -> bytes:
-        data = b""
-        while len(data) < n:
-            chunk = sock.recv(min(n - len(data), 65536))
+        buf = bytearray(n)
+        view = memoryview(buf)
+        while view:
+            chunk = sock.recv(min(view.nbytes, 65536))
             if not chunk:
                 raise ConnectionError("Connection closed")
-            data += chunk
-        return data
+            view[:len(chunk)] = chunk
+            view = view[len(chunk):]
+        return bytes(buf)
 
 
 def flush_prefill_sends() -> None:

--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -141,25 +141,15 @@ class TcpRelay:
 
         # CUDA rank detection: self status from device check.
         self._is_cuda = _is_cuda_device()
-        # Probe peers to find CUDA nodes. Use RST-after-connect to avoid
-        # creating a connection that the server's accept() would pick up.
-        self._cuda_peers: set[int] = set()
-        if self._is_cuda:
-            self._cuda_peers.add(self.rank)  # self
-            for i, ip in enumerate(self.peer_ips):
-                if i == self.rank or ip == "0.0.0.0":
-                    continue
-                peer_port = self._port_base + i
-                try:
-                    s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
-                    s.settimeout(3.0)
-                    s.connect((ip, peer_port))
-                    s.setsockopt(_socket.SOL_SOCKET, _socket.SO_LINGER,
-                                 _struct.pack("ii", 1, 0))
-                    s.close()
-                    self._cuda_peers.add(i)
-                except Exception:
-                    pass
+        # Determine CUDA peers using env var set by utils_mlx.py,
+        # or fallback to self-only (conservative).
+        cuda_ranks_str = os.environ.get("MLX_CUDA_RANKS", "")
+        if cuda_ranks_str:
+            self._cuda_peers: set[int] = set(int(r) for r in cuda_ranks_str.split(",") if r.strip())
+        elif self._is_cuda:
+            self._cuda_peers = {self.rank}
+        else:
+            self._cuda_peers = set()
 
         self._server_socket: _socket.socket | None = None
         self._connections: dict[int, _socket.socket] = {}

--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -1,3 +1,4 @@
+import socket as _socket
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator
 from functools import partial
@@ -70,12 +71,218 @@ if TYPE_CHECKING:
 
 
 _pending_prefill_sends: list[tuple[mx.array, int, mx.distributed.Group]] = []
+_tcp_relay: "TcpRelay | None" = None
+
+
+def _is_cuda_device() -> bool:
+    """Check if the current MLX device is CUDA (Linux GPU)."""
+    import platform
+    if platform.system() != "Linux":
+        return False
+    return mx.default_device().type == mx.DeviceType.gpu
+
+
+def _get_tcp_relay() -> "TcpRelay":
+    global _tcp_relay
+    if _tcp_relay is None:
+        _tcp_relay = TcpRelay()
+    return _tcp_relay
+
+
+class TcpRelay:
+    """Custom TCP-based send/recv to bypass MLX's broken CUDA send/recv.
+
+    Uses the IP addresses from the MLX ring hostfile but with raw TCP sockets
+    for data transfer. The MLX ring backend is still used for collective ops
+    (all_gather, all_sum) which work correctly.
+    """
+
+    def __init__(self) -> None:
+        import json
+        import os
+        import struct as _struct
+
+        # The MLX_HOSTFILE may be a deleted tempfile. Try MLX_HOSTS_JSON first.
+        hosts_json = os.environ.get("MLX_HOSTS_JSON")
+        if hosts_json:
+            hosts = json.loads(hosts_json)
+        else:
+            hostfile = os.environ.get("MLX_HOSTFILE", "")
+            if not hostfile:
+                raise RuntimeError("Neither MLX_HOSTFILE nor MLX_HOSTS_JSON set")
+            try:
+                with open(hostfile) as f:
+                    hosts = json.loads(f.read())
+            except FileNotFoundError:
+                raise RuntimeError(
+                    "MLX_HOSTFILE was deleted (tempdir cleanup). "
+                    "Set MLX_HOSTS_JSON in utils_mlx.py."
+                )
+
+        if isinstance(hosts, str):
+            hosts = json.loads(hosts)
+
+        self.rank = int(os.environ.get("MLX_RANK", "0"))
+        self.world_size = len(hosts)
+
+        # For direct TCP, use a dedicated port per rank to avoid conflicts
+        self._port_base = 40000
+        self._tcp_port = self._port_base + self.rank
+
+        # Build peer IP map: peer_ips[rank] = actual IP from hostfile
+        # In each rank's hostfile, self is "0.0.0.0" and others have real IPs.
+        self.peer_ips: list[str] = []
+        for h in hosts:
+            if isinstance(h, dict):
+                ip = h.get("ip", h.get("address", ""))
+            else:
+                ip = str(h).split(":")[0]  # "192.168.177.11:65392" → "192.168.177.11"
+            self.peer_ips.append(ip)
+
+        # CUDA rank detection: self status from device check.
+        self._is_cuda = _is_cuda_device()
+        # Probe peers to find CUDA nodes. Use RST-after-connect to avoid
+        # creating a connection that the server's accept() would pick up.
+        self._cuda_peers: set[int] = set()
+        if self._is_cuda:
+            self._cuda_peers.add(self.rank)  # self
+            for i, ip in enumerate(self.peer_ips):
+                if i == self.rank or ip == "0.0.0.0":
+                    continue
+                peer_port = self._port_base + i
+                try:
+                    s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+                    s.settimeout(3.0)
+                    s.connect((ip, peer_port))
+                    # Send RST on close instead of FIN — server won't accept this
+                    s.setsockopt(_socket.SOL_SOCKET, _socket.SO_LINGER,
+                                 _struct.pack("ii", 1, 0))
+                    s.close()
+                    self._cuda_peers.add(i)
+                except Exception:
+                    pass
+
+        self._server_socket: _socket.socket | None = None
+        self._connections: dict[int, _socket.socket] = {}
+
+    def is_cuda_to_cuda(self, dst_rank: int) -> bool:
+        """Check if both self and dst_rank are CUDA."""
+        return self._is_cuda and dst_rank in self._cuda_peers
+
+    def _ensure_server(self) -> None:
+        if self._server_socket is not None:
+            return
+        self._server_socket = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+        self._server_socket.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+        self._server_socket.bind(("0.0.0.0", self._tcp_port))
+        self._server_socket.listen(self.world_size)
+        self._server_socket.settimeout(120.0)
+
+    def _connect_to(self, dst_rank: int) -> _socket.socket:
+        if dst_rank in self._connections:
+            return self._connections[dst_rank]
+
+        peer_ip = self.peer_ips[dst_rank]
+        assert peer_ip != "0.0.0.0", f"Cannot connect to self (rank {dst_rank})"
+        peer_port = self._port_base + dst_rank
+
+        import time
+        last_err = None
+        for attempt in range(120):
+            try:
+                sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+                sock.settimeout(120.0)
+                sock.connect((peer_ip, peer_port))
+                self._connections[dst_rank] = sock
+                return sock
+            except Exception as e:
+                last_err = e
+                sock.close()
+                if attempt == 0 or attempt % 10 == 9:
+                    from exo.worker.runner.bootstrap import logger
+                    logger.warning(f"TcpRelay connect({peer_ip}:{peer_port}) attempt {attempt+1}/120: {e}")
+                time.sleep(1)
+        raise ConnectionError(f"Could not connect to rank {dst_rank} at {peer_ip}:{peer_port}") from last_err
+
+    def send(self, x: mx.array, dst: int) -> mx.array:
+        """Send array to dst rank via TCP."""
+        import struct
+
+        import numpy as np
+
+        x_np = np.array(x)
+        mx.eval(x)
+
+        dtype_map = {
+            np.float32: 0, np.float16: 1, np.int32: 2, np.int64: 3,
+            np.bool_: 4, np.uint8: 5,
+        }
+        dtype_code = dtype_map.get(x_np.dtype.type, 0)
+
+        data = x_np.astype(np.float32).tobytes()
+        header = struct.pack("!IIIQ", len(x_np.shape), dtype_code, x_np.dtype.itemsize, len(data))
+        shape_data = struct.pack(f"!{len(x_np.shape)}I", *x_np.shape)
+
+        self._ensure_server()
+        sock = self._connect_to(dst)
+        sock.sendall(header + shape_data + data)
+        return x
+
+    def recv_like(self, ref: mx.array, src: int) -> mx.array:
+        """Recv array from src rank via TCP."""
+        import struct
+
+        import numpy as np
+
+        self._ensure_server()
+
+        if src in self._connections:
+            sock = self._connections[src]
+        else:
+            import time
+            for attempt in range(120):
+                try:
+                    self._server_socket.settimeout(5.0)
+                    sock, _ = self._server_socket.accept()
+                    self._server_socket.settimeout(120.0)
+                    self._connections[src] = sock
+                    break
+                except _socket.timeout:
+                    if attempt % 10 == 0:
+                        from exo.worker.runner.bootstrap import logger
+                        logger.warning(f"TcpRelay accept from rank {src} attempt {attempt+1}/120 timeout")
+                    time.sleep(1)
+            else:
+                raise ConnectionError(f"TcpRelay accept from rank {src} timed out after 120 attempts")
+
+        header = self._recv_exact(sock, 20)
+        ndim, _dtype_code, _itemsize, total = struct.unpack("!IIIQ", header)
+        shape_data = self._recv_exact(sock, ndim * 4)
+        shape = struct.unpack(f"!{ndim}I", shape_data)
+
+        data = self._recv_exact(sock, total)
+        arr = np.frombuffer(data, dtype=np.float32).reshape(shape)
+        return mx.array(arr)
+
+    @staticmethod
+    def _recv_exact(sock: _socket.socket, n: int) -> bytes:
+        data = b""
+        while len(data) < n:
+            chunk = sock.recv(min(n - len(data), 65536))
+            if not chunk:
+                raise ConnectionError("Connection closed")
+            data += chunk
+        return data
 
 
 def flush_prefill_sends() -> None:
     for output, dst, group in _pending_prefill_sends:
-        sent = mx.distributed.send(output, dst, group=group)
-        mx.async_eval(sent)
+        if _is_cuda_device() and _get_tcp_relay().is_cuda_to_cuda(dst):
+            relay = _get_tcp_relay()
+            relay.send(output, dst)
+        else:
+            sent = mx.distributed.send(output, dst, group=group)
+            mx.async_eval(sent)
     _pending_prefill_sends.clear()
 
 
@@ -131,11 +338,15 @@ class PipelineFirstLayer(CustomMlxLayer):
 
     def __call__(self, x: mx.array, *args: object, **kwargs: object) -> mx.array:
         if self.r != 0:
-            # We want to avoid GPU timeout errors by evalling the distributed operation
-            # so that it stays on CPU, which does not have a timeout.
             mx.eval(x)
-            x = mx.distributed.recv_like(x, (self.r - 1), group=self.group)
-            mx.eval(x)
+            src = self.r - 1
+            if _is_cuda_device() and _get_tcp_relay().is_cuda_to_cuda(src):
+                relay = _get_tcp_relay()
+                x = relay.recv_like(x, src)
+                mx.eval(x)
+            else:
+                x = mx.distributed.recv_like(x, src, group=self.group)
+                mx.eval(x)
         return self.original_layer(x, *args, **kwargs)
 
 
@@ -161,23 +372,22 @@ class PipelineLastLayer(CustomMlxLayer):
         ).arguments.get("cache", None)
 
         output: mx.array = self.original_layer(x, *args, **kwargs)
-
-        # Eval layer output to materialize it before send — this splits the graph
-        # so the send is isolated and the receiving rank's recv can complete.
         mx.eval(output)
 
         if self.r != self.s - 1:
+            dst = (self.r + 1) % self.s
             if self.queue_sends:
                 _pending_prefill_sends.append(
-                    (output, (self.r + 1) % self.s, self.group)
+                    (output, dst, self.group)
                 )
+            elif _is_cuda_device() and _get_tcp_relay().is_cuda_to_cuda(dst):
+                relay = _get_tcp_relay()
+                relay.send(output, dst)
             else:
                 output = mx.distributed.send(
-                    output, (self.r + 1) % self.s, group=self.group
+                    output, dst, group=self.group
                 )
             if cache is not None:
-                # CacheList (used by MLA models like DeepSeekV32, GLM MoE DSA)
-                # doesn't have .keys directly; access via first sub-cache.
                 _cache = cache[0] if hasattr(cache, "caches") else cache  # type: ignore
                 if hasattr(_cache, "keys"):  # pyright: ignore[reportAny]
                     _cache.keys = mx.depends(_cache.keys, output)  # type: ignore

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -372,6 +372,11 @@ def prefill(
     set_pipeline_queue_sends(model, queue_sends=False)
     set_pipeline_prefill(model, is_prefill=False)
 
+    # Barrier after prefill to prevent ranks from entering generation (all_gather)
+    # while other ranks are still in prefill (skip all_gather).
+    if is_pipeline:
+        mx_barrier(group)
+
     # stream_generate added 1 extra generated token to the cache, so we should trim it.
     # Because of needing to roll back arrays cache, we will generate on 2 tokens so trim 1 more.
     pre_gen = snapshots[-2] if has_ssm else None

--- a/src/exo/worker/engines/mlx/patches/__init__.py
+++ b/src/exo/worker/engines/mlx/patches/__init__.py
@@ -1,3 +1,4 @@
+from exo.worker.engines.mlx.patches.cuda_compat import apply_cuda_compat_patches
 from exo.worker.engines.mlx.patches.opt_batch_gen import apply_batch_gen_patch
 from exo.worker.engines.mlx.patches.standard_yarn_rope import patch_yarn_rope
 
@@ -9,5 +10,6 @@ def apply_mlx_patches() -> None:
     if _applied:
         return
     _applied = True
+    apply_cuda_compat_patches()
     patch_yarn_rope()
     apply_batch_gen_patch()

--- a/src/exo/worker/engines/mlx/patches/cuda_compat.py
+++ b/src/exo/worker/engines/mlx/patches/cuda_compat.py
@@ -1,0 +1,24 @@
+"""CUDA compatibility patches for MLX on Linux.
+
+MLX on Linux CUDA has some API differences from macOS Metal.
+This module provides shims to bridge those gaps.
+"""
+
+import sys
+
+import mlx.core as mx
+
+
+def apply_cuda_compat_patches() -> None:
+    """Apply MLX CUDA compatibility patches.
+
+    These patches are only applied on Linux systems where MLX uses the CUDA backend.
+    They are no-ops on macOS or CPU-only Linux.
+    """
+    if sys.platform == "darwin":
+        return
+
+    # mlx-lm expects new_thread_local_stream, but Linux CUDA MLX exposes new_stream.
+    # Patch mx to provide the expected API.
+    if not hasattr(mx, "new_thread_local_stream") and hasattr(mx, "new_stream"):
+        mx.new_thread_local_stream = mx.new_stream  # type: ignore[attr-defined]

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -287,10 +287,11 @@ def shard_and_load(
         _hosts = _json.loads(hosts_json)
         _my_rank = int(os.environ.get("MLX_RANK", "0"))
         for i, h in enumerate(_hosts):
-            ip = str(h).split(":")[0] if not isinstance(h, dict) else h.get("ip", "")
-            if ip == "0.0.0.0":
-                _cuda_ranks.append(str(i))
+            if i == _my_rank:
+                if _is_cuda:
+                    _cuda_ranks.append(str(i))
                 continue
+            ip = str(h).split(":")[0] if not isinstance(h, dict) else h.get("ip", "")
             peer_port = 40000 + i
             try:
                 s = _sock.socket(_sock.AF_INET, _sock.SOCK_STREAM)

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -120,7 +120,7 @@ def mlx_distributed_init(
 
                 group = mx.distributed.init(backend="ring", strict=True)
 
-                # Eagerly start TcpRelay server on CUDA nodes so peers can probe
+                # Eagerly start TcpRelay server on CUDA nodes
                 import platform
                 is_linux_gpu = platform.system() == "Linux" and mx.default_device().type == mx.DeviceType.gpu
                 logger.info(f"CUDA check: os={platform.system()}, device={mx.default_device()}, is_linux_gpu={is_linux_gpu}")

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -274,6 +274,36 @@ def shard_and_load(
 
     logger.info(f"Group size: {group.size()}, group rank: {group.rank()}")
 
+    # Probe peers' TcpRelay ports to determine CUDA ranks (non-invasive).
+    # TcpRelay servers are started eagerly during distributed init.
+    import platform as _plat
+    import socket as _sock
+    import struct as _struct
+    _is_cuda = _plat.system() == "Linux" and mx.default_device().type == mx.DeviceType.gpu
+    _cuda_ranks = []
+    if _is_cuda:
+        hosts_json = os.environ.get("MLX_HOSTS_JSON", "[]")
+        import json as _json
+        _hosts = _json.loads(hosts_json)
+        _my_rank = int(os.environ.get("MLX_RANK", "0"))
+        for i, h in enumerate(_hosts):
+            ip = str(h).split(":")[0] if not isinstance(h, dict) else h.get("ip", "")
+            if ip == "0.0.0.0":
+                _cuda_ranks.append(str(i))
+                continue
+            peer_port = 40000 + i
+            try:
+                s = _sock.socket(_sock.AF_INET, _sock.SOCK_STREAM)
+                s.settimeout(2.0)
+                s.connect((ip, peer_port))
+                s.setsockopt(_sock.SOL_SOCKET, _sock.SO_LINGER, _struct.pack("ii", 1, 0))
+                s.close()
+                _cuda_ranks.append(str(i))
+            except Exception:
+                pass
+    os.environ["MLX_CUDA_RANKS"] = ",".join(_cuda_ranks)
+    logger.info(f"CUDA ranks probed: {_cuda_ranks}")
+
     match shard_metadata:
         case TensorShardMetadata():
             logger.info(f"loading model from {model_path} with tensor parallelism")

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -793,29 +793,22 @@ def mlx_force_oom(size: int = 200000) -> None:
     mx.eval(f)
 
 
-def set_wired_limit_for_model(model_size: Memory):
-    """
-    A context manager to temporarily change the wired limit.
-
-    Note, the wired limit should not be changed during an async eval.  If an
-    async eval could be running pass in the streams to synchronize with prior
-    to exiting the context manager.
-    """
-    if not mx.metal.is_available():
-        return
-
-    max_rec_size = Memory.from_bytes(
-        int(mx.device_info()["max_recommended_working_set_size"])
-    )
-    if model_size > 0.9 * max_rec_size:
-        logger.warning(
-            f"Generating with a model that requires {model_size.in_float_mb:.1f} MB "
-            f"which is close to the maximum recommended size of {max_rec_size.in_float_mb:.1f} "
-            "MB. This can be slow. See the documentation for possible work-arounds: "
-            "https://github.com/ml-explore/mlx-lm/tree/main#large-models"
+def set_wired_limit_for_model(model_size: Memory) -> None:
+    if mx.metal.is_available():
+        max_rec_size = Memory.from_bytes(
+            int(mx.device_info()["max_recommended_working_set_size"])
         )
-    mx.set_wired_limit(max_rec_size.in_bytes)
-    logger.info(f"Wired limit set to {max_rec_size}.")
+        if model_size > 0.9 * max_rec_size:
+            logger.warning(
+                f"Generating with a model that requires {model_size.in_float_mb:.1f} MB "
+                f"which is close to the maximum recommended size of {max_rec_size.in_float_mb:.1f} "
+                "MB. This can be slow. See the documentation for possible work-arounds: "
+                "https://github.com/ml-explore/mlx-lm/tree/main#large-models"
+            )
+        mx.set_wired_limit(max_rec_size.in_bytes)
+        logger.info(f"Wired limit set to {max_rec_size}.")
+    elif hasattr(mx, "cuda") and mx.cuda.is_available():
+        logger.info("CUDA backend active — skipping Metal wired limit.")
 
 
 def mlx_cleanup(

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -114,10 +114,24 @@ def mlx_distributed_init(
                 )
 
                 os.environ["MLX_HOSTFILE"] = coordination_file
+                os.environ["MLX_HOSTS_JSON"] = hosts_json
                 os.environ["MLX_RANK"] = str(rank)
                 # os.environ["MLX_RING_VERBOSE"] = "1"  # NOTE: we don't use it enough to care (turn on again if need to)
 
                 group = mx.distributed.init(backend="ring", strict=True)
+
+                # Eagerly start TcpRelay server on CUDA nodes so peers can probe
+                import platform
+                is_linux_gpu = platform.system() == "Linux" and mx.default_device().type == mx.DeviceType.gpu
+                logger.info(f"CUDA check: os={platform.system()}, device={mx.default_device()}, is_linux_gpu={is_linux_gpu}")
+                if is_linux_gpu:
+                    try:
+                        from exo.worker.engines.mlx.auto_parallel import _get_tcp_relay
+                        relay = _get_tcp_relay()
+                        relay._ensure_server()
+                        logger.info(f"CUDA TcpRelay server started on port {relay._tcp_port}")
+                    except Exception as e:
+                        logger.error(f"Failed to start TcpRelay: {e}")
 
             case MlxJacclInstance(
                 jaccl_devices=jaccl_devices, jaccl_coordinators=jaccl_coordinators

--- a/src/exo/worker/runner/bootstrap.py
+++ b/src/exo/worker/runner/bootstrap.py
@@ -1,5 +1,6 @@
 import os
 import resource
+import sys
 import traceback
 from dataclasses import dataclass
 from typing import Self, cast
@@ -51,12 +52,14 @@ def entrypoint(
     resource.setrlimit(resource.RLIMIT_NOFILE, (min(max(soft, 2048), hard), hard))
 
     fast_synch_override = os.environ.get("EXO_FAST_SYNCH")
-    if fast_synch_override == "false":
-        os.environ["MLX_METAL_FAST_SYNCH"] = "0"
+    if sys.platform == "darwin":
+        if fast_synch_override == "false":
+            os.environ["MLX_METAL_FAST_SYNCH"] = "0"
+        else:
+            os.environ["MLX_METAL_FAST_SYNCH"] = "1"
+        logger.info(f"Fast synch flag: {os.environ['MLX_METAL_FAST_SYNCH']}")
     else:
-        os.environ["MLX_METAL_FAST_SYNCH"] = "1"
-
-    logger.info(f"Fast synch flag: {os.environ['MLX_METAL_FAST_SYNCH']}")
+        logger.info("Fast synch flag: skipped (non-Darwin platform)")
 
     # Import main after setting global logger - this lets us just import logger from this module
     try:


### PR DESCRIPTION
## Motivation

PR #2103 为 exo 添加了 Linux CUDA 原生推理支持，使纯 CUDA 节点可以参与 MLX ring 分布式推理。但在实际 3 节点异构集群（Metal + CUDA）测试中暴露了三个阻断性问题：

1. **MLX 0.32.0 CUDA `send`/`recv` 不可用** — CUDA-to-CUDA 链路上 point-to-point 通信会 hang，导致多 CUDA 节点间无法传递 tensor
2. **CUDA peer 检测不可靠** — 原方案无显式 CUDA rank 声明机制，异构拓扑下无法准确判断哪些链路需要走旁路
3. **stale connection 阻塞集群组网** — CUDA 探测阶段产生的半开连接残留在 `accept()` 队列中，阻止第三个节点正常加入

此外还有若干兼容性问题：`mlx-lm` 期望的 `new_thread_local_stream` API 在 CUDA 后端不存在；`MLX_METAL_FAST_SYNCH` 在 Linux 上设置会触发警告；Linux 缺少 `networksetup` 导致网卡类型全部返回 `unknown`；wired limit 设置在 CUDA 设备上报错。

## Changes

**涉及 8 个文件（7 修改 + 1 新增），净增约 350 行：**

### 1. `auto_parallel.py` — TcpRelay 核心（+220 行）

- **`_is_cuda_device()`** — 检测当前进程是否运行在 Linux CUDA 后端
- **`TcpRelay` 类** — 完整的 TCP 通信旁路层，替代 MLX 的 CUDA send/recv：
  - `__init__`: 从 `MLX_HOSTS_JSON` 或 `MLX_HOSTFILE` 解析 peer IP 映射；从 `MLX_CUDA_RANKS` 获取 CUDA peer 集合；port 40000+rank 避免冲突
  - `is_cuda_to_cuda(dst_rank)`: 判断 src→dst 是否为 CUDA-to-CUDA 链路
  - `_ensure_server()`: 启动 TCP listen socket
  - `_connect_to(dst_rank)`: 120 次重试连接 peer（每次 1s 间隔）
  - `send(x, dst)`: mx.array → numpy → 原始 dtype bytes → struct header + shape + data → sendall
  - `recv_like(ref, src)`: accept 循环 + MSG_PEEK stale connection 过滤 → 解析 header → 按 dtype_code 还原 numpy → mx.array
  - `_recv_exact(sock, n)`: 确保完整读取 n bytes
- **路由逻辑修改** — `flush_prefill_sends()`、`_RingRecvWrapper.__call__`、`_RingSendWrapper.__call__` 中所有 send/recv 调用点均增加 `is_cuda_to_cuda()` 判断，CUDA-to-CUDA 走 TcpRelay，其余走 MLX 原生路径
- 支持 float32/float16/bfloat16/int32/int64/bool/uint8 序列化，保留原始精度

### 2. `utils_mlx.py` — 分布式初始化 + CUDA 探测

- 新增 `MLX_HOSTS_JSON` 环境变量，将 hostfile 内容持久化（避免 tempfile 被 tempdir cleanup 删除）
- CUDA 节点在 `mlx_distributed_init` 后 eager 启动 TcpRelay server
- `shard_and_load` 中新增延迟 CUDA peer 探测：connect 其他节点的 TcpRelay 端口，成功则该 peer 是 CUDA，结果写入 `MLX_CUDA_RANKS`
- `set_wired_limit_for_model()` 重构：Metal 走原逻辑，CUDA 后端跳过

### 3. `generate.py` — Prefill Barrier

- Pipeline prefill 完成后添加 `mx_barrier(group)`，防止 rank 间 prefill/generation 阶段不同步导致 all_gather 死锁

### 4. `cuda_compat.py`（新文件）— MLX API Shim

- 将 `mx.new_stream` 别名为 `mx.new_thread_local_stream`（mlx-lm 期望的 API）

### 5. `placement.py` — Metal 中置拓扑旋转

- `_rotate_metal_to_middle()`: 3 节点 Pipeline 场景下将 Metal 节点旋转到中间 rank（index 1），确保所有链路走 Metal↔CUDA（可用）而非 CUDA↔CUDA（hang）

### 6. `placement_utils.py` — IP 优先级调整

- Ethernet 从优先级 2 → 0，Thunderbolt 从 0 → 2（DGX 场景无 Thunderbolt）

### 7. `system_info.py` — Linux 网卡类型推断

- 新增 `_linux_interface_types()`: 基于接口名正则匹配推断类型

### 8. `bootstrap.py` — 平台条件化

- `MLX_METAL_FAST_SYNCH` 仅 Darwin 平台设置

## Why It Works

**数据通路架构（3 节点异构）：**

```
                MLX native              TcpRelay (raw TCP)
   Rank 0 ◄────────────────► Rank 1 ◄────────────────────► Rank 2
  (CUDA)     send/recv OK     (Metal)   bypass broken CUDA    (CUDA)
                               中间节点     send/recv
```

`_rotate_metal_to_middle` 确保 Metal 在中间 rank，两条链路都是 Metal↔CUDA（MLX 原生可用）。纯 CUDA 集群则用 TcpRelay 完全旁路。

**CUDA peer 探测流程：**
1. CUDA 节点 eager 启动 TcpRelay server (port 40000+rank)
2. `shard_and_load` 阶段 connect peer 端口探测 → 成功=CUDA，超时=Metal
3. 结果写入 `MLX_CUDA_RANKS` 供路由判断

**stale connection 清理：**
accept 循环中 `MSG_PEEK` 预读，无数据则 close 并继续 accept。

## Test Plan

**Manual Testing:**

- [ ] 3 节点异构：1x Mac (Metal) + 2x Linux GPU (CUDA) 端到端 text generation
- [ ] 2 节点纯 CUDA 集群：TcpRelay 旁路正常
- [ ] 2 节点 Metal 集群：无回归
- [ ] 节点动态加入：第三个节点上线无 stale connection 阻塞

**Automated Testing:**

- [ ] 单元测试：`is_cuda_to_cuda()` 覆盖
- [ ] 单元测试：`_linux_interface_types()` 正则匹配
- [ ] 集成测试：`_rotate_metal_to_middle()` 拓扑旋转正确性

## Dependencies

- 基于 PR #2103 (MLX CUDA 原生支持)
- 需要 `mlx-cuda >= 0.31.2`
- 需要 `numpy`（TcpRelay 序列化）

## Known Limitations

- `_rotate_metal_to_middle` 仅处理 3 节点，4+ 节点需更通用策略
- CUDA peer 探测有 2s 超时开销
- TcpRelay 缺少 cleanup 逻辑（进程退出可能残留端口占用）
