### PR TITLE
Make prefill step size configurable via EXO_PREFILL_STEP_SIZE (#2141)

### DIFF
--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -1,6 +1,7 @@
 import contextlib
 import functools
 import math
+import os
 import time
 import uuid
 from typing import Callable, Generator, cast, get_args
@@ -331,7 +332,7 @@ def prefill(
 
     is_pipeline = _has_pipeline_communication_layer(model)
 
-    prefill_step_size = 4096
+    prefill_step_size = int(os.getenv("EXO_PREFILL_STEP_SIZE", "4096"))
 
     try:
         if is_pipeline and num_tokens >= prefill_step_size:


### PR DESCRIPTION
### Problem (#2141)

The prefill step size in the MLX generator is hardcoded:

```python
prefill_step_size = 4096
```

As reported in #2141, on some setups (RDMA over Thunderbolt across Macs) a step size of 4096 stalls — activity collapses to a single GPU and a query can hang for hours — while 1024 keeps all devices busy and responds in under a minute. The reporter asked for this to be a "hardcoded default, env, or commandline option."

### Fix

Read the step size from `EXO_PREFILL_STEP_SIZE`, defaulting to `4096`, matching exo's existing `os.getenv("EXO_*", default)` convention (e.g. `EXO_OFFLINE`, `EXO_BOOTSTRAP_PEERS`). Behavior is unchanged unless the env var is set, so users on affected interconnects can drop it to 1024 without a code change.

### Verification

```
default (unset)              -> 4096
EXO_PREFILL_STEP_SIZE=1024   -> 1024  (int)
```

`ruff check` (incl. import sort) clean on the file.
