### PR TITLE
fix(worker): snapshot pending/in_progress before iterating in supervisor

### DIFF
--- a/src/exo/worker/runner/supervisor.py
+++ b/src/exo/worker/runner/supervisor.py
@@ -351,7 +351,7 @@ class RunnerSupervisor:
             # this is the happy path shutdown - we don't need to spam log with it
             await self._check_runner()
         finally:
-            for tid in self.pending:
+            for tid in list(self.pending):
                 self.pending[tid].set()
 
     async def _watch_runner(self) -> None:
@@ -405,7 +405,7 @@ class RunnerSupervisor:
             for d in self._runner_stdio_handler.diagnostics.diagnostics()
             if not isinstance(d, RunnerUnknown)
         ]
-        for task in self.in_progress.values():
+        for task in list(self.in_progress.values()):
             if isinstance(task, (TextGeneration, ImageGeneration, ImageEdits)):
                 with anyio.CancelScope(shield=True):
                     await self._event_sender.send(


### PR DESCRIPTION
Suggested PR title (concise):
fix(worker): snapshot pending/in_progress before iterating in supervisor — a single runner death was crashing the whole node via dictionary changed size during iteration




Summary

When a runner dies (e.g. a SIGSEGV during inference), RunnerSupervisor._check_runner runs
concurrently with the event-handling loop _forward_events. Both iterate live dicts
(self.pending, self.in_progress) that the other path mutates. The iteration can observe the
dict change size mid-loop and raise:

RuntimeError: dictionary changed size during iteration

This is unhandled, propagates through the surrounding TaskGroup as an ExceptionGroup, and
brings the entire EXO process down on that node (EXO Shutdown complete). The master then
re-elects and removes the now-dead node "due to inactivity", collapsing the running instance —
so one recoverable runner death turns into a full multi-node cluster collapse.

The fix is to iterate a snapshot (list(...)) in both places so concurrent mutation can't break
the loop.


Why this matters

_check_runner is the path that should make runner deaths recoverable — but the unguarded
iteration makes it the thing that escalates a single recoverable death into a full-node EXO crash
and cluster collapse. Guarding the two iterations converts these into clean single-runner restarts.

Affected file

src/exo/worker/runner/supervisor.py (HEAD; commit b5375f8)

The two races

1. _forward_events (line 354) iterates self.pending while the same loop pops it (line 330),
and _check_runner also mutates pending:

python# line 354
for tid in self.pending:
    self.pending[tid].set()

Racing writers: self.pending[...] = event (line 291), self.pending.pop(...) (lines 330, 355).

2. _check_runner (line 408) iterates self.in_progress.values() while it is mutated from
multiple sites:

python# line 408
for task in self.in_progress.values():

Racing writers: self.in_progress[...] = task (line 292), self.in_progress.pop(...)
(lines 296, 347).

When a runner dies, _check_runner fires while _forward_events is mid-iteration (or vice versa)
→ dictionary changed size during iteration.

The fix (2 lines)

diff   # src/exo/worker/runner/supervisor.py — _forward_events
-            for tid in self.pending:
+            for tid in list(self.pending):
                 self.pending[tid].set()

diff   # src/exo/worker/runner/supervisor.py — _check_runner
-        for task in self.in_progress.values():
+        for task in list(self.in_progress.values()):

list(...) takes a one-time snapshot of the keys/values, so a concurrent insert/pop from the
other coroutine no longer invalidates the in-progress iteration. No behavioral change otherwise —
the loop bodies are unchanged.

Crash evidence (from a 4-node M3 Ultra cluster, Tensor-Parallel inference)

Proximate trigger was a runner SIGSEGV on first inference; the cleanup race then escalated it:

Dead node's log:

Runner exited with exit code -11
ERROR  Runner terminated with signal=11 (Segmentation fault: 11)
RuntimeError: Runner found to be dead
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
    | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
      | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
        | RuntimeError: dictionary changed size during iteration
[ INFO | exo.main:main:307 ] EXO Shutdown complete          <-- whole-node EXO shutdown

Surviving node (master) — the downstream cascade:

[ exo.shared.election:_campaign ] Waiting for other campaign to finish
[ exo.main:_elect_loop ]          Node elected Master
[ exo.api.main:unpause ]          Unpausing API
[ exo.master.main:_plan ]         Manually removing node <id> due to inactivity

Net effect without the patch: instances: [], topology drops a node, cluster collapses, manual
rebuild required.

Note: the SIGSEGV (runner death) itself is a separate issue (and is what triggers this path).
This PR does not address the segfault; it ensures that when a runner dies for any reason, EXO
cleanly recovers/restarts the runner instead of crashing the whole node via the iteration race.

Test plan


Run a multi-node instance (Tensor or Pipeline).
Cause a runner to die (in our repro it was a SIGSEGV on first inference after idle; a runner
process kill reproduces the cleanup path equivalently).
Before the patch: dictionary changed size during iteration → EXO Shutdown complete →
master re-election → node removed → cluster collapses.
After the patch: the dead runner is detected and recreated (RunnerFailed → CreateRunner);
no dictionary changed size error, no whole-node shutdown, no re-election; cluster stays intact.


Verified the patched bytecode is exercised and the cluster stays up (4 nodes, connections healthy)
across the runner-death cleanup path.

