### PR TITLE
fix(security): block SSRF in fetch_image_url via scheme allowlist and private IP rejection

### DIFF
--- a/src/exo/api/adapters/chat_completions.py
+++ b/src/exo/api/adapters/chat_completions.py
@@ -1,10 +1,12 @@
 """OpenAI Chat Completions API adapter for converting requests/responses."""
 
 import base64
+import ipaddress
 import re
 import time
 from collections.abc import AsyncGenerator
 from typing import Any
+from urllib.parse import urlparse
 
 from exo.api.types import (
     ChatCompletionChoice,
@@ -38,6 +40,12 @@ from exo.shared.types.text_generation import (
     resolve_reasoning_params,
 )
 
+_BLOCKED_METADATA_HOSTS: frozenset[str] = frozenset({
+    "169.254.169.254",           # AWS IMDSv1
+    "metadata.google.internal",  # GCP
+    "169.254.170.2",             # Azure IMDS
+})
+
 
 def extract_base64_from_data_url(data_url: str) -> Base64Image:
     match = re.match(r"data:[^;]+;base64,(.+)", data_url)
@@ -47,6 +55,23 @@ def extract_base64_from_data_url(data_url: str) -> Base64Image:
 
 
 async def fetch_image_url(url: str) -> Base64Image:
+    parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"URL scheme '{parsed.scheme}' not allowed; only http and https are permitted")
+
+    if parsed.hostname in _BLOCKED_METADATA_HOSTS:
+        raise ValueError(f"Access to '{parsed.hostname}' is denied (cloud metadata endpoint)")
+
+    if parsed.hostname:
+        try:
+            ip = ipaddress.ip_address(parsed.hostname)
+        except ValueError:
+            ip = None  # hostname, not a literal IP — DNS resolution proceeds normally
+
+        if ip is not None and (ip.is_private or ip.is_loopback or ip.is_link_local):
+            raise ValueError(f"Non-public IP address '{parsed.hostname}' not allowed")
+
     headers = {"User-Agent": "exo/1.0"}
     async with (
         create_http_session(timeout_profile="short") as session,

--- a/src/exo/api/adapters/chat_completions.py
+++ b/src/exo/api/adapters/chat_completions.py
@@ -40,11 +40,13 @@ from exo.shared.types.text_generation import (
     resolve_reasoning_params,
 )
 
-_BLOCKED_METADATA_HOSTS: frozenset[str] = frozenset({
-    "169.254.169.254",           # AWS IMDSv1
-    "metadata.google.internal",  # GCP
-    "169.254.170.2",             # Azure IMDS
-})
+_BLOCKED_METADATA_HOSTS: frozenset[str] = frozenset(
+    {
+        "169.254.169.254",  # AWS IMDSv1
+        "metadata.google.internal",  # GCP
+        "169.254.170.2",  # Azure IMDS
+    }
+)
 
 
 def extract_base64_from_data_url(data_url: str) -> Base64Image:
@@ -58,10 +60,14 @@ async def fetch_image_url(url: str) -> Base64Image:
     parsed = urlparse(url)
 
     if parsed.scheme not in ("http", "https"):
-        raise ValueError(f"URL scheme '{parsed.scheme}' not allowed; only http and https are permitted")
+        raise ValueError(
+            f"URL scheme '{parsed.scheme}' not allowed; only http and https are permitted"
+        )
 
     if parsed.hostname in _BLOCKED_METADATA_HOSTS:
-        raise ValueError(f"Access to '{parsed.hostname}' is denied (cloud metadata endpoint)")
+        raise ValueError(
+            f"Access to '{parsed.hostname}' is denied (cloud metadata endpoint)"
+        )
 
     if parsed.hostname:
         try:

--- a/src/exo/api/adapters/tests/test_fetch_image_url.py
+++ b/src/exo/api/adapters/tests/test_fetch_image_url.py
@@ -1,0 +1,153 @@
+# pyright: reportAny=false
+"""Tests for fetch_image_url SSRF protection.
+
+Verifies that scheme, metadata-host, and literal private/loopback/link-local IP
+checks fire before any network access, and that valid public URLs are allowed.
+"""
+
+import base64
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from exo.api.adapters.chat_completions import fetch_image_url
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_session(response_data: bytes = b"img") -> MagicMock:
+    """Return a mock aiohttp session whose .get() never actually sends a request."""
+    resp = MagicMock()
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    resp.raise_for_status = MagicMock()
+    resp.read = AsyncMock(return_value=response_data)
+
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    session.get = MagicMock(return_value=resp)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Rejection cases — scheme
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_file_scheme_rejected() -> None:
+    with patch("exo.api.adapters.chat_completions.create_http_session") as mock_cs:
+        with pytest.raises(ValueError, match="scheme"):
+            await fetch_image_url("file:///etc/passwd")
+        mock_cs.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ftp_scheme_rejected() -> None:
+    with patch("exo.api.adapters.chat_completions.create_http_session") as mock_cs:
+        with pytest.raises(ValueError, match="scheme"):
+            await fetch_image_url("ftp://example.com/image.jpg")
+        mock_cs.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Rejection cases — metadata host blocklist
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_aws_metadata_rejected() -> None:
+    with patch("exo.api.adapters.chat_completions.create_http_session") as mock_cs:
+        with pytest.raises(ValueError, match="metadata"):
+            await fetch_image_url("http://169.254.169.254/latest/meta-data/")
+        mock_cs.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gcp_metadata_rejected() -> None:
+    with patch("exo.api.adapters.chat_completions.create_http_session") as mock_cs:
+        with pytest.raises(ValueError, match="metadata"):
+            await fetch_image_url("http://metadata.google.internal/computeMetadata/v1/")
+        mock_cs.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_azure_metadata_rejected() -> None:
+    with patch("exo.api.adapters.chat_completions.create_http_session") as mock_cs:
+        with pytest.raises(ValueError, match="metadata"):
+            await fetch_image_url("http://169.254.170.2/metadata/instance")
+        mock_cs.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Rejection cases — literal private/loopback/link-local IPs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_private_ip_rfc1918_rejected() -> None:
+    with patch("exo.api.adapters.chat_completions.create_http_session") as mock_cs:
+        with pytest.raises(ValueError, match="Non-public IP"):
+            await fetch_image_url("http://192.168.1.1/image.jpg")
+        mock_cs.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_private_ip_10_rejected() -> None:
+    with patch("exo.api.adapters.chat_completions.create_http_session") as mock_cs:
+        with pytest.raises(ValueError, match="Non-public IP"):
+            await fetch_image_url("http://10.0.0.1/image.jpg")
+        mock_cs.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_loopback_rejected() -> None:
+    with patch("exo.api.adapters.chat_completions.create_http_session") as mock_cs:
+        with pytest.raises(ValueError, match="Non-public IP"):
+            await fetch_image_url("http://127.0.0.1/internal")
+        mock_cs.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_link_local_non_metadata_rejected() -> None:
+    """Link-local IPs not in metadata blocklist are still rejected by the IP check."""
+    with patch("exo.api.adapters.chat_completions.create_http_session") as mock_cs:
+        with pytest.raises(ValueError, match="Non-public IP"):
+            await fetch_image_url("http://169.254.1.1/any")
+        mock_cs.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Allowed cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_valid_https_url_succeeds() -> None:
+    image_data = b"\x89PNG\r\n"
+    session = _mock_session(image_data)
+    with patch("exo.api.adapters.chat_completions.create_http_session", return_value=session):
+        result = await fetch_image_url("https://example.com/image.png")
+    assert result == base64.b64encode(image_data).decode("ascii")
+    session.get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_public_ip_literal_allowed() -> None:
+    """8.8.8.8 is a genuine public IP (Google DNS); should pass the IP check."""
+    image_data = b"data"
+    session = _mock_session(image_data)
+    with patch("exo.api.adapters.chat_completions.create_http_session", return_value=session):
+        result = await fetch_image_url("https://8.8.8.8/image.jpg")
+    assert result == base64.b64encode(image_data).decode("ascii")
+    session.get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_hostname_not_literal_ip_allowed_through() -> None:
+    """A plain hostname is not a literal IP; ip_address() raises ValueError and check is skipped."""
+    image_data = b"pixels"
+    session = _mock_session(image_data)
+    with patch("exo.api.adapters.chat_completions.create_http_session", return_value=session):
+        result = await fetch_image_url("https://cdn.example.com/photo.jpg")
+    assert result == base64.b64encode(image_data).decode("ascii")
+    session.get.assert_called_once()

--- a/src/exo/api/adapters/tests/test_fetch_image_url.py
+++ b/src/exo/api/adapters/tests/test_fetch_image_url.py
@@ -12,10 +12,10 @@ import pytest
 
 from exo.api.adapters.chat_completions import fetch_image_url
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _mock_session(response_data: bytes = b"img") -> MagicMock:
     """Return a mock aiohttp session whose .get() never actually sends a request."""
@@ -36,6 +36,7 @@ def _mock_session(response_data: bytes = b"img") -> MagicMock:
 # Rejection cases — scheme
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_file_scheme_rejected() -> None:
     with patch("exo.api.adapters.chat_completions.create_http_session") as mock_cs:
@@ -55,6 +56,7 @@ async def test_ftp_scheme_rejected() -> None:
 # ---------------------------------------------------------------------------
 # Rejection cases — metadata host blocklist
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_aws_metadata_rejected() -> None:
@@ -83,6 +85,7 @@ async def test_azure_metadata_rejected() -> None:
 # ---------------------------------------------------------------------------
 # Rejection cases — literal private/loopback/link-local IPs
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_private_ip_rfc1918_rejected() -> None:
@@ -121,11 +124,14 @@ async def test_link_local_non_metadata_rejected() -> None:
 # Allowed cases
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_valid_https_url_succeeds() -> None:
     image_data = b"\x89PNG\r\n"
     session = _mock_session(image_data)
-    with patch("exo.api.adapters.chat_completions.create_http_session", return_value=session):
+    with patch(
+        "exo.api.adapters.chat_completions.create_http_session", return_value=session
+    ):
         result = await fetch_image_url("https://example.com/image.png")
     assert result == base64.b64encode(image_data).decode("ascii")
     session.get.assert_called_once()
@@ -136,7 +142,9 @@ async def test_public_ip_literal_allowed() -> None:
     """8.8.8.8 is a genuine public IP (Google DNS); should pass the IP check."""
     image_data = b"data"
     session = _mock_session(image_data)
-    with patch("exo.api.adapters.chat_completions.create_http_session", return_value=session):
+    with patch(
+        "exo.api.adapters.chat_completions.create_http_session", return_value=session
+    ):
         result = await fetch_image_url("https://8.8.8.8/image.jpg")
     assert result == base64.b64encode(image_data).decode("ascii")
     session.get.assert_called_once()
@@ -147,7 +155,9 @@ async def test_hostname_not_literal_ip_allowed_through() -> None:
     """A plain hostname is not a literal IP; ip_address() raises ValueError and check is skipped."""
     image_data = b"pixels"
     session = _mock_session(image_data)
-    with patch("exo.api.adapters.chat_completions.create_http_session", return_value=session):
+    with patch(
+        "exo.api.adapters.chat_completions.create_http_session", return_value=session
+    ):
         result = await fetch_image_url("https://cdn.example.com/photo.jpg")
     assert result == base64.b64encode(image_data).decode("ascii")
     session.get.assert_called_once()


### PR DESCRIPTION
## Summary

`fetch_image_url()` in `chat_completions.py` fetches arbitrary URLs provided by API clients with no validation. This allows SSRF attacks:

- `http://169.254.169.254/latest/meta-data/iam/security-credentials/` leaks AWS IAM credentials
- `http://192.168.1.1/admin` scans the internal network
- `file:///etc/passwd` reads local files (if aiohttp supports the scheme)

## Fix

Adds three validation checks before `session.get()` is ever called:

1. **Scheme allowlist** — only `http`/`https` permitted
2. **Metadata host blocklist** — rejects AWS IMDSv1, GCP, and Azure IMDS endpoints
3. **Literal IP rejection** — `ipaddress.ip_address(hostname)` detects private, loopback, and link-local IPs; DNS hostnames are not blocked (DNS rebinding protection is deferred)

No new package dependencies — uses only stdlib `ipaddress` and `urllib.parse`.

## Tests

12 test cases in `src/exo/api/adapters/tests/test_fetch_image_url.py`:
- Every rejection case asserts `session.get()` is **never called** (mock + `assert_not_called()`)
- Coverage: scheme, all 3 metadata hosts, RFC 1918, loopback, link-local, valid HTTPS, public IP literal, hostname passthrough

## Scope

**In scope:** Literal IP validation at parse time.
**Out of scope:** DNS rebinding (hostname → private IP after resolution). That requires resolving hostnames before connecting, which is a larger change best handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)