### PR TITLE
fix: app target fails to build under Xcode 26 beta (#ImplicitStrongCapture)

### DIFF
--- a/app/EXO/EXO/EXOApp.swift
+++ b/app/EXO/EXO/EXOApp.swift
@@ -71,7 +71,7 @@ struct EXOApp: App {
                 .environmentObject(bugReportWindowController)
         } label: {
             menuBarIcon
-                .onReceive(controller.$isFirstLaunchReady) { ready in
+                .onReceive(controller.$isFirstLaunchReady) { [weak controller] ready in
                     if ready {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
                             self.firstLaunchPopout.onComplete = { [weak controller] in


### PR DESCRIPTION
## Summary

The outer `onReceive` closure in `EXOApp.swift` captures `controller` strongly while the nested `onComplete` closure declares `[weak controller]`. Newer Swift toolchains (Xcode 26 beta) reject this mismatch under `#ImplicitStrongCapture`:

```
error: 'weak' ownership of capture 'controller' differs from implicitly-captured strong reference (#ImplicitStrongCapture)
```

so the EXO app target no longer builds. One-liner: capture weakly at the outer closure, matching the intent the nested closure already expresses.

Verified building the app with both Xcode 26.5 (current) and the Xcode 26 beta toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)