### PR TITLE
fix(master): add --no-master flag and prevent --no-api nodes from self-electing

### DIFF
--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -46,6 +46,7 @@ class Node:
     node_id: NodeId
     offline: bool
     _api_port: int
+    _no_master: bool
     _tg: TaskGroup = field(init=False, default_factory=TaskGroup)
 
     @classmethod
@@ -112,22 +113,28 @@ class Node:
         else:
             worker = None
 
-        # We start every node with a master
-        master = Master(
-            node_id,
-            session_id,
-            event_sender=event_router.sender(),
-            global_event_sender=router.sender(topics.GLOBAL_EVENTS),
-            local_event_receiver=router.receiver(topics.LOCAL_EVENTS),
-            command_receiver=router.receiver(topics.COMMANDS),
-            download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
-        )
+        # We start every node with a master, unless --no-master is set
+        if args.no_master:
+            master = None
+        else:
+            master = Master(
+                node_id,
+                session_id,
+                event_sender=event_router.sender(),
+                global_event_sender=router.sender(topics.GLOBAL_EVENTS),
+                local_event_receiver=router.receiver(topics.LOCAL_EVENTS),
+                command_receiver=router.receiver(topics.COMMANDS),
+                download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
+            )
 
         er_send, er_recv = channel[ElectionResult]()
         election = Election(
             node_id,
             # If someone manages to assemble 1 MILLION devices into an exo cluster then. well done. good job champ.
             seniority=1_000_000 if args.force_master else 0,
+            # --no-api nodes (coordinators) must not self-elect as master; any API-bearing node beats them.
+            # --no-master explicitly prevents self-election even during solo partitions.
+            is_candidate=args.spawn_api and not args.no_master,
             # nb: this DOES feedback right now. i have thoughts on how to address this,
             # but ultimately it seems not worth the complexity
             election_message_sender=router.sender(topics.ELECTION_MESSAGES),
@@ -149,6 +156,7 @@ class Node:
             node_id,
             args.offline,
             args.api_port,
+            args.no_master,
         )
 
     async def run(self):
@@ -209,6 +217,12 @@ class Node:
                         "cannot be new master if we remain master"
                     )
                     logger.info("Node elected Master - maintaining self")
+                elif (
+                    result.session_id.master_node_id == self.node_id
+                    and self.master is None
+                    and self._no_master
+                ):
+                    logger.warning("Node won election but --no-master is set. Refusing promotion.")
                 elif (
                     result.session_id.master_node_id == self.node_id
                     and self.master is None
@@ -377,6 +391,7 @@ def main_inner(args: "Args"):
 class Args(FrozenModel):
     verbosity: int = 0
     force_master: bool = False
+    no_master: bool = False
     spawn_api: bool = False
     api_port: PositiveInt = 52415
     tb_only: bool = False
@@ -413,6 +428,12 @@ class Args(FrozenModel):
             "--force-master",
             action="store_true",
             dest="force_master",
+        )
+        parser.add_argument(
+            "--no-master",
+            action="store_true",
+            dest="no_master",
+            help="Prevent this node from ever becoming master (worker-only mode)",
         )
         parser.add_argument(
             "--no-api",

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -222,7 +222,9 @@ class Node:
                     and self.master is None
                     and self._no_master
                 ):
-                    logger.warning("Node won election but --no-master is set. Refusing promotion.")
+                    logger.warning(
+                        "Node won election but --no-master is set. Refusing promotion."
+                    )
                 elif (
                     result.session_id.master_node_id == self.node_id
                     and self.master is None

--- a/src/exo/shared/election.py
+++ b/src/exo/shared/election.py
@@ -257,7 +257,10 @@ class Election:
         # Non-candidate nodes must never propose themselves as master.
         # Re-propose the last known master instead. During a solo partition
         # this prevents the node from winning by default.
-        if not self.is_candidate and self.current_session.master_node_id != self.node_id:
+        if (
+            not self.is_candidate
+            and self.current_session.master_node_id != self.node_id
+        ):
             return ElectionMessage(
                 proposed_session=self.current_session,
                 clock=c,

--- a/src/exo/shared/election.py
+++ b/src/exo/shared/election.py
@@ -61,6 +61,7 @@ class Election:
         # If we aren't a candidate, simply don't increment seniority.
         # For reference: This node can be elected master if all nodes are not master candidates
         # Any master candidate will automatically win out over this node.
+        self.is_candidate = is_candidate
         self.seniority = seniority if is_candidate else -1
         self.clock = 0
         self.node_id = node_id
@@ -253,6 +254,16 @@ class Election:
 
     def _election_status(self, clock: int | None = None) -> ElectionMessage:
         c = self.clock if clock is None else clock
+        # Non-candidate nodes must never propose themselves as master.
+        # Re-propose the last known master instead. During a solo partition
+        # this prevents the node from winning by default.
+        if not self.is_candidate and self.current_session.master_node_id != self.node_id:
+            return ElectionMessage(
+                proposed_session=self.current_session,
+                clock=c,
+                seniority=self.seniority,
+                commands_seen=self.commands_seen,
+            )
         return ElectionMessage(
             proposed_session=(
                 self.current_session

--- a/src/exo/shared/tests/conftest.py
+++ b/src/exo/shared/tests/conftest.py
@@ -19,7 +19,9 @@ if "exo_rs" not in sys.modules:
     _stub.FromSwarm = _FromSwarm  # type: ignore[attr-defined]
     _stub.AllQueuesFullError = type("AllQueuesFullError", (Exception,), {})  # type: ignore[attr-defined]
     _stub.MessageTooLargeError = type("MessageTooLargeError", (Exception,), {})  # type: ignore[attr-defined]
-    _stub.NoPeersSubscribedToTopicError = type("NoPeersSubscribedToTopicError", (Exception,), {})  # type: ignore[attr-defined]
+    _stub.NoPeersSubscribedToTopicError = type(
+        "NoPeersSubscribedToTopicError", (Exception,), {}
+    )  # type: ignore[attr-defined]
     _stub.Keypair = MagicMock  # type: ignore[attr-defined]
     _stub.NetworkingHandle = MagicMock  # type: ignore[attr-defined]
     _stub.Pidfile = MagicMock  # type: ignore[attr-defined]

--- a/src/exo/shared/tests/conftest.py
+++ b/src/exo/shared/tests/conftest.py
@@ -1,7 +1,30 @@
 """Pytest configuration and shared fixtures for shared package tests."""
 
 import asyncio
+import sys
+import types
 from typing import Generator
+from unittest.mock import MagicMock
+
+# Stub the exo_rs Rust extension so tests can run without a compiled binary.
+# Only installed when the real extension is not already available.
+if "exo_rs" not in sys.modules:
+    _stub = types.ModuleType("exo_rs")
+
+    class _FromSwarm:
+        class Connection:
+            peer_id: str = ""
+            connected: bool = False
+
+    _stub.FromSwarm = _FromSwarm  # type: ignore[attr-defined]
+    _stub.AllQueuesFullError = type("AllQueuesFullError", (Exception,), {})  # type: ignore[attr-defined]
+    _stub.MessageTooLargeError = type("MessageTooLargeError", (Exception,), {})  # type: ignore[attr-defined]
+    _stub.NoPeersSubscribedToTopicError = type("NoPeersSubscribedToTopicError", (Exception,), {})  # type: ignore[attr-defined]
+    _stub.Keypair = MagicMock  # type: ignore[attr-defined]
+    _stub.NetworkingHandle = MagicMock  # type: ignore[attr-defined]
+    _stub.Pidfile = MagicMock  # type: ignore[attr-defined]
+    _stub.PidfileError = type("PidfileError", (Exception,), {})  # type: ignore[attr-defined]
+    sys.modules["exo_rs"] = _stub
 
 import pytest
 from _pytest.logging import LogCaptureFixture


### PR DESCRIPTION
## Summary

Two related fixes for node role management in multi-node clusters:

### 1. `--no-master` flag

New CLI flag that skips `Master` instantiation entirely. Previously every node always started a Master even when it was intended to run as a pure worker (e.g. a GPU worker with no API surface). With `--no-master`, the Master event loop, command processor, and download coordinator are not started.

### 2. `--no-api` nodes must not self-elect

When a node is started with `--no-api` (`spawn_api=False`), it should not be eligible to become master — an API-less node winning an election means no API is reachable in the cluster. Previously, a `--no-api` node in a solo partition would self-elect (the bully algorithm has no other candidates). This PR sets `is_candidate = args.spawn_api and not args.no_master`, which gives non-candidate nodes a seniority of `-1` so any API-bearing node beats them.

A complementary guard in `election.py` ensures non-candidate nodes re-propose the last known master during solo partitions instead of winning by default.

### Flag precedence

| Flags | Result |
|-------|--------|
| `--no-master` | master=None, is_candidate=False |
| `--no-api` | is_candidate=False, seniority=-1 |
| `--force-master` | seniority=1_000_000 (only applies when is_candidate=True) |
| `--no-master --force-master` | master=None (--no-master wins) |
| `--no-api --force-master` | seniority=-1 (--no-api wins) |

## Tests

- 14 existing election tests (`src/exo/shared/tests/test_election.py`) all pass
- Added `exo_rs` stub to `src/exo/shared/tests/conftest.py` so tests run without a compiled Rust binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)