### PR TITLE
Add a use_prefix_cache request flag to bypass the KV prefix cache

### DIFF
--- a/src/exo/api/adapters/chat_completions.py
+++ b/src/exo/api/adapters/chat_completions.py
@@ -175,6 +175,7 @@ async def chat_request_to_text_generation(
         presence_penalty=request.presence_penalty,
         frequency_penalty=request.frequency_penalty,
         images=images,
+        ephemeral=request.ephemeral or False,
     )
 
 

--- a/src/exo/api/adapters/chat_completions.py
+++ b/src/exo/api/adapters/chat_completions.py
@@ -175,7 +175,7 @@ async def chat_request_to_text_generation(
         presence_penalty=request.presence_penalty,
         frequency_penalty=request.frequency_penalty,
         images=images,
-        ephemeral=request.ephemeral or False,
+        use_prefix_cache=request.use_prefix_cache,
     )
 
 

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -241,11 +241,11 @@ class ChatCompletionRequest(BaseModel):
     tools: list[dict[str, Any]] | None = None
     reasoning_effort: ReasoningEffort | None = None
     enable_thinking: bool | None = None
-    # When true, run prefill+decode normally but never read from or write to the
-    # shared KV prefix cache: a fresh per-request cache is used and discarded.
-    # Useful for one-off or throwaway requests that should not evict cached
-    # prefixes or leave a cache entry behind.
-    ephemeral: bool | None = None
+    # Whether this request may use the shared KV prefix cache. Defaults to True.
+    # Set to False to run a full prefill+decode on a fresh per-request cache that
+    # is discarded afterwards, for one-off or throwaway requests that should not
+    # evict other clients' cached prefixes or leave a cache entry behind.
+    use_prefix_cache: bool = True
     min_p: float | None = None
     repetition_penalty: float | None = None
     repetition_context_size: int | None = None

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -241,6 +241,11 @@ class ChatCompletionRequest(BaseModel):
     tools: list[dict[str, Any]] | None = None
     reasoning_effort: ReasoningEffort | None = None
     enable_thinking: bool | None = None
+    # When true, run prefill+decode normally but never read from or write to the
+    # shared KV prefix cache: a fresh per-request cache is used and discarded.
+    # Useful for one-off or throwaway requests that should not evict cached
+    # prefixes or leave a cache entry behind.
+    ephemeral: bool | None = None
     min_p: float | None = None
     repetition_penalty: float | None = None
     repetition_context_size: int | None = None

--- a/src/exo/shared/types/text_generation.py
+++ b/src/exo/shared/types/text_generation.py
@@ -115,10 +115,10 @@ class TextGenerationTaskParams(BaseModel, frozen=True):
     stream: bool = False
     tools: list[dict[str, Any]] | None = None
     bench: bool = False
-    use_prefix_cache: bool = False
-    # Run prefill+decode but never touch the shared KV prefix cache (fresh
-    # throwaway cache, no read/write). For one-off or throwaway requests.
-    ephemeral: bool = False
+    # Whether to use the shared KV prefix cache. When False, run prefill+decode
+    # on a fresh per-request cache and store nothing (for one-off/throwaway
+    # requests). Defaults to True so normal generation caches as usual.
+    use_prefix_cache: bool = True
     top_k: int | None = None
     stop: str | list[str] | None = None
     seed: int | None = None

--- a/src/exo/shared/types/text_generation.py
+++ b/src/exo/shared/types/text_generation.py
@@ -116,6 +116,9 @@ class TextGenerationTaskParams(BaseModel, frozen=True):
     tools: list[dict[str, Any]] | None = None
     bench: bool = False
     use_prefix_cache: bool = False
+    # Run prefill+decode but never touch the shared KV prefix cache (fresh
+    # throwaway cache, no read/write). For one-off or throwaway requests.
+    ephemeral: bool = False
     top_k: int | None = None
     stop: str | list[str] | None = None
     seed: int | None = None

--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -161,11 +161,7 @@ class ExoBatchGenerator:
         is_exact_hit = False
         prompt_tokens = all_prompt_tokens
 
-        if (
-            self.kv_prefix_cache is not None
-            and (not is_bench or task_params.use_prefix_cache)
-            and not task_params.ephemeral
-        ):
+        if self.kv_prefix_cache is not None and task_params.use_prefix_cache:
             cache, remaining_tokens, matched_index, is_exact_hit = (
                 self.kv_prefix_cache.get_kv_cache(
                     self.model, all_prompt_tokens, media_regions=media_regions
@@ -266,7 +262,7 @@ class ExoBatchGenerator:
                 c.values = c._trim(trim_size, c.values)
                 c._idx = c.max_size
 
-        if (not is_bench or task_params.use_prefix_cache) and not task_params.ephemeral:
+        if task_params.use_prefix_cache:
             min_prefix_hit_length = max(
                 1000, system_prompt_token_count(task_params, self.tokenizer)
             )

--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -161,8 +161,10 @@ class ExoBatchGenerator:
         is_exact_hit = False
         prompt_tokens = all_prompt_tokens
 
-        if self.kv_prefix_cache is not None and (
-            not is_bench or task_params.use_prefix_cache
+        if (
+            self.kv_prefix_cache is not None
+            and (not is_bench or task_params.use_prefix_cache)
+            and not task_params.ephemeral
         ):
             cache, remaining_tokens, matched_index, is_exact_hit = (
                 self.kv_prefix_cache.get_kv_cache(
@@ -264,7 +266,7 @@ class ExoBatchGenerator:
                 c.values = c._trim(trim_size, c.values)
                 c._idx = c.max_size
 
-        if not is_bench or task_params.use_prefix_cache:
+        if (not is_bench or task_params.use_prefix_cache) and not task_params.ephemeral:
             min_prefix_hit_length = max(
                 1000, system_prompt_token_count(task_params, self.tokenizer)
             )

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -572,11 +572,11 @@ def mlx_generate(
         all_prompt_tokens = vision.prompt_tokens
     media_regions: list[MediaRegion] = vision.media_regions if vision else []
 
-    # Skip the prefix cache for benchmarks, and for ephemeral requests that must
-    # leave no cache trace. Nulling it here makes both the read below and the
-    # post-generation store a no-op.
+    # Skip the prefix cache when the request opts out (use_prefix_cache=False),
+    # e.g. benchmarks or one-off requests that must leave no cache trace. Nulling
+    # it here makes both the read below and the post-generation store a no-op.
     is_bench = task.bench
-    if (is_bench and not task.use_prefix_cache) or task.ephemeral:
+    if not task.use_prefix_cache:
         kv_prefix_cache = None
 
     # Use prefix cache if available, otherwise create fresh cache

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -572,9 +572,11 @@ def mlx_generate(
         all_prompt_tokens = vision.prompt_tokens
     media_regions: list[MediaRegion] = vision.media_regions if vision else []
 
-    # Do not use the prefix cache if we are trying to do benchmarks.
+    # Skip the prefix cache for benchmarks, and for ephemeral requests that must
+    # leave no cache trace. Nulling it here makes both the read below and the
+    # post-generation store a no-op.
     is_bench = task.bench
-    if is_bench and not task.use_prefix_cache:
+    if (is_bench and not task.use_prefix_cache) or task.ephemeral:
         kv_prefix_cache = None
 
     # Use prefix cache if available, otherwise create fresh cache


### PR DESCRIPTION
## Summary

Adds an optional `use_prefix_cache` flag to chat-completion requests. It defaults to `true` (current behavior). Set it to `false` to run a normal prefill+decode on a fresh per-request cache that is discarded, so the request never reads from or writes to the shared KV prefix cache.

## Motivation

Sometimes a caller wants to run a real generation without disturbing the prefix cache. For example:

- periodic warm-up / liveness probes that keep the model and generation path hot, but should not accumulate throwaway cache entries;
- one-off or automated requests that shouldn't evict other clients' cached conversation prefixes via LRU;
- ad-hoc calls where caching the prompt brings no benefit.

`BenchChatCompletionRequest` already has a `use_prefix_cache` field for exactly this bypass in bench mode. Following review feedback, this promotes that same flag to the base `ChatCompletionRequest` instead of adding a separate flag, so there's one knob doing one job.

## Implementation

- `ChatCompletionRequest.use_prefix_cache` defaults to `true`. `BenchChatCompletionRequest` keeps `use_prefix_cache = false` as an override, so bench behavior is unchanged.
- The chat-completions adapter maps it onto `TextGenerationTaskParams.use_prefix_cache`, whose default is now `true` so every existing caller keeps caching.
- The generators (`mlx_generate` and `ExoBatchGenerator`) skip the prefix cache whenever `use_prefix_cache` is `false`, decoupled from `bench`. `bench` now only governs benchmark measurement, not caching.

## Compatibility

Defaults to `true`, so existing callers are unaffected. The bench path still bypasses the cache by default via its `use_prefix_cache = false` override.
