### PR TITLE
Add Kimi K2.7-Code model card (official INT4 weights + vision)

### DIFF
--- a/resources/inference_model_cards/moonshotai--Kimi-K2.7-Code.toml
+++ b/resources/inference_model_cards/moonshotai--Kimi-K2.7-Code.toml
@@ -1,0 +1,36 @@
+model_id = "moonshotai/Kimi-K2.7-Code"
+n_layers = 61
+hidden_size = 7168
+num_key_value_heads = 64
+supports_tensor = true
+tasks = ["TextGeneration"]
+family = "kimi"
+quantization = ""
+base_model = "Kimi K2.7 Code"
+capabilities = ["text", "thinking", "thinking_toggle", "vision"]
+
+context_length = 262144
+backends = ["MlxMetal", "MlxCuda", "MlxCpu"]
+[storage_size]
+in_bytes = 595204986173
+
+# Vision tower + mm_projector extracted unmodified (bf16) from the official
+# repo, in the same format as exolabs/Kimi-K2.6-vision; extraction script
+# included in the weights repo. Vision config is identical to Kimi-K2.6's.
+[vision]
+image_token_id = 163605
+model_type = "kimi_vl"
+weights_repo = "aidiffuser/Kimi-K2.7-Code-vision"
+processor_repo = "moonshotai/Kimi-K2.7-Code"
+
+# Source: https://huggingface.co/moonshotai/Kimi-K2.7-Code
+# (recommends temperature 1.0 / top_p 0.95 for thinking mode, same as K2.6)
+[sampling_defaults]
+temperature = 1.0
+top_p = 0.95
+min_p = 0.01
+
+[sampling_defaults.non_thinking]
+temperature = 0.6
+top_p = 0.95
+min_p = 0.01


### PR DESCRIPTION
Adds a model card for [moonshotai/Kimi-K2.7-Code](https://huggingface.co/moonshotai/Kimi-K2.7-Code), released 2026-06-12.

Same architecture as Kimi K2.6 (`kimi_k25`, 61 layers, official INT4), so the card mirrors the existing `moonshotai--Kimi-K2.6.toml`. Sampling defaults per the model card (temperature 1.0 / top_p 0.95 for thinking mode).

**Vision:** the official repo ships MoonViT weights inline, so I extracted the 335 `vision_tower.*` / `mm_projector.*` tensors (unmodified bf16) into [aidiffuser/Kimi-K2.7-Code-vision](https://huggingface.co/aidiffuser/Kimi-K2.7-Code-vision), following the `exolabs/Kimi-K2.6-vision` format. The vision config is byte-identical to K2.6's; the extraction script is included in the repo for verification. Happy to have this re-hosted under the exolabs org if you prefer — it's a one-line change to the card.

**Tested:** distributed serving on 2× Mac Studio M3 Ultra (512 GB), tensor parallelism, text + thinking + image understanding all confirmed working.