### PR TITLE
docs: add Homebrew cask install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ The macOS app requires macOS Tahoe 26.2 or later.
 
 Download the latest build here: [EXO-latest.dmg](https://assets.exolabs.net/EXO-latest.dmg).
 
+You can also install the latest build with Homebrew:
+
+```bash
+brew install --cask exo
+```
+
 The app will ask for permission to modify system settings and install a new Network profile. Improvements to this are being worked on.
 
 **Custom Namespace for Cluster Isolation:**


### PR DESCRIPTION
## Motivation

exo is now available as a Homebrew cask, so the README should show the simplest macOS installation path alongside the existing DMG download.

Fixes https://github.com/exo-explore/exo/issues/2105
https://github.com/exo-explore/exo/issues/176

## Changes

- Added `brew install --cask exo` to the macOS App section of `README.md`
- Kept the existing DMG download link as the first installation option

## Why It Works

Adding the Homebrew cask command gives macOS users a package-manager-managed installation path while preserving the existing DMG download option.

## Test Plan

### Manual Testing

- Reviewed the rendered Markdown structure in `README.md`

### Automated Testing

- Not run. Documentation-only change.

## Related

- https://github.com/Homebrew/homebrew-cask/pull/265956