### PR TITLE
shard refactor

### DIFF
--- a/dashboard/src/lib/components/ChatSidebar.svelte
+++ b/dashboard/src/lib/components/ChatSidebar.svelte
@@ -12,6 +12,8 @@
     toggleDebugMode,
     topologyOnlyMode,
     toggleTopologyOnlyMode,
+    getInstanceFirstShard,
+    type Instance,
   } from "$lib/stores/app.svelte";
 
   interface Props {
@@ -186,7 +188,7 @@
   function extractInstanceModelId(instanceWrapped: unknown): string | null {
     const [, instance] = getTaggedValue(instanceWrapped);
     if (!instance || typeof instance !== "object") return null;
-    const inst = instance as { shardAssignments?: { modelId?: string } };
+    const inst = instance as Instance;
     return inst.shardAssignments?.modelId ?? null;
   }
 
@@ -204,11 +206,7 @@
     else if (instanceTag === "MlxJacclInstance") instanceType = "MLX RDMA";
 
     let sharding: string | null = null;
-    const inst = instance as {
-      shardAssignments?: { runnerToShard?: Record<string, unknown> };
-    };
-    const runnerToShard = inst.shardAssignments?.runnerToShard || {};
-    const firstShardWrapped = Object.values(runnerToShard)[0];
+    const firstShardWrapped = getInstanceFirstShard(instance as Instance);
     if (firstShardWrapped) {
       const [shardTag] = getTaggedValue(firstShardWrapped);
       if (shardTag === "PipelineShardMetadata") sharding = "Pipeline";

--- a/dashboard/src/lib/components/PrefillDecodeDisaggregation.svelte
+++ b/dashboard/src/lib/components/PrefillDecodeDisaggregation.svelte
@@ -9,6 +9,7 @@
     createInstanceLink,
     updateInstanceLink,
     deleteInstanceLink,
+    getInstanceNodeIds,
     type Instance,
   } from "$lib/stores/app.svelte";
   import { deriveBaseModel, deriveFamily } from "$lib/utils/model_family";
@@ -16,7 +17,6 @@
   type InstanceWrapper = {
     MlxRingInstance?: Instance;
     MlxJacclInstance?: Instance;
-    VllmInstance?: Instance;
   };
 
   let interval: ReturnType<typeof setInterval> | null = null;
@@ -43,13 +43,9 @@
     const ids = nodeIdentities();
     for (const [id, raw] of Object.entries(instances())) {
       const wrapper = raw as InstanceWrapper;
-      const inst =
-        wrapper.MlxRingInstance ??
-        wrapper.MlxJacclInstance ??
-        wrapper.VllmInstance;
+      const inst = wrapper.MlxRingInstance ?? wrapper.MlxJacclInstance;
       const modelId = inst?.shardAssignments?.modelId ?? "";
-      const nodeToRunner = inst?.shardAssignments?.nodeToRunner ?? {};
-      const nodeIds = Object.keys(nodeToRunner);
+      const nodeIds = getInstanceNodeIds(inst);
       const nodeNames = nodeIds
         .map((nodeId) => ids[nodeId]?.friendlyName ?? nodeId.slice(0, 6))
         .filter((name) => !!name);

--- a/dashboard/src/lib/stores/app.svelte.ts
+++ b/dashboard/src/lib/stores/app.svelte.ts
@@ -66,12 +66,40 @@ export interface TopologyData {
   edges: TopologyEdge[];
 }
 
+export type InstanceShard = [nodeId: string, runnerId: string, shard: unknown];
+
+export interface ShardAssignments {
+  modelId: string;
+  shards: InstanceShard[];
+  primaryOutputNode: number;
+}
+
 export interface Instance {
-  shardAssignments?: {
-    modelId?: string;
-    runnerToShard?: Record<string, unknown>;
-    nodeToRunner?: Record<string, string>;
-  };
+  shardAssignments: ShardAssignments;
+}
+
+export function getInstanceShards(
+  instance: Instance | null | undefined,
+): InstanceShard[] {
+  return instance?.shardAssignments.shards ?? [];
+}
+
+export function getInstanceRunnerIds(
+  instance: Instance | null | undefined,
+): string[] {
+  return getInstanceShards(instance).map(([, runnerId]) => runnerId);
+}
+
+export function getInstanceNodeIds(
+  instance: Instance | null | undefined,
+): string[] {
+  return [...new Set(getInstanceShards(instance).map(([nodeId]) => nodeId))];
+}
+
+export function getInstanceFirstShard(
+  instance: Instance | null | undefined,
+): unknown {
+  return getInstanceShards(instance)[0]?.[2];
 }
 
 export interface RawInstanceLink {
@@ -918,7 +946,7 @@ class AppStore {
   private extractInstanceModelId(instanceWrapped: unknown): string | null {
     const [, instance] = this.getTaggedValue(instanceWrapped);
     if (!instance || typeof instance !== "object") return null;
-    const inst = instance as { shardAssignments?: { modelId?: string } };
+    const inst = instance as Instance;
     return inst.shardAssignments?.modelId ?? null;
   }
 
@@ -936,11 +964,8 @@ class AppStore {
     else if (instanceTag === "MlxJacclInstance") instanceType = "MLX RDMA";
 
     let sharding: string | null = null;
-    const inst = instance as {
-      shardAssignments?: { runnerToShard?: Record<string, unknown> };
-    };
-    const runnerToShard = inst.shardAssignments?.runnerToShard || {};
-    const firstShardWrapped = Object.values(runnerToShard)[0];
+    const inst = instance as Instance;
+    const firstShardWrapped = getInstanceFirstShard(inst);
     if (firstShardWrapped) {
       const [shardTag] = this.getTaggedValue(firstShardWrapped);
       if (shardTag === "PipelineShardMetadata") sharding = "Pipeline";
@@ -2262,7 +2287,7 @@ class AppStore {
         if (keys.length === 1) {
           const instance = (instanceWrapper as Record<string, unknown>)[
             keys[0]
-          ] as { shardAssignments?: { modelId?: string } };
+          ] as Instance;
           const instanceModelId = instance?.shardAssignments?.modelId;
 
           // ensure to only return requestedModelId that matches an instance

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -65,6 +65,11 @@
     nodeThunderboltBridge,
     nodeIdentities,
     isConnected,
+    getInstanceFirstShard,
+    getInstanceNodeIds,
+    getInstanceRunnerIds,
+    getInstanceShards,
+    type Instance,
     type DownloadProgress,
     type PlacementPreview,
   } from "$lib/stores/app.svelte";
@@ -998,11 +1003,7 @@
     if (keys.length !== 1) return new Set();
     const instance = (instanceWrapped as Record<string, unknown>)[keys[0]];
     if (!instance || typeof instance !== "object") return new Set();
-    const inst = instance as {
-      shardAssignments?: { nodeToRunner?: Record<string, string> };
-    };
-    if (!inst.shardAssignments?.nodeToRunner) return new Set();
-    return new Set(Object.keys(inst.shardAssignments.nodeToRunner));
+    return new Set(getInstanceNodeIds(instance as Instance));
   }
 
   function toggleInstanceDownloadDetails(nodeId: string): void {
@@ -1784,13 +1785,7 @@
       };
     }
 
-    const inst = instance as {
-      shardAssignments?: {
-        nodeToRunner?: Record<string, string>;
-        runnerToShard?: Record<string, unknown>;
-        modelId?: string;
-      };
-    };
+    const inst = instance as Instance;
     const instanceModelId = inst.shardAssignments?.modelId;
 
     if (!instanceModelId) {
@@ -1805,16 +1800,7 @@
       };
     }
 
-    // Get node IDs assigned to this instance
-    const nodeToRunner = inst.shardAssignments?.nodeToRunner || {};
-    const runnerToShard = inst.shardAssignments?.runnerToShard || {};
-    const runnerToNode: Record<string, string> = {};
-    for (const [nodeId, runnerId] of Object.entries(nodeToRunner)) {
-      runnerToNode[runnerId] = nodeId;
-    }
-    const instanceNodeIds = Object.keys(runnerToShard)
-      .map((runnerId) => runnerToNode[runnerId])
-      .filter(Boolean);
+    const instanceNodeIds = getInstanceNodeIds(inst);
 
     const result = collectDownloadStatus(instanceModelId, instanceNodeIds);
 
@@ -1858,6 +1844,7 @@
       case "FAILED":
         return "text-red-400";
       case "SHUTDOWN":
+      case "SHUTTING DOWN":
         return "text-gray-400";
       case "DOWNLOADING":
         return "text-blue-400";
@@ -1865,6 +1852,7 @@
       case "WARMING UP":
       case "WAITING":
       case "INITIALIZING":
+      case "CONNECTING":
         return "text-yellow-400";
       case "RUNNING":
         return "text-teal-400";
@@ -1887,10 +1875,7 @@
       return { statusText: "PREPARING", statusClass: "inactive" };
     }
 
-    const inst = instance as {
-      shardAssignments?: { runnerToShard?: Record<string, unknown> };
-    };
-    const runnerIds = Object.keys(inst.shardAssignments?.runnerToShard || {});
+    const runnerIds = getInstanceRunnerIds(instance as Instance);
 
     const statuses = runnerIds
       .map((rid) => {
@@ -1898,14 +1883,15 @@
         if (!r) return null;
         const [kind] = getTagged(r);
         const statusMap: Record<string, string> = {
-          RunnerWaitingForInitialization: "WaitingForInitialization",
-          RunnerInitializingBackend: "InitializingBackend",
-          RunnerWaitingForModel: "WaitingForModel",
+          RunnerIdle: "Idle",
+          RunnerConnecting: "Connecting",
+          RunnerConnected: "Connected",
           RunnerLoading: "Loading",
           RunnerLoaded: "Loaded",
           RunnerWarmingUp: "WarmingUp",
           RunnerReady: "Ready",
           RunnerRunning: "Running",
+          RunnerShuttingDown: "ShuttingDown",
           RunnerShutdown: "Shutdown",
           RunnerFailed: "Failed",
         };
@@ -1959,14 +1945,15 @@
       return { statusText: "RUNNING", statusClass: "running" };
     if (has("Ready")) return { statusText: "READY", statusClass: "loaded" };
     if (has("Loaded")) return { statusText: "LOADED", statusClass: "loaded" };
-    if (has("WaitingForModel"))
-      return { statusText: "WAITING", statusClass: "starting" };
-    if (has("InitializingBackend"))
+    if (has("Connected"))
       return { statusText: "INITIALIZING", statusClass: "starting" };
-    if (has("WaitingForInitialization"))
-      return { statusText: "INITIALIZING", statusClass: "starting" };
+    if (has("Connecting"))
+      return { statusText: "CONNECTING", statusClass: "starting" };
+    if (has("Idle")) return { statusText: "WAITING", statusClass: "starting" };
+    if (has("ShuttingDown"))
+      return { statusText: "SHUTTING DOWN", statusClass: "inactive" };
 
-    return { statusText: "RUNNING", statusClass: "active" };
+    return { statusText: "PREPARING", statusClass: "inactive" };
   }
 
   function getBytes(value: unknown): number {
@@ -2039,7 +2026,7 @@
   function getInstanceModelId(instanceWrapped: unknown): string {
     const [, instance] = getTagged(instanceWrapped);
     if (!instance || typeof instance !== "object") return "Unknown";
-    const inst = instance as { shardAssignments?: { modelId?: string } };
+    const inst = instance as Instance;
     return inst.shardAssignments?.modelId || "Unknown Model";
   }
 
@@ -2067,17 +2054,11 @@
     if (instanceTag === "MlxRingInstance") instanceType = "MLX Ring";
     else if (instanceTag === "MlxJacclInstance") instanceType = "MLX RDMA";
 
-    const inst = instance as {
-      shardAssignments?: {
-        nodeToRunner?: Record<string, string>;
-        runnerToShard?: Record<string, unknown>;
-      };
-    };
+    const inst = instance as Instance;
 
     // Sharding strategy from first shard
     let sharding = "Unknown";
-    const runnerToShard = inst.shardAssignments?.runnerToShard || {};
-    const firstShardWrapped = Object.values(runnerToShard)[0];
+    const firstShardWrapped = getInstanceFirstShard(inst);
     if (firstShardWrapped) {
       const [shardTag] = getTagged(firstShardWrapped);
       if (shardTag === "PipelineShardMetadata") sharding = "Pipeline";
@@ -2087,8 +2068,7 @@
     }
 
     // Node names from topology
-    const nodeToRunner = inst.shardAssignments?.nodeToRunner || {};
-    const nodeIds = Object.keys(nodeToRunner);
+    const nodeIds = getInstanceNodeIds(inst);
     const nodeNames = nodeIds.map((nodeId) => {
       const node = data?.nodes?.[nodeId];
       return node?.friendly_name || nodeId.slice(0, 8);
@@ -2192,35 +2172,19 @@
   }
 
   function getOrderedRunnerNodes(
-    instance: Record<string, unknown>,
+    instance: Instance,
     shardType: "Pipeline" | "Tensor",
   ) {
-    const runnerToShard =
-      (
-        instance.shardAssignments as
-          | { runnerToShard?: Record<string, unknown> }
-          | undefined
-      )?.runnerToShard || {};
-    const nodeToRunner =
-      (
-        instance.shardAssignments as
-          | { nodeToRunner?: Record<string, string> }
-          | undefined
-      )?.nodeToRunner || {};
-    const runnerEntries = Object.entries(runnerToShard).map(
-      ([runnerId, shardWrapped]) => {
+    const runnerEntries = getInstanceShards(instance).map(
+      ([nodeId, runnerId, shardWrapped]) => {
         const [tag, shard] = getTagged(shardWrapped);
         const meta = shard as
           | {
-              modelMeta?: {
-                worldSize?: number;
-                nLayers?: number;
-                deviceRank?: number;
-              };
+              deviceRank?: number;
             }
           | undefined;
-        const deviceRank = meta?.modelMeta?.deviceRank ?? 0;
-        return { runnerId, tag, deviceRank };
+        const deviceRank = meta?.deviceRank ?? 0;
+        return { nodeId, runnerId, tag, deviceRank };
       },
     );
 
@@ -2231,13 +2195,11 @@
           : r.tag === "TensorShardMetadata",
       )
       .sort((a, b) => a.deviceRank - b.deviceRank)
-      .map((r, idx) => {
-        const nodeId = Object.entries(nodeToRunner).find(
-          ([, rid]) => rid === r.runnerId,
-        )?.[0];
-        return { nodeId, runnerId: r.runnerId, order: idx };
-      })
-      .filter((item) => item.nodeId);
+      .map((r, idx) => ({
+        nodeId: r.nodeId,
+        runnerId: r.runnerId,
+        order: idx,
+      }));
 
     return ordered as Array<{
       nodeId: string;
@@ -2281,10 +2243,7 @@
 
     // Jaccl (RDMA) – show RDMA interfaces from ibvDevices
     if (instanceTag === "MlxJacclInstance") {
-      const ordered = getOrderedRunnerNodes(
-        instance as Record<string, unknown>,
-        "Tensor",
-      );
+      const ordered = getOrderedRunnerNodes(instance as Instance, "Tensor");
       const ibvDevices =
         (instance as { ibvDevices?: Array<Array<string | null>> }).ibvDevices ||
         [];
@@ -2316,10 +2275,7 @@
 
     // Ring – derive ring order from pipeline shard ranks and pick host IPs from hostsByNode
     if (instanceTag === "MlxRingInstance") {
-      const ordered = getOrderedRunnerNodes(
-        instance as Record<string, unknown>,
-        "Pipeline",
-      );
+      const ordered = getOrderedRunnerNodes(instance as Instance, "Pipeline");
       const hostsByNode =
         (
           instance as {
@@ -2606,6 +2562,7 @@
         status.statusText === "WARMING UP" ||
         status.statusText === "WAITING" ||
         status.statusText === "INITIALIZING" ||
+        status.statusText === "CONNECTING" ||
         status.statusText === "PREPARING"
       ) {
         chatLaunchState = "launching";
@@ -5108,7 +5065,10 @@
                   {@const isFailed = statusText === "FAILED"}
                   {@const isLoading = statusText === "LOADING"}
                   {@const isWarmingUp =
-                    statusText === "WARMING UP" || statusText === "WAITING"}
+                    statusText === "WARMING UP" ||
+                    statusText === "WAITING" ||
+                    statusText === "INITIALIZING" ||
+                    statusText === "CONNECTING"}
                   {@const isReady =
                     statusText === "READY" || statusText === "LOADED"}
                   {@const isRunning = statusText === "RUNNING"}
@@ -6244,7 +6204,10 @@
                     {@const isFailed = statusText === "FAILED"}
                     {@const isLoading = statusText === "LOADING"}
                     {@const isWarmingUp =
-                      statusText === "WARMING UP" || statusText === "WAITING"}
+                      statusText === "WARMING UP" ||
+                      statusText === "WAITING" ||
+                      statusText === "INITIALIZING" ||
+                      statusText === "CONNECTING"}
                     {@const isReady =
                       statusText === "READY" || statusText === "LOADED"}
                     {@const isRunning = statusText === "RUNNING"}

--- a/dashboard/src/routes/integrations/+page.svelte
+++ b/dashboard/src/routes/integrations/+page.svelte
@@ -3,7 +3,11 @@
   import { fade } from "svelte/transition";
   import HeaderNav from "$lib/components/HeaderNav.svelte";
   import IntegrationCard from "$lib/components/IntegrationCard.svelte";
-  import { instances, refreshState } from "$lib/stores/app.svelte";
+  import {
+    instances,
+    refreshState,
+    type Instance,
+  } from "$lib/stores/app.svelte";
   import { onMount } from "svelte";
 
   const apiUrl = browser
@@ -24,9 +28,7 @@
         if (values.length > 0) {
           const instance = values[0];
           if (instance && typeof instance === "object") {
-            const inst = instance as {
-              shardAssignments?: { modelId?: string };
-            };
+            const inst = instance as Instance;
             const modelId = inst.shardAssignments?.modelId;
             if (modelId && !models.includes(modelId)) {
               models.push(modelId);

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -596,7 +596,7 @@ class API:
 
             instance = new_instances[0]
             shard_assignments = instance.shard_assignments
-            placement_node_ids = list(shard_assignments.node_to_runner.keys())
+            placement_node_ids = list(s.node_id for s in shard_assignments.shards)
 
             memory_delta_by_node: dict[str, int] = {}
             if placement_node_ids:
@@ -1624,20 +1624,18 @@ class API:
         return JSONResponse(content="Ollama is running")
 
     async def ollama_chat(
-        self, request: Request
+        self, request: OllamaChatRequest
     ) -> OllamaChatResponse | StreamingResponse:
         """Ollama Chat API — accepts JSON regardless of Content-Type."""
-        body = await request.body()
-        payload = OllamaChatRequest.model_validate_json(body)
-        task_params = ollama_request_to_text_generation(payload)
-        validated_model = await self._validate_model_has_instance(
+        task_params = ollama_request_to_text_generation(request)
+        resolved_model = await self._validate_model_has_instance(
             ModelId(task_params.model)
         )
-        task_params = task_params.model_copy(update={"model": validated_model})
+        task_params = task_params.model_copy(update={"model": resolved_model})
 
         command = await self._send_text_generation_with_images(task_params)
 
-        if payload.stream:
+        if request.stream:
             return StreamingResponse(
                 generate_ollama_chat_stream(
                     command.command_id,
@@ -1660,20 +1658,18 @@ class API:
             )
 
     async def ollama_generate(
-        self, request: Request
+        self, request: OllamaGenerateRequest
     ) -> OllamaGenerateResponse | StreamingResponse:
         """Ollama Generate API — accepts JSON regardless of Content-Type."""
-        body = await request.body()
-        payload = OllamaGenerateRequest.model_validate_json(body)
-        task_params = ollama_generate_request_to_text_generation(payload)
-        validated_model = await self._validate_model_has_instance(
+        task_params = ollama_generate_request_to_text_generation(request)
+        resolved_model = await self._validate_model_has_instance(
             ModelId(task_params.model)
         )
-        task_params = task_params.model_copy(update={"model": validated_model})
+        task_params = task_params.model_copy(update={"model": resolved_model})
 
         command = await self._send_text_generation_with_images(task_params)
 
-        if payload.stream:
+        if request.stream:
             return StreamingResponse(
                 generate_ollama_generate_stream(
                     command.command_id,
@@ -1728,11 +1724,9 @@ class API:
             ]
         )
 
-    async def ollama_show(self, request: Request) -> OllamaShowResponse:
+    async def ollama_show(self, request: OllamaShowRequest) -> OllamaShowResponse:
         """Returns model information in Ollama show format."""
-        body = await request.body()
-        payload = OllamaShowRequest.model_validate_json(body)
-        model_name = payload.name or payload.model
+        model_name = request.name or request.model
         if not model_name:
             raise HTTPException(status_code=400, detail="name or model is required")
         try:

--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -79,9 +79,9 @@ def _prefill_endpoint_for(
     decode = state.instances.get(decode_instance_id)
     if decode is None:
         return None
-    decode_node = next(iter(decode.shard_assignments.node_to_runner.keys()), None)
-    if decode_node is None:
-        return None
+    decode_node = decode.shard_assignments.shards[
+        decode.shard_assignments.primary_output_node
+    ].node_id
 
     sources: set[InstanceId] = set()
     for link in instance_links:
@@ -102,7 +102,7 @@ def _prefill_endpoint_for(
         instance = state.instances.get(src_id)
         if instance is None:
             continue
-        for node_id, runner_id in instance.shard_assignments.node_to_runner.items():
+        for node_id, runner_id, _ in instance.shard_assignments.shards:
             port = state.prefill_server_ports.get(runner_id)
             if port is None:
                 continue
@@ -143,7 +143,7 @@ class Master:
         self._multi_buffer = MultiSourceBuffer[SystemId, Event]()
         self._event_log = DiskEventLog(EXO_EVENT_LOG_DIR / "master")
         self._pending_traces: dict[TaskId, dict[int, list[TraceEventData]]] = {}
-        self._expected_ranks: dict[TaskId, set[int]] = {}
+        self._world_sizes: dict[TaskId, int] = {}
         self.aggregator: LVAggregator = aggregator
         self.storage: Storage = storage
 
@@ -306,11 +306,9 @@ class Master:
                                     selected_instance_id
                                 )
                                 if selected_instance:
-                                    ranks = set(
-                                        shard.device_rank
-                                        for shard in selected_instance.shard_assignments.runner_to_shard.values()
+                                    self._world_sizes[task_id] = len(
+                                        selected_instance.shard_assignments.shards
                                     )
-                                    self._expected_ranks[task_id] = ranks
                         case ImageEdits():
                             for instance in self.state.instances.values():
                                 if (
@@ -362,11 +360,9 @@ class Master:
                                     selected_instance_id
                                 )
                                 if selected_instance:
-                                    ranks = set(
-                                        shard.device_rank
-                                        for shard in selected_instance.shard_assignments.runner_to_shard.values()
+                                    self._world_sizes[task_id] = len(
+                                        selected_instance.shard_assignments.shards
                                     )
-                                    self._expected_ranks[task_id] = ranks
                         case DeleteInstance():
                             placement = delete_instance(command, self.state.instances)
                             transition_events = get_transition_events(
@@ -466,7 +462,7 @@ class Master:
                 self.state.with_aggregator(self.aggregator).topology.list_nodes()
             )
             for instance_id, instance in self.state.instances.items():
-                for node_id in instance.shard_assignments.node_to_runner:
+                for node_id, _, _ in instance.shard_assignments.shards:
                     if node_id not in connected_node_ids:
                         await self.event_sender.send(
                             InstanceDeleted(instance_id=instance_id)
@@ -535,9 +531,8 @@ class Master:
         self._pending_traces[task_id][event.rank] = event.traces
 
         if (
-            task_id in self._expected_ranks
-            and set(self._pending_traces[task_id].keys())
-            >= self._expected_ranks[task_id]
+            task_id in self._world_sizes
+            and len(self._pending_traces[task_id]) >= self._world_sizes[task_id]
         ):
             await self._merge_and_save_traces(task_id)
 
@@ -551,5 +546,5 @@ class Master:
         )
 
         del self._pending_traces[task_id]
-        if task_id in self._expected_ranks:
-            del self._expected_ranks[task_id]
+        if task_id in self._world_sizes:
+            del self._world_sizes[task_id]

--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -262,20 +262,7 @@ def place_instance(
 
     match command.instance_meta:
         case InstanceMeta.MlxJaccl:
-            # TODO(evan): shard assignments should contain information about ranks, this is ugly
-            def get_device_rank(node_id: NodeId) -> int:
-                runner_id = shard_assignments.node_to_runner[node_id]
-                shard_metadata = shard_assignments.runner_to_shard.get(runner_id)
-                assert shard_metadata is not None
-                return shard_metadata.device_rank
-
-            zero_node_ids = [
-                node_id
-                for node_id in selected_cycle.node_ids
-                if get_device_rank(node_id) == 0
-            ]
-            assert len(zero_node_ids) == 1
-            coordinator_node_id = zero_node_ids[0]
+            coordinator_node_id = shard_assignments.shards[0].node_id
 
             mlx_jaccl_devices = get_mlx_jaccl_devices_matrix(
                 [node_id for node_id in selected_cycle],
@@ -376,10 +363,10 @@ def cancel_unnecessary_downloads(
     active_models = set(
         (
             node_id,
-            instance.shard_assignments.runner_to_shard[runner_id].model_card.model_id,
+            instance.shard_assignments.model_id,
         )
         for instance in instances.values()
-        for node_id, runner_id in instance.shard_assignments.node_to_runner.items()
+        for node_id, _, _ in instance.shard_assignments.shards
     )
     for pair in currently_downloading:
         if pair not in active_models:

--- a/src/exo/master/placement_utils.py
+++ b/src/exo/master/placement_utils.py
@@ -8,12 +8,11 @@ from exo.shared.types.common import Host, NodeId
 from exo.shared.types.memory import Memory
 from exo.shared.types.profiling import MemoryUsage, NodeNetworkInfo
 from exo.shared.types.topology import Cycle, RDMAConnection, SocketConnection
-from exo.shared.types.worker.runners import RunnerId, ShardAssignments
+from exo.shared.types.worker.runners import RunnerId, ShardAssignments, ShardWithId
 from exo.shared.types.worker.shards import (
     CfgShardMetadata,
     PipelineShardMetadata,
     Sharding,
-    ShardMetadata,
     TensorShardMetadata,
 )
 
@@ -152,27 +151,27 @@ def _get_shard_assignments_for_cfg_parallel(
     _validate_cycle(cycle)
 
     world_size = len(cycle)
-    cfg_world_size = 2
-    pipeline_world_size = world_size // cfg_world_size
+    pipeline_world_size = world_size // 2
 
     # Allocate layers for one pipeline group (both groups run the same layers)
     pipeline_node_ids = cycle.node_ids[:pipeline_world_size]
     pipeline_memory = _compute_total_memory(pipeline_node_ids, node_memory)
+
+    # nb: only validates the forward path...
     layer_allocations = _allocate_and_validate_layers(
         pipeline_node_ids, node_memory, pipeline_memory, model_card
     )
 
     # Ring topology: group 0 ascending [0,1,2,...], group 1 descending [...,2,1,0]
     # This places both last stages as neighbors for CFG exchange.
-    position_to_cfg_pipeline = [(0, r) for r in range(pipeline_world_size)] + [
-        (1, r) for r in reversed(range(pipeline_world_size))
-    ]
+    position_to_cfg_pipeline = list(range(pipeline_world_size)) + list(
+        reversed(range(pipeline_world_size))
+    )
 
-    runner_to_shard: dict[RunnerId, ShardMetadata] = {}
-    node_to_runner: dict[NodeId, RunnerId] = {}
+    shards: list[ShardWithId] = []
 
     for device_rank, node_id in enumerate(cycle.node_ids):
-        cfg_rank, pipeline_rank = position_to_cfg_pipeline[device_rank]
+        pipeline_rank = position_to_cfg_pipeline[device_rank]
         layers_before = sum(layer_allocations[:pipeline_rank])
         node_layers = layer_allocations[pipeline_rank]
 
@@ -183,20 +182,15 @@ def _get_shard_assignments_for_cfg_parallel(
             start_layer=layers_before,
             end_layer=layers_before + node_layers,
             n_layers=model_card.n_layers,
-            cfg_rank=cfg_rank,
-            cfg_world_size=cfg_world_size,
-            pipeline_rank=pipeline_rank,
-            pipeline_world_size=pipeline_world_size,
         )
 
         runner_id = RunnerId()
-        runner_to_shard[runner_id] = shard
-        node_to_runner[node_id] = runner_id
+        shards.append(ShardWithId(node_id, runner_id, shard))
 
     return ShardAssignments(
         model_id=model_card.model_id,
-        runner_to_shard=runner_to_shard,
-        node_to_runner=node_to_runner,
+        shards=shards,
+        primary_output_node=pipeline_world_size - 1,
     )
 
 
@@ -208,13 +202,13 @@ def _get_shard_assignments_for_pure_pipeline(
     """Create shard assignments for pure pipeline execution."""
     _validate_cycle(cycle)
     total_memory = _compute_total_memory(cycle.node_ids, node_memory)
+    world_size = len(cycle)
 
     layer_allocations = _allocate_and_validate_layers(
         cycle.node_ids, node_memory, total_memory, model_card
     )
 
-    runner_to_shard: dict[RunnerId, ShardMetadata] = {}
-    node_to_runner: dict[NodeId, RunnerId] = {}
+    shards: list[ShardWithId] = []
 
     for pipeline_rank, node_id in enumerate(cycle.node_ids):
         layers_before = sum(layer_allocations[:pipeline_rank])
@@ -223,20 +217,17 @@ def _get_shard_assignments_for_pure_pipeline(
         shard = PipelineShardMetadata(
             model_card=model_card,
             device_rank=pipeline_rank,
-            world_size=len(cycle),
+            world_size=world_size,
             start_layer=layers_before,
             end_layer=layers_before + node_layers,
             n_layers=model_card.n_layers,
         )
 
         runner_id = RunnerId()
-        runner_to_shard[runner_id] = shard
-        node_to_runner[node_id] = runner_id
+        shards.append(ShardWithId(node_id, runner_id, shard))
 
     return ShardAssignments(
-        model_id=model_card.model_id,
-        runner_to_shard=runner_to_shard,
-        node_to_runner=node_to_runner,
+        model_id=model_card.model_id, shards=shards, primary_output_node=world_size - 1
     )
 
 
@@ -246,8 +237,7 @@ def get_shard_assignments_for_tensor_parallel(
 ):
     total_layers = model_card.n_layers
     world_size = len(cycle)
-    runner_to_shard: dict[RunnerId, ShardMetadata] = {}
-    node_to_runner: dict[NodeId, RunnerId] = {}
+    shards: list[ShardWithId] = []
 
     for i, node_id in enumerate(cycle):
         shard = TensorShardMetadata(
@@ -260,14 +250,10 @@ def get_shard_assignments_for_tensor_parallel(
         )
 
         runner_id = RunnerId()
-
-        runner_to_shard[runner_id] = shard
-        node_to_runner[node_id] = runner_id
+        shards.append(ShardWithId(node_id, runner_id, shard))
 
     shard_assignments = ShardAssignments(
-        model_id=model_card.model_id,
-        runner_to_shard=runner_to_shard,
-        node_to_runner=node_to_runner,
+        model_id=model_card.model_id, shards=shards, primary_output_node=world_size - 1
     )
 
     return shard_assignments

--- a/src/exo/master/tests/test_master.py
+++ b/src/exo/master/tests/test_master.py
@@ -6,7 +6,6 @@ import pytest
 from loguru import logger
 
 from exo.master.main import Master
-from exo.routing.router import get_node_zid
 from exo.shared.models.model_cards import ModelCard, ModelTask
 from exo.shared.types.backends import Backend
 from exo.shared.types.commands import (
@@ -16,7 +15,7 @@ from exo.shared.types.commands import (
     PlaceInstance,
     TextGeneration,
 )
-from exo.shared.types.common import ModelId, SessionId, SystemId
+from exo.shared.types.common import ModelId, NodeId, SessionId, SystemId
 from exo.shared.types.events import (
     Event,
     GlobalForwarderEvent,
@@ -42,6 +41,7 @@ from exo.shared.types.worker.instances import (
     MlxRingInstance,
     ShardAssignments,
 )
+from exo.shared.types.worker.runners import ShardWithId
 from exo.shared.types.worker.shards import PipelineShardMetadata, Sharding
 from exo.utils.channels import channel
 from exo.utils.info_gatherer.info_gatherer import NodeBackends
@@ -68,7 +68,7 @@ class MockStorage:
 
 @pytest.mark.asyncio
 async def test_master():
-    node_id = get_node_zid()
+    node_id = NodeId("yoooo")
     session_id = SessionId(master_node_id=node_id, election_clock=0)
 
     ge_sender, global_event_receiver = channel[GlobalForwarderEvent]()
@@ -226,29 +226,33 @@ async def test_master():
         assert isinstance(events[2].event, InstanceCreated)
         created_instance = events[2].event.instance
         assert isinstance(created_instance, MlxRingInstance)
-        runner_id = list(created_instance.shard_assignments.runner_to_shard.keys())[0]
+        runner_id = created_instance.shard_assignments.shards[0].runner_id
         # Validate the shard assignments
         expected_shard_assignments = ShardAssignments(
             model_id=ModelId("llama-3.2-1b"),
-            runner_to_shard={
-                (runner_id): PipelineShardMetadata(
-                    start_layer=0,
-                    end_layer=16,
-                    n_layers=16,
-                    model_card=ModelCard(
-                        model_id=ModelId("llama-3.2-1b"),
+            shards=[
+                ShardWithId(
+                    node_id,
+                    runner_id,
+                    PipelineShardMetadata(
+                        start_layer=0,
+                        end_layer=16,
                         n_layers=16,
-                        storage_size=Memory.from_bytes(678948),
-                        hidden_size=7168,
-                        supports_tensor=True,
-                        tasks=[ModelTask.TextGeneration],
-                        backends=[Backend.MlxMetal],
+                        model_card=ModelCard(
+                            model_id=ModelId("llama-3.2-1b"),
+                            n_layers=16,
+                            storage_size=Memory.from_bytes(678948),
+                            hidden_size=7168,
+                            supports_tensor=True,
+                            tasks=[ModelTask.TextGeneration],
+                            backends=[Backend.MlxMetal],
+                        ),
+                        device_rank=0,
+                        world_size=1,
                     ),
-                    device_rank=0,
-                    world_size=1,
                 )
-            },
-            node_to_runner={node_id: runner_id},
+            ],
+            primary_output_node=0,
         )
         assert created_instance.shard_assignments == expected_shard_assignments
         # For single-node, hosts_by_node should have one entry with self-binding

--- a/src/exo/master/tests/test_placement.py
+++ b/src/exo/master/tests/test_placement.py
@@ -49,16 +49,36 @@ from exo.shared.types.worker.instances import (
     MlxJacclInstance,
     MlxRingInstance,
 )
-from exo.shared.types.worker.runners import ShardAssignments
+from exo.shared.types.worker.runners import RunnerId, ShardAssignments, ShardWithId
 from exo.shared.types.worker.shards import PipelineShardMetadata, Sharding
 
 
+class MockShard:
+    def is_primary_output(self) -> bool:
+        return True
+
+
 @pytest.fixture
-def instance() -> Instance:
+def instance(model_card: ModelCard) -> Instance:
     return MlxRingInstance(
         instance_id=InstanceId(),
         shard_assignments=ShardAssignments(
-            model_id=ModelId("test-model"), runner_to_shard={}, node_to_runner={}
+            model_id=ModelId("test-model"),
+            shards=[
+                ShardWithId(
+                    NodeId(),
+                    RunnerId(),
+                    PipelineShardMetadata(
+                        model_card=model_card,
+                        device_rank=0,
+                        world_size=1,
+                        start_layer=0,
+                        end_layer=model_card.n_layers,
+                        n_layers=model_card.n_layers,
+                    ),
+                )
+            ],
+            primary_output_node=0,
         ),
         hosts_by_node={},
         ephemeral_port=50000,
@@ -123,6 +143,11 @@ def test_get_instance_placements_create_instance(
     node_id_a = NodeId()
     node_id_b = NodeId()
     node_id_c = NodeId()
+    node_to_layers = {
+        node_id_a: expected_layers[0],
+        node_id_b: expected_layers[1],
+        node_id_c: expected_layers[2],
+    }
 
     # fully connected (directed) between the 3 nodes
     conn_a_b = Connection(
@@ -175,22 +200,11 @@ def test_get_instance_placements_create_instance(
     instance = placements[instance_id]
     assert instance.shard_assignments.model_id == model_card.model_id
 
-    runner_id_a = instance.shard_assignments.node_to_runner[node_id_a]
-    runner_id_b = instance.shard_assignments.node_to_runner[node_id_b]
-    runner_id_c = instance.shard_assignments.node_to_runner[node_id_c]
+    for nid, _, shard in (shards := instance.shard_assignments.shards):
+        assert shard.end_layer - shard.start_layer == node_to_layers[nid]
 
-    shard_a = instance.shard_assignments.runner_to_shard[runner_id_a]
-    shard_b = instance.shard_assignments.runner_to_shard[runner_id_b]
-    shard_c = instance.shard_assignments.runner_to_shard[runner_id_c]
-
-    assert shard_a.end_layer - shard_a.start_layer == expected_layers[0]
-    assert shard_b.end_layer - shard_b.start_layer == expected_layers[1]
-    assert shard_c.end_layer - shard_c.start_layer == expected_layers[2]
-
-    shards = [shard_a, shard_b, shard_c]
-    shards_sorted = sorted(shards, key=lambda s: s.start_layer)
-    assert shards_sorted[0].start_layer == 0
-    assert shards_sorted[-1].end_layer == total_layers
+    assert shards[0].shard.start_layer == 0
+    assert shards[-1].shard.end_layer == total_layers
 
 
 def test_get_instance_placements_one_node_exact_fit() -> None:
@@ -218,9 +232,7 @@ def test_get_instance_placements_one_node_exact_fit() -> None:
     instance_id = list(placements.keys())[0]
     instance = placements[instance_id]
     assert instance.shard_assignments.model_id == "test-model"
-    assert len(instance.shard_assignments.node_to_runner) == 1
-    assert len(instance.shard_assignments.runner_to_shard) == 1
-    assert len(instance.shard_assignments.runner_to_shard) == 1
+    assert len(instance.shard_assignments.shards) == 1
 
 
 def test_get_instance_placements_one_node_fits_with_extra_memory() -> None:
@@ -248,9 +260,7 @@ def test_get_instance_placements_one_node_fits_with_extra_memory() -> None:
     instance_id = list(placements.keys())[0]
     instance = placements[instance_id]
     assert instance.shard_assignments.model_id == "test-model"
-    assert len(instance.shard_assignments.node_to_runner) == 1
-    assert len(instance.shard_assignments.runner_to_shard) == 1
-    assert len(instance.shard_assignments.runner_to_shard) == 1
+    assert len(instance.shard_assignments.shards) == 1
 
 
 def test_get_instance_placements_one_node_not_fit() -> None:
@@ -381,7 +391,7 @@ def test_placement_selects_leaf_nodes(
     assert len(placements) == 1
     instance = list(placements.values())[0]
 
-    assigned_nodes = set(instance.shard_assignments.node_to_runner.keys())
+    assigned_nodes = set(map(lambda it: it.node_id, instance.shard_assignments.shards))
     assert assigned_nodes == set((node_id_a, node_id_b)) or assigned_nodes == set(
         (
             node_id_c,
@@ -498,8 +508,8 @@ def test_tensor_rdma_backend_connectivity_matrix(
     for i in range(3):
         assert matrix[i][i] is None
 
-    assigned_nodes = list(instance.shard_assignments.node_to_runner.keys())
-    node_to_idx = {node_id: idx for idx, node_id in enumerate(assigned_nodes)}
+    assigned_nodes = list(instance.shard_assignments.shards)
+    node_to_idx = {node_id: idx for idx, (node_id, _, _) in enumerate(assigned_nodes)}
 
     idx_a = node_to_idx[node_a]
     idx_b = node_to_idx[node_b]
@@ -511,7 +521,7 @@ def test_tensor_rdma_backend_connectivity_matrix(
 
     # Verify coordinators are set for all nodes
     assert len(instance.jaccl_coordinators) == 3
-    for node_id in assigned_nodes:
+    for node_id, _, _ in assigned_nodes:
         assert node_id in instance.jaccl_coordinators
         coordinator = instance.jaccl_coordinators[node_id]
         assert ":" in coordinator
@@ -825,7 +835,7 @@ def test_placement_prefers_cycle_with_downloaded_model(
 
     assert len(placements) == 1
     instance = list(placements.values())[0]
-    assigned_nodes = set(instance.shard_assignments.node_to_runner.keys())
+    assigned_nodes = set(map(lambda it: it.node_id, instance.shard_assignments.shards))
     assert assigned_nodes == {node_b}
 
 
@@ -903,7 +913,7 @@ def test_placement_prefers_cycle_with_higher_download_progress(
 
     assert len(placements) == 1
     instance = list(placements.values())[0]
-    assigned_nodes = set(instance.shard_assignments.node_to_runner.keys())
+    assigned_nodes = set(map(lambda it: it.node_id, instance.shard_assignments.shards))
     assert assigned_nodes == {node_b}
 
 
@@ -957,7 +967,7 @@ def test_placement_does_not_prefer_cycle_with_failed_download(
 
     assert len(placements) == 1
     instance = list(placements.values())[0]
-    assigned_nodes = set(instance.shard_assignments.node_to_runner.keys())
+    assigned_nodes = set(map(lambda it: it.node_id, instance.shard_assignments.shards))
     # node_a should win on RAM tiebreaker since failed download scores 0.0
     assert assigned_nodes == {node_a}
 

--- a/src/exo/master/tests/test_placement_utils.py
+++ b/src/exo/master/tests/test_placement_utils.py
@@ -204,6 +204,11 @@ def test_get_shard_assignments(
     node_a_id = NodeId()
     node_b_id = NodeId()
     node_c_id = NodeId()
+    layers_by_node = {
+        node_a_id: expected_layers[0],
+        node_b_id: expected_layers[1],
+        node_c_id: expected_layers[2],
+    }
 
     # create connections (A -> B -> C -> A forms a 3-cycle, plus B -> A also exists)
     connection1 = Connection(
@@ -258,25 +263,8 @@ def test_get_shard_assignments(
     )
 
     # assert
-    runner_id_a = shard_assignments.node_to_runner[node_a_id]
-    runner_id_b = shard_assignments.node_to_runner[node_b_id]
-    runner_id_c = shard_assignments.node_to_runner[node_c_id]
-
-    assert (
-        shard_assignments.runner_to_shard[runner_id_a].end_layer
-        - shard_assignments.runner_to_shard[runner_id_a].start_layer
-        == expected_layers[0]
-    )
-    assert (
-        shard_assignments.runner_to_shard[runner_id_b].end_layer
-        - shard_assignments.runner_to_shard[runner_id_b].start_layer
-        == expected_layers[1]
-    )
-    assert (
-        shard_assignments.runner_to_shard[runner_id_c].end_layer
-        - shard_assignments.runner_to_shard[runner_id_c].start_layer
-        == expected_layers[2]
-    )
+    for nid, _, shard in shard_assignments.shards:
+        assert shard.end_layer - shard.start_layer == layers_by_node[nid]
 
 
 def test_get_mlx_jaccl_coordinators():
@@ -543,11 +531,11 @@ class TestCfgParallelPlacement:
             model_card, cycle, node_memory
         )
 
-        shards = list(assignments.runner_to_shard.values())
+        shards = list(assignments.shards)
         assert len(shards) == 2
 
         # CFG models should get CfgShardMetadata
-        for shard in shards:
+        for _, _, shard in shards:
             assert isinstance(shard, CfgShardMetadata)
             # Both nodes should have all layers (no pipeline split)
             assert shard.start_layer == 0
@@ -558,7 +546,7 @@ class TestCfgParallelPlacement:
             assert shard.pipeline_rank == 0
 
         cfg_ranks = sorted(
-            s.cfg_rank for s in shards if isinstance(s, CfgShardMetadata)
+            s.shard.cfg_rank for s in shards if isinstance(s.shard, CfgShardMetadata)
         )
         assert cfg_ranks == [0, 1]
 
@@ -587,11 +575,11 @@ class TestCfgParallelPlacement:
             model_card, cycle, node_memory
         )
 
-        shards = list(assignments.runner_to_shard.values())
+        shards = assignments.shards
         assert len(shards) == 4
 
         # CFG models should get CfgShardMetadata
-        for shard in shards:
+        for _, _, shard in shards:
             assert isinstance(shard, CfgShardMetadata)
             assert shard.cfg_world_size == 2
             assert shard.pipeline_world_size == 2
@@ -599,10 +587,14 @@ class TestCfgParallelPlacement:
 
         # Check we have 2 nodes in each CFG group
         cfg_0_shards = [
-            s for s in shards if isinstance(s, CfgShardMetadata) and s.cfg_rank == 0
+            s.shard
+            for s in shards
+            if isinstance(s.shard, CfgShardMetadata) and s.shard.cfg_rank == 0
         ]
         cfg_1_shards = [
-            s for s in shards if isinstance(s, CfgShardMetadata) and s.cfg_rank == 1
+            s.shard
+            for s in shards
+            if isinstance(s.shard, CfgShardMetadata) and s.shard.cfg_rank == 1
         ]
         assert len(cfg_0_shards) == 2
         assert len(cfg_1_shards) == 2
@@ -637,11 +629,11 @@ class TestCfgParallelPlacement:
             model_card, cycle, node_memory
         )
 
-        shards = list(assignments.runner_to_shard.values())
+        shards = list(assignments.shards)
         assert len(shards) == 3
 
         # Odd node count with CFG model falls back to PipelineShardMetadata (sequential CFG)
-        for shard in shards:
+        for _, _, shard in shards:
             assert isinstance(shard, PipelineShardMetadata)
 
     def test_two_nodes_non_cfg_model_uses_pipeline(self):
@@ -673,18 +665,18 @@ class TestCfgParallelPlacement:
             model_card, cycle, node_memory
         )
 
-        shards = list(assignments.runner_to_shard.values())
+        shards = list(assignments.shards)
         assert len(shards) == 2
 
         # Non-CFG models should get PipelineShardMetadata
-        for shard in shards:
+        for _, _, shard in shards:
             assert isinstance(shard, PipelineShardMetadata)
 
         # Should have actual layer sharding (pipeline)
         layer_ranges = sorted(
-            (s.start_layer, s.end_layer)
+            (s.shard.start_layer, s.shard.end_layer)
             for s in shards
-            if isinstance(s, PipelineShardMetadata)
+            if isinstance(s.shard, PipelineShardMetadata)
         )
         # First shard starts at 0, last shard ends at 57
         assert layer_ranges[0][0] == 0

--- a/src/exo/shared/types/worker/instances.py
+++ b/src/exo/shared/types/worker/instances.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from enum import Enum
 
 from pydantic import model_validator
@@ -22,7 +23,14 @@ class BaseInstance(TaggedModel):
     shard_assignments: ShardAssignments
 
     def shard(self, runner_id: RunnerId) -> ShardMetadata | None:
-        return self.shard_assignments.runner_to_shard.get(runner_id, None)
+        for _, rid, shard in self.shard_assignments.shards:
+            if rid == runner_id:
+                return shard
+
+    def runners_for(self, node_id: NodeId) -> Iterable[RunnerId]:
+        for nid, rid, _ in self.shard_assignments.shards:
+            if nid == node_id:
+                yield rid
 
 
 class MlxRingInstance(BaseInstance):
@@ -59,8 +67,9 @@ class BoundInstance(FrozenModel):
 
     @model_validator(mode="after")
     def validate_shard_exists(self) -> "BoundInstance":
-        assert (
-            self.bound_runner_id in self.instance.shard_assignments.runner_to_shard
+        assert any(
+            rid == self.bound_runner_id
+            for (_, rid, _) in self.instance.shard_assignments.shards
         ), (
             "Bound Instance must be constructed with a runner_id that is in the instances assigned shards"
         )

--- a/src/exo/shared/types/worker/runners.py
+++ b/src/exo/shared/types/worker/runners.py
@@ -1,4 +1,5 @@
-from collections.abc import Mapping
+from collections.abc import Sequence
+from typing import NamedTuple
 
 from pydantic import model_validator
 
@@ -83,16 +84,26 @@ RunnerStatus = (
 )
 
 
+class ShardWithId(NamedTuple):
+    node_id: NodeId
+    runner_id: RunnerId
+    shard: ShardMetadata
+
+
 class ShardAssignments(FrozenModel):
     model_id: ModelId
-    runner_to_shard: Mapping[RunnerId, ShardMetadata]
-    node_to_runner: Mapping[NodeId, RunnerId]
+    shards: Sequence[ShardWithId]
+    # this node needs to be connected to the API node for the stream to be considered ready
+    # (this is a device rank)
+    primary_output_node: int
 
     @model_validator(mode="after")
     def validate_runners_exist(self) -> "ShardAssignments":
-        for runner_id in self.node_to_runner.values():
-            if runner_id not in self.runner_to_shard:
-                raise ValueError(
-                    f"Runner {runner_id} in node_to_runner does not exist in runner_to_shard"
-                )
+        for position, shard in enumerate(self.shards):
+            if shard.shard.device_rank != position:
+                raise ValueError("shard position does not correspond to device rank")
+
+        if not self.shards[self.primary_output_node].shard.is_primary_output():
+            raise ValueError("primary output node does not correspond to primary shard")
+
         return self

--- a/src/exo/shared/types/worker/shards.py
+++ b/src/exo/shared/types/worker/shards.py
@@ -15,17 +15,13 @@ class Sharding(str, Enum):
 class BaseShardMetadata(TaggedModel):
     """
     Defines a specific shard of the model that is ready to be run on a device.
-    Replaces previous `Shard` object.
+    Layers are represented as a half-open interval [start_layer, end_layer),
+    where start_layer is inclusive and end_layer is exclusive.
     """
 
     model_card: ModelCard
     device_rank: int
     world_size: int
-
-    # Error handling; equivalent to monkey-patch, but we can't monkey-patch runner.py
-    # This is kinda annoying because it allocates memory in the ShardMetadata object. Can be rethought after Shanghai.
-    immediate_exception: bool = False
-    should_timeout: float | None = None
 
     start_layer: int = Field(ge=0)
     end_layer: int = Field(ge=0)
@@ -51,27 +47,56 @@ class BaseShardMetadata(TaggedModel):
             )
         )
 
+    def is_primary_output(self) -> bool:
+        return self.device_rank == self.world_size - 1
+
 
 @final
 class PipelineShardMetadata(BaseShardMetadata):
-    """
-    Pipeline parallelism shard meta.
-
-    Layers are represented as a half-open interval [start_layer, end_layer),
-    where start_layer is inclusive and end_layer is exclusive.
-    """
+    pass
 
 
 @final
 class CfgShardMetadata(BaseShardMetadata):
-    """Shard metadata for CFG-parallel image generation models."""
+    # example
+    # world_size 6
+    # rank prank crank
+    #  0     0     0
+    #  1     1     0
+    #  2     2     0
+    #  3     2     1
+    #  4     1     1
+    #  5     0     1
 
-    cfg_rank: int  # 0 = positive branch, 1 = negative branch
-    cfg_world_size: int = 2
+    @property
+    def cfg_rank(self) -> int:
+        # 0 = positive branch, 1 = negative branch
+        return 0 if self.device_rank < self.world_size // 2 else 1
 
-    # Pipeline-relative coordinates (computed at placement time)
-    pipeline_rank: int  # rank within the pipeline group (0, 1, 2, ...)
-    pipeline_world_size: int  # number of nodes per pipeline group
+    @property
+    def cfg_world_size(self) -> int:
+        return 2
+
+    @property
+    def pipeline_rank(self) -> int:
+        return (
+            self.device_rank
+            if self.cfg_rank == 0
+            else (self.world_size - self.device_rank - 1)
+        )
+
+    @property
+    def pipeline_world_size(self) -> int:
+        return self.world_size // 2
+
+    def is_primary_output(self) -> bool:
+        """
+        For CFG models: the last pipeline stage in CFG group 0 (positive prompt).
+        For non-CFG models: the last pipeline stage.
+        """
+        assert self.pipeline_world_size == self.world_size // 2
+        assert self.world_size % 2 == 0
+        return self.device_rank == (self.world_size // 2) - 1
 
 
 @final

--- a/src/exo/utils/__init__.py
+++ b/src/exo/utils/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Type
+from typing import Any, Callable, Iterable, Iterator, Type, TypeGuard
 
 from .phantom import PhantomData
 
@@ -19,3 +19,11 @@ def todo[T](
     _phantom: PhantomData[T] = None,
 ) -> T:
     raise NotImplementedError(msg)
+
+
+def not_none[T](t: T | None) -> TypeGuard[T]:
+    return t is not None
+
+
+def fmap[T, U](f: Callable[[T], U | None], s: Iterable[T]) -> Iterator[U]:
+    return filter(not_none, map(f, s))

--- a/src/exo/worker/engines/image/builder.py
+++ b/src/exo/worker/engines/image/builder.py
@@ -30,8 +30,6 @@ from exo.shared.types.worker.runner_response import (
     ModelLoadingResponse,
 )
 from exo.shared.types.worker.shards import (
-    CfgShardMetadata,
-    PipelineShardMetadata,
     ShardMetadata,
 )
 from exo.utils.channels import MpReceiver, MpSender
@@ -47,22 +45,6 @@ from exo.worker.engines.image.generate import (
 from exo.worker.engines.mlx.utils_mlx import (
     initialize_mlx,
 )
-
-
-def _is_primary_output_node(shard_metadata: ShardMetadata) -> bool:
-    """Check if this node is the primary output node for image generation.
-
-    For CFG models: the last pipeline stage in CFG group 0 (positive prompt).
-    For non-CFG models: the last pipeline stage.
-    """
-    if isinstance(shard_metadata, CfgShardMetadata):
-        is_pipeline_last = (
-            shard_metadata.pipeline_rank == shard_metadata.pipeline_world_size - 1
-        )
-        return is_pipeline_last and shard_metadata.cfg_rank == 0
-    elif isinstance(shard_metadata, PipelineShardMetadata):
-        return shard_metadata.device_rank == shard_metadata.world_size - 1
-    return False
 
 
 def _send_traces_if_enabled(
@@ -171,7 +153,7 @@ class ImageEngine(Engine):
             resp = next(self.current_gen, None)
         return (
             (resp,)
-            if resp is not None and _is_primary_output_node(self.shard_metadata)
+            if resp is not None and self.shard_metadata.is_primary_output()
             else ()
         )
 
@@ -202,10 +184,10 @@ class ImageEngine(Engine):
                 task=task_params,
                 cancel_checker=cancel_checker,
             ):
-                if _is_primary_output_node(self.shard_metadata):
+                if self.shard_metadata.is_primary_output():
                     yield (task_id, response)
         except Exception as e:
-            if _is_primary_output_node(self.shard_metadata):
+            if self.shard_metadata.is_primary_output():
                 yield (
                     task_id,
                     ErrorChunk(

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -154,7 +154,7 @@ def initialize_mlx(
     # TODO: pass in seed from params
     mx.random.seed(42)
 
-    assert len(bound_instance.instance.shard_assignments.node_to_runner) > 1, (
+    assert len(bound_instance.instance.shard_assignments.shards) > 1, (
         "Tried to initialize mlx for a single node instance"
     )
     return mlx_distributed_init(bound_instance)

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -383,9 +383,8 @@ class Worker:
 
     async def _start_runner_task(self, task: Task):
         if (instance := self.state.instances.get(task.instance_id)) is not None:
-            await self.runners[
-                instance.shard_assignments.node_to_runner[self.node_id]
-            ].start_task(task)
+            for rid in instance.runners_for(self.node_id):
+                await self.runners[rid].start_task(task)
 
     async def _create_supervisor(self, task: CreateRunner) -> RunnerSupervisor:
         """Creates and stores a new AssignedRunner with initial downloading status."""

--- a/src/exo/worker/plan.py
+++ b/src/exo/worker/plan.py
@@ -40,6 +40,7 @@ from exo.shared.types.worker.runners import (
     RunnerStatus,
     RunnerWarmingUp,
 )
+from exo.utils import fmap
 from exo.utils.keyed_backoff import KeyedBackoff
 from exo.worker.runner.supervisor import RunnerSupervisor
 
@@ -88,8 +89,10 @@ def _kill_runner(
             )
 
         for (
-            global_runner_id
-        ) in runner.bound_instance.instance.shard_assignments.node_to_runner.values():
+            _,
+            global_runner_id,
+            _,
+        ) in runner.bound_instance.instance.shard_assignments.shards:
             if runner_id == global_runner_id:
                 continue
 
@@ -108,7 +111,13 @@ def _create_runner(
     instance_backoff: KeyedBackoff[InstanceId],
 ) -> CreateRunner | None:
     for instance in instances.values():
-        runner_id = instance.shard_assignments.node_to_runner.get(node_id, None)
+        runner_id = next(
+            fmap(
+                lambda it: it.runner_id if it.node_id == node_id else None,
+                instance.shard_assignments.shards,
+            ),
+            None,
+        )
         if runner_id is None:
             continue
 
@@ -118,7 +127,7 @@ def _create_runner(
         # don't create runners if any other nodes have runners that have failed - wait for them to fix themselves first.
         instance_has_failed_runner = any(
             isinstance(all_runners.get(remote_runner_id), RunnerFailed)
-            for remote_runner_id in instance.shard_assignments.node_to_runner.values()
+            for (_, remote_runner_id, _) in instance.shard_assignments.shards
             if remote_runner_id != runner_id
         )
         we_have_failed_before = isinstance(all_runners.get(runner_id), RunnerFailed)
@@ -175,7 +184,7 @@ def _init_distributed_backend(
         instance = runner.bound_instance.instance
         shard_assignments = instance.shard_assignments
 
-        is_single_node_instance = len(shard_assignments.runner_to_shard) == 1
+        is_single_node_instance = len(shard_assignments.shards) == 1
         if is_single_node_instance:
             continue
 
@@ -185,7 +194,7 @@ def _init_distributed_backend(
                 all_runners.get(global_runner_id),
                 (RunnerConnecting, RunnerIdle),
             )
-            for global_runner_id in shard_assignments.runner_to_shard
+            for (_, global_runner_id, _) in shard_assignments.shards
         )
 
         if not (runner_is_idle and all_runners_connecting):
@@ -205,7 +214,7 @@ def _init_distributed_backend(
         # Rank = n-1
         connecting_rank_ready = device_rank == world_size - 1 and all(
             isinstance(all_runners.get(global_runner_id, None), RunnerConnecting)
-            for global_runner_id in shard_assignments.runner_to_shard
+            for (_, global_runner_id, _) in shard_assignments.shards
             if global_runner_id != runner_id
         )
 
@@ -233,12 +242,12 @@ def _load_model(
                 and dp.shard_metadata.model_card.model_id == shard_assignments.model_id
                 for dp in global_download_status[nid]
             )
-            for nid in shard_assignments.node_to_runner
+            for (nid, _, _) in shard_assignments.shards
         )
         if not all_local_downloads_complete:
             continue
 
-        is_single_node_instance = len(instance.shard_assignments.runner_to_shard) == 1
+        is_single_node_instance = len(instance.shard_assignments.shards) == 1
         if is_single_node_instance and isinstance(runner.status, RunnerIdle):
             return LoadModel(instance_id=instance.instance_id)
 
@@ -249,7 +258,7 @@ def _load_model(
                 all_runners.get(global_runner_id, None),
                 (RunnerConnected, RunnerLoading, RunnerLoaded),
             )
-            for global_runner_id in shard_assignments.runner_to_shard
+            for (_, global_runner_id, _) in shard_assignments.shards
         )
 
         if is_runner_waiting and all_ready_for_model:
@@ -281,13 +290,13 @@ def _ready_to_warmup(
                 all_runners.get(global_runner_id, None),
                 (RunnerLoaded, RunnerWarmingUp),
             )
-            for global_runner_id in shard_assignments.runner_to_shard
+            for (_, global_runner_id, _) in shard_assignments.shards
         )
 
         # Rank = 0
         connecting_rank_ready = device_rank == 0 and all(
             isinstance(all_runners.get(global_runner_id, None), RunnerWarmingUp)
-            for global_runner_id in shard_assignments.runner_to_shard
+            for (_, global_runner_id, _) in shard_assignments.shards
             if global_runner_id != runner_id
         )
 
@@ -338,7 +347,11 @@ def _pending_tasks(
 
             if isinstance(runner.status, (RunnerReady, RunnerRunning)) and all(
                 isinstance(all_runners[global_runner_id], (RunnerReady, RunnerRunning))
-                for global_runner_id in runner.bound_instance.instance.shard_assignments.runner_to_shard
+                for (
+                    _,
+                    global_runner_id,
+                    _,
+                ) in runner.bound_instance.instance.shard_assignments.shards
             ):
                 return task
 

--- a/src/exo/worker/runner/runner.py
+++ b/src/exo/worker/runner/runner.py
@@ -102,10 +102,6 @@ class Runner:
         self.device_rank = self.shard_metadata.device_rank
 
         logger.info("hello from the runner")
-        if getattr(self.shard_metadata, "immediate_exception", False):
-            raise Exception("Fake exception - runner failed to spin up.")
-        if timeout := getattr(self.shard_metadata, "should_timeout", 0):
-            time.sleep(timeout)
 
         self.setup_start_time = time.time()
 

--- a/src/exo/worker/tests/unittests/conftest.py
+++ b/src/exo/worker/tests/unittests/conftest.py
@@ -11,7 +11,12 @@ from exo.shared.types.worker.instances import (
     InstanceId,
     MlxRingInstance,
 )
-from exo.shared.types.worker.runners import RunnerId, RunnerStatus, ShardAssignments
+from exo.shared.types.worker.runners import (
+    RunnerId,
+    RunnerStatus,
+    ShardAssignments,
+    ShardWithId,
+)
 from exo.shared.types.worker.shards import PipelineShardMetadata, ShardMetadata
 
 
@@ -52,16 +57,22 @@ def get_pipeline_shard_metadata(
     )
 
 
+# todo: clean up legacy formatted shards
 def get_shard_assignments(
     model_id: ModelId,
     node_to_runner: dict[NodeId, RunnerId],
     runner_to_shard: dict[RunnerId, ShardMetadata],
 ) -> ShardAssignments:
-    return ShardAssignments(
-        model_id=model_id,
-        node_to_runner=node_to_runner,
-        runner_to_shard=runner_to_shard,
-    )
+    pon = 0
+    shards = [
+        ShardWithId(nid, rid := node_to_runner[nid], runner_to_shard[rid])
+        for nid in node_to_runner
+    ]
+    for i, (_, _, shard) in enumerate(shards):
+        if shard.is_primary_output():
+            pon = i
+
+    return ShardAssignments(model_id=model_id, shards=shards, primary_output_node=pon)
 
 
 def get_mlx_ring_instance(

--- a/tools/src/exo_tools/harness.py
+++ b/tools/src/exo_tools/harness.py
@@ -52,18 +52,17 @@ def instance_id_from_instance(instance: dict[str, Any]) -> str:
 
 def nodes_used_in_instance(instance: dict[str, Any]) -> int:
     inner = unwrap_instance(instance)
-    return len(inner["shardAssignments"]["nodeToRunner"])
+    return len(inner["shardAssignments"]["shards"])
 
 
 def runner_ids_from_instance(instance: dict[str, Any]) -> list[str]:
     inner = unwrap_instance(instance)
-    runner_to_shard = inner["shardAssignments"]["runnerToShard"]
-    return list(runner_to_shard.keys())
+    return [r for (_, r, _) in inner["shardAssignments"]["shards"]]
 
 
 def node_ids_from_instance(instance: dict[str, Any]) -> list[str]:
     inner = unwrap_instance(instance)
-    return list(inner["shardAssignments"]["nodeToRunner"].keys())
+    return [n for (n, _, _) in inner["shardAssignments"]["shards"]]
 
 
 def runner_ready(runner: dict[str, Any]) -> bool:
@@ -322,8 +321,8 @@ def run_planning_phase(
 
     # Get nodes from preview
     inner = unwrap_instance(preview["instance"])
-    node_ids = list(inner["shardAssignments"]["nodeToRunner"].keys())
-    runner_to_shard = inner["shardAssignments"]["runnerToShard"]
+    node_ids = [n for (n, _, _) in inner["shardAssignments"]["shards"]]
+    shards = inner["shardAssignments"]["shards"]
 
     needs_download = False
 
@@ -391,9 +390,7 @@ def run_planning_phase(
 
     # Start downloads (idempotent)
     download_t0 = time.perf_counter() if needs_download else None
-    for node_id in node_ids:
-        runner_id = inner["shardAssignments"]["nodeToRunner"][node_id]
-        shard = runner_to_shard[runner_id]
+    for node_id, _, shard in shards:
         client.request_json(
             "POST",
             "/download/start",


### PR DESCRIPTION
replaces node_to_runner and runner_to_shard with a list by device rank of node ids, runner ids and shardmetadata. centralizes the concept of a "primary output node" -- n-1 for pipeline and tensor instances, n//2 - 1 for CFG instances.