### PR TITLE
fix(runner): handle fused/embedded think delimiters in parse_thinking_models

### DIFF
--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -390,6 +390,9 @@ def parse_thinking_models(
             yield response.model_copy(update={"is_thinking": False})
             continue
 
+        # Fast path: the delimiter arrives as its own clean chunk (or the
+        # accumulation is exactly the delimiter). Preserved verbatim so the
+        # existing clean-token behavior and its regression tests are untouched.
         if accumulated == think_start and not is_thinking:
             is_thinking = True
             accumulated = ""
@@ -399,6 +402,60 @@ def parse_thinking_models(
             is_thinking = False
             accumulated = ""
             pending_buffer.clear()
+            continue
+
+        # Fused / embedded delimiter handling.
+        #
+        # The mlx-lm streaming detokenizer yields `last_segment` deltas that can
+        # carry MORE than one token's text, so a think delimiter may arrive
+        # glued to neighbouring text in a single chunk (e.g. "code.</think>def")
+        # or the accumulation may overshoot the exact match when the delimiter
+        # spans chunks (e.g. "</" then "think>def" -> "</think>def"). The
+        # exact-equality checks above miss both cases, which previously leaked
+        # the delimiter + the post-delimiter answer into the wrong stream
+        # (reasoning text + code dumped into `content`). Detect the currently
+        # active delimiter as a SUBSTRING and split around it. Loop so multiple
+        # delimiters fused into one chunk are all handled.
+        active = think_end if is_thinking else think_start
+        if active and active in accumulated:
+            # Any prefix-buffered tokens are mirrored in `accumulated` (both are
+            # appended in lockstep), so their text is already represented in the
+            # split below. Discard the parallel copy rather than draining it, to
+            # avoid double-emitting delimiter fragments that were buffered as a
+            # clean prefix (e.g. "</" then "think>answer").
+            pending_buffer.clear()
+            while True:
+                active = think_end if is_thinking else think_start
+                if not active or active not in accumulated:
+                    break
+                idx = accumulated.index(active)
+                pre = accumulated[:idx]
+                if pre:
+                    yield response.model_copy(
+                        update={"text": pre, "is_thinking": is_thinking}
+                    )
+                # Swallow the delimiter and flip the thinking state.
+                is_thinking = not is_thinking
+                accumulated = accumulated[idx + len(active):]
+            # Handle the remainder after the last delimiter. If it is a clean
+            # (incomplete) prefix of the next possible delimiter, keep it
+            # buffered and wait for more; otherwise emit it with the new flag.
+            if accumulated:
+                nxt = think_end if is_thinking else think_start
+                is_clean_prefix = bool(
+                    nxt
+                    and len(accumulated) < len(nxt)
+                    and accumulated == nxt[: len(accumulated)]
+                )
+                if is_clean_prefix:
+                    pending_buffer.append(
+                        response.model_copy(update={"text": accumulated})
+                    )
+                else:
+                    yield response.model_copy(
+                        update={"text": accumulated, "is_thinking": is_thinking}
+                    )
+                    accumulated = ""
             continue
 
         if (think_start and accumulated == think_start[: len(accumulated)]) or (

--- a/src/exo/worker/tests/unittests/test_runner/test_finish_reason_sse.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_finish_reason_sse.py
@@ -672,3 +672,139 @@ class TestThinkingModelsPrefixBuffering:
         assert "<parameter=pattern>" in raw
         assert "</parameter>" in raw
         assert "</function>" in raw
+
+
+# ── parse_thinking_models fused / embedded delimiter ────────────
+#
+# Regression coverage for the bug where the mlx-lm streaming detokenizer
+# delivers a think delimiter glued to neighbouring text in a single chunk
+# (e.g. "Let's code.</think>def fibonacci(n):"). The exact-equality boundary
+# check missed this and leaked the delimiter + the real answer into the
+# reasoning stream, dumping chain-of-thought prose into `content`.
+
+
+class TestThinkingModelsFusedDelimiter:
+    def test_fused_end_delimiter_single_chunk(self):
+        # The confirmed production bug: </think> fused mid-chunk with both the
+        # trailing reasoning and the opening of the real answer.
+        tokens = [
+            _make_response("reasoning here ", 0),
+            _make_response("done.</think>def fibonacci(n):", 1),
+            _make_response("", 2, finish_reason="stop"),
+        ]
+        results = _step_until_finish(
+            parse_thinking_models(
+                _queue_source(tokens),
+                think_start="<think>",
+                think_end="</think>",
+                starts_in_thinking=True,
+            )
+        )
+        gens = [
+            r
+            for r in results
+            if isinstance(r, GenerationResponse) and r.finish_reason is None
+        ]
+        texts = [(r.text, r.is_thinking) for r in gens]
+        # pre-delimiter text stays in the thinking stream, post-delimiter
+        # answer is content, delimiter itself is swallowed.
+        assert texts == [
+            ("reasoning here ", True),
+            ("done.", True),
+            ("def fibonacci(n):", False),
+        ]
+        assert "</think>" not in _drain_text(results)
+
+    def test_end_delimiter_spanning_two_chunks(self):
+        # Delimiter split across chunks so accumulation overshoots the exact
+        # match: "</" then "think>def" -> accumulated "</think>def".
+        tokens = [
+            _make_response("body", 0),
+            _make_response("</", 1),
+            _make_response("think>answer", 2),
+            _make_response("", 3, finish_reason="stop"),
+        ]
+        results = _step_until_finish(
+            parse_thinking_models(
+                _queue_source(tokens),
+                think_start="<think>",
+                think_end="</think>",
+                starts_in_thinking=True,
+            )
+        )
+        gens = [
+            r
+            for r in results
+            if isinstance(r, GenerationResponse) and r.finish_reason is None
+        ]
+        texts = [(r.text, r.is_thinking) for r in gens]
+        assert texts == [("body", True), ("answer", False)]
+        assert "</think>" not in _drain_text(results)
+
+    def test_clean_end_delimiter_token_regression(self):
+        # The delimiter arriving as its own clean token must keep working
+        # exactly as before (fast path untouched).
+        tokens = [
+            _make_response("body", 0),
+            _make_response("</think>", 1),
+            _make_response("answer", 2),
+            _make_response("", 3, finish_reason="stop"),
+        ]
+        results = _step_until_finish(
+            parse_thinking_models(
+                _queue_source(tokens),
+                think_start="<think>",
+                think_end="</think>",
+                starts_in_thinking=True,
+            )
+        )
+        gens = [
+            r
+            for r in results
+            if isinstance(r, GenerationResponse) and r.finish_reason is None
+        ]
+        texts = [(r.text, r.is_thinking) for r in gens]
+        assert texts == [("body", True), ("answer", False)]
+
+    def test_fused_start_delimiter_single_chunk(self):
+        # Symmetric case: <think> fused with surrounding text while not yet
+        # thinking.
+        tokens = [
+            _make_response("preamble <think>now reasoning", 0),
+            _make_response("", 1, finish_reason="stop"),
+        ]
+        results = _step_until_finish(
+            parse_thinking_models(
+                _queue_source(tokens),
+                think_start="<think>",
+                think_end="</think>",
+                starts_in_thinking=False,
+            )
+        )
+        gens = [
+            r
+            for r in results
+            if isinstance(r, GenerationResponse) and r.finish_reason is None
+        ]
+        texts = [(r.text, r.is_thinking) for r in gens]
+        assert texts == [("preamble ", False), ("now reasoning", True)]
+        assert "<think>" not in _drain_text(results)
+
+    def test_no_thinking_passthrough(self):
+        # No delimiters at all: every chunk flows through as content.
+        tokens = [
+            _make_response("hello ", 0),
+            _make_response("world", 1),
+            _make_response("", 2, finish_reason="stop"),
+        ]
+        results = _step_until_finish(
+            parse_thinking_models(
+                _queue_source(tokens),
+                think_start="<think>",
+                think_end="</think>",
+                starts_in_thinking=False,
+            )
+        )
+        assert _drain_text(results) == "hello world"
+        gens = [r for r in results if isinstance(r, GenerationResponse)]
+        assert all(not r.is_thinking for r in gens)


### PR DESCRIPTION
**Repo:** exo-explore/exo
**Branch:** adurham:pr/thinking-parser-fused-delimiter
**Target:** exo-explore/exo:main
**Commits:** 1 (`170f9023`, cherry-picked from fork `08eac031`)
**Depends on:** none — isolated, applies cleanly on current main

---

# Title

`fix(runner): handle fused/embedded think delimiters in parse_thinking_models`

# Body

## Summary

`parse_thinking_models` (`src/exo/worker/runner/llm_inference/model_output_parsers.py`)
splits a token stream into reasoning vs. content by detecting the `<think>` /
`</think>` delimiters. It flips the `is_thinking` flag **only on exact string
equality** (`accumulated == think_end`). But the mlx-lm streaming detokenizer
emits `last_segment` deltas that can carry **multiple tokens' worth of text in a
single chunk**, so the delimiter can arrive:

- **fused** with neighbouring text — e.g. `"...Let's code.</think>def fibonacci(n):"` in one chunk, or
- **spanning** chunks such that the accumulation overshoots — e.g. `"</"` then `"think>def"` → `accumulated == "</think>def"`.

In both cases the exact-equality check never matches, the boundary is missed,
and the delimiter **plus the post-delimiter answer leak into the wrong stream** —
chain-of-thought prose ends up in `content` (or the answer ends up flagged as
`is_thinking`).

This PR adds substring/boundary detection that splits around the delimiter
wherever it appears in the chunk, while preserving the existing clean-token fast
path and prefix-buffering verbatim.

## Motivation / reproducer

Observed on DeepSeek-V4-Flash (a thinking model whose `</think>` is token id
128822). On longer generations the detokenizer frequently emits the closing
delimiter fused with the first tokens of the answer. The result is a `content`
field containing a literal `</think>` followed by reasoning text and then the
real answer — which breaks any downstream consumer that treats `content` as the
clean answer (e.g. a code grader sees a `SyntaxError`; a UI shows raw `</think>`
tags; OpenAI-API clients get reasoning bleed in `message.content`).

Minimal logical repro (the streaming detokenizer delivers the delimiter fused):

```
chunk 0: "reasoning "           (is_thinking=True)
chunk 1: "done.</think>def x():" (the bug: </think> fused mid-chunk)
```

Pre-fix: chunk 1 falls through to the default branch and is emitted with the
stale `is_thinking=True`, so `</think>def x():` is misclassified.
Post-fix: emits `"done."` as thinking, swallows `</think>`, emits `"def x():"`
as content.

## Approach

In `parse_thinking_models`, before the default emit:

1. Locate the **currently active** delimiter (`think_end` while thinking,
   `think_start` otherwise) as a **substring** of the accumulation.
2. Split around it: emit the pre-delimiter text with the current flag, swallow
   the delimiter, flip `is_thinking`, and re-process the remainder in a loop
   (handles multiple fused delimiters in one chunk).
3. The clean single-token fast path (exact equality) and the partial-prefix
   buffering path are **unchanged**, so existing behaviour and its regression
   tests are preserved. Prefix-buffered tokens are cleared (not drained) when
   the substring branch fires, to avoid double-emitting delimiter fragments
   (e.g. a buffered `"</"` followed by `"think>answer"`).

The fix is generic to any thinking model — it is not specific to DeepSeek.

## Test plan

Adds `TestThinkingModelsFusedDelimiter` to
`src/exo/worker/tests/unittests/test_runner/test_finish_reason_sse.py` (5 cases):

- `test_fused_end_delimiter_single_chunk` — `"done.</think>def..."` in one chunk
- `test_end_delimiter_spanning_two_chunks` — `"</"` then `"think>answer"`
- `test_clean_end_delimiter_token_regression` — delimiter as its own token (the
  original fast path) still works
- `test_fused_start_delimiter_single_chunk` — symmetric `<think>` case
- `test_no_thinking_passthrough` — no delimiters, all content

All 5 pass; the 26 pre-existing tests in that file remain green (31/31 total).
`parse_thinking_models` is pure Python (operates on `GenerationResponse`
objects, no mlx/Metal dependency), so the tests run on CPU.

## Production validation

Running as the default thinking-delimiter parser on a 2-node Mac Studio M4 Max
cluster serving DeepSeek-V4-Flash (8-bit), where it eliminated `</think>`
leakage into `content` on long reasoning generations.

## Notes

Cherry-picked clean onto current `main` (post-zenoh, 09f9ea31); touches only the
parser and its test file (2 files, +193 lines), no other coupling.
