### PR TITLE
fix: include image dimensions in vision cache hash keys

### DIFF
--- a/src/exo/worker/engines/mlx/vision.py
+++ b/src/exo/worker/engines/mlx/vision.py
@@ -709,7 +709,9 @@ def _find_media_regions(
     for i, region in enumerate(regions):
         if i < len(images):
             img = decode_base64_image(images[i])
-            region.content_hash = hashlib.sha256(img.tobytes()).hexdigest()
+            h = hashlib.sha256(f"{img.width}x{img.height}".encode())
+            h.update(img.tobytes())
+            region.content_hash = h.hexdigest()
         else:
             logger.warning(f"Media region {i} has no corresponding image")
 
@@ -738,6 +740,7 @@ class VisionProcessor:
         h = hashlib.sha256()
         for img in images:
             pil = decode_base64_image(img)
+            h.update(f"{pil.width}x{pil.height}".encode())
             h.update(pil.tobytes())
         return h.hexdigest()
 


### PR DESCRIPTION
## Summary

- Mix `width×height` into the SHA-256 hash for both `_image_cache_key()` and `content_hash` in `src/exo/worker/engines/mlx/vision.py`
- Prevents shape-collision cache poisoning where images with different dimensions but identical raw pixel bytes hit the same cache entry

## Problem

`PIL.Image.tobytes()` returns raw pixel bytes **without dimension information**. After `convert("RGB")`, two images with different width×height but identical pixel sequences (e.g. 6×4 vs 4×6) produce the same `tobytes()` output and therefore the same SHA-256 hash. This is a deterministic collision — no brute-force required.

Since the vision encoder resizes images by aspect ratio, a 6×4 and 4×6 image produce semantically different features. The collision causes:

1. **`_feature_cache`** (line 754): returns cached features from the wrong image
2. **`content_hash`** prefix cache (line 417 in `cache.py`): `_validate_media_match` skips truncation, reusing KV states based on incorrect vision features

Minimal reproduction:

```python
from PIL import Image
import hashlib

pixels = bytes(range(72))  # 6*4*3 = 72 bytes RGB
img_a = Image.frombytes("RGB", (6, 4), pixels)
img_b = Image.frombytes("RGB", (4, 6), pixels)

assert hashlib.sha256(img_a.tobytes()).hexdigest() == hashlib.sha256(img_b.tobytes()).hexdigest()  # passes
assert img_a.size != img_b.size  # but images are different
```

## Fix

Prepend `"{width}x{height}"` to the hash input at both locations, so dimension-different images always produce distinct keys.

Closes https://github.com/exo-explore/exo/issues/2151

## Test plan

- [ ] Verify the PoC above produces different hashes after the fix
- [ ] Run existing vision tests (`pytest tests/ -k vision`)
- [ ] Manual test: send two images with swapped dimensions to the API, confirm they produce independent inference results