### PR TITLE
fix: pre-populate GPT-OSS tiktoken vocab cache to fix runner crash

### DIFF
--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -1,3 +1,7 @@
+import hashlib
+import os
+import tempfile
+import urllib.request
 from collections.abc import Callable, Generator, Iterator
 from functools import cache
 from typing import Any
@@ -31,9 +35,45 @@ from exo.worker.engines.mlx.vendor.dsml_encoding import parse_dsml_output
 from exo.worker.runner.bootstrap import logger
 from exo.worker.runner.llm_inference.tool_parsers import ToolParser
 
+_GPT_OSS_VOCAB_URL = "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken"
+_GPT_OSS_VOCAB_SHA256 = "446a9538cb6c348e3516120d7c08b09f57c36495e2acfffe59a5bf8b0cfb1a2d"
+
+
+def _ensure_gpt_oss_vocab_cached() -> None:
+    """Download the GPT-OSS tiktoken vocab file if it is not already cached.
+
+    The openai_harmony Rust library uses reqwest (rustls) for downloads, which
+    fails in spawned subprocess contexts on some platforms. This function uses
+    Python's urllib as a fallback to pre-populate the tiktoken-rs cache so that
+    the Rust library can load from disk instead.
+    """
+    cache_dir = os.environ.get("TIKTOKEN_RS_CACHE_DIR", os.path.join(tempfile.gettempdir(), "tiktoken-rs-cache"))
+    # tiktoken-rs keys cached files by the SHA-1 of the download URL
+    cache_key = hashlib.sha1(_GPT_OSS_VOCAB_URL.encode()).hexdigest()
+    cache_path = os.path.join(cache_dir, cache_key)
+    if os.path.exists(cache_path):
+        return
+    os.makedirs(cache_dir, exist_ok=True)
+    logger.info(f"Downloading GPT-OSS vocab file to {cache_path}")
+    tmp_path = cache_path + ".tmp"
+    try:
+        urllib.request.urlretrieve(_GPT_OSS_VOCAB_URL, tmp_path)
+        with open(tmp_path, "rb") as f:
+            digest = hashlib.sha256(f.read()).hexdigest()
+        if digest != _GPT_OSS_VOCAB_SHA256:
+            os.remove(tmp_path)
+            raise RuntimeError(f"SHA-256 mismatch for GPT-OSS vocab: expected {_GPT_OSS_VOCAB_SHA256}, got {digest}")
+        os.replace(tmp_path, cache_path)
+        logger.info("GPT-OSS vocab file cached successfully")
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        raise
+
 
 @cache
 def get_gpt_oss_encoding():
+    _ensure_gpt_oss_vocab_cached()
     encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
     return encoding
 

--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -35,8 +35,12 @@ from exo.worker.engines.mlx.vendor.dsml_encoding import parse_dsml_output
 from exo.worker.runner.bootstrap import logger
 from exo.worker.runner.llm_inference.tool_parsers import ToolParser
 
-_GPT_OSS_VOCAB_URL = "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken"
-_GPT_OSS_VOCAB_SHA256 = "446a9538cb6c348e3516120d7c08b09f57c36495e2acfffe59a5bf8b0cfb1a2d"
+_GPT_OSS_VOCAB_URL = (
+    "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken"
+)
+_GPT_OSS_VOCAB_SHA256 = (
+    "446a9538cb6c348e3516120d7c08b09f57c36495e2acfffe59a5bf8b0cfb1a2d"
+)
 
 
 def _ensure_gpt_oss_vocab_cached() -> None:
@@ -47,7 +51,10 @@ def _ensure_gpt_oss_vocab_cached() -> None:
     Python's urllib as a fallback to pre-populate the tiktoken-rs cache so that
     the Rust library can load from disk instead.
     """
-    cache_dir = os.environ.get("TIKTOKEN_RS_CACHE_DIR", os.path.join(tempfile.gettempdir(), "tiktoken-rs-cache"))
+    cache_dir = os.environ.get(
+        "TIKTOKEN_RS_CACHE_DIR",
+        os.path.join(tempfile.gettempdir(), "tiktoken-rs-cache"),
+    )
     # tiktoken-rs keys cached files by the SHA-1 of the download URL
     cache_key = hashlib.sha1(_GPT_OSS_VOCAB_URL.encode()).hexdigest()
     cache_path = os.path.join(cache_dir, cache_key)
@@ -62,7 +69,9 @@ def _ensure_gpt_oss_vocab_cached() -> None:
             digest = hashlib.sha256(f.read()).hexdigest()
         if digest != _GPT_OSS_VOCAB_SHA256:
             os.remove(tmp_path)
-            raise RuntimeError(f"SHA-256 mismatch for GPT-OSS vocab: expected {_GPT_OSS_VOCAB_SHA256}, got {digest}")
+            raise RuntimeError(
+                f"SHA-256 mismatch for GPT-OSS vocab: expected {_GPT_OSS_VOCAB_SHA256}, got {digest}"
+            )
         os.replace(tmp_path, cache_path)
         logger.info("GPT-OSS vocab file cached successfully")
     except Exception:


### PR DESCRIPTION
## Problem
  The runner crashes on the first generation step when using the gpt-oss model with:
  ```
  openai_harmony.HarmonyError: error downloading or loading vocab file: failed to download or load vocab file
  ```
  
  The `openai_harmony` Rust library uses `reqwest` (with `rustls`) to download the `o200k_base.tiktoken` vocab file on first use. This download fails inside Python `spawn` subprocesses on some 
  platforms (confirmed on Linux aarch64), even though the URL is reachable via `curl` and Python's own `urllib`. The encoding is loaded lazily on the first generation step, so the crash surfaces 
  mid-inference.
  
  ## Fix
  Added `_ensure_gpt_oss_vocab_cached()` in `model_output_parsers.py`, called inside `get_gpt_oss_encoding()` before delegating to the Rust `load_harmony_encoding()`. It uses Python's `urllib` 
  to download and cache the file with the correct tiktoken-rs filename (SHA-1 of the URL), respects `TIKTOKEN_RS_CACHE_DIR`, verifies the SHA-256 of the downloaded file, and uses an atomic write to 
  avoid partial files.