### PR TITLE
Preserve real finish_reason for tool calls truncated by length

### DIFF
--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -476,6 +476,12 @@ def parse_tool_calls(
             continue
 
         if response.finish_reason is not None:
+            # Generation stopped (e.g. length/stop) before the tool call's
+            # closing tag. This is a normal truncated completion, not a server
+            # failure: surface the partial tool-call text with the model's real
+            # finish_reason so clients get standard truncation semantics instead
+            # of an error chunk. Overwriting it with "error" here turned an
+            # out-of-budget tool call into an InternalServerError.
             logger.info(
                 "tool call parsing interrupted, yield partial tool call as text"
             )
@@ -483,7 +489,6 @@ def parse_tool_calls(
                 update={
                     "text": "".join(tool_call_text_parts),
                     "token": 0,
-                    "finish_reason": "error",
                 }
             )
             yield response

--- a/src/exo/worker/tests/unittests/test_runner/test_parse_tool_calls.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_parse_tool_calls.py
@@ -86,6 +86,25 @@ class TestParseToolCalls:
         assert results[0].text == "<tool_call>bad content</tool_call>"
         assert results[0].finish_reason == "error"
 
+    def test_truncated_tool_call_preserves_finish_reason(self):
+        """A tool call cut off by the model's stop reason (no closing tag) is a
+        normal truncated completion, not an error: the partial text is yielded
+        with the model's real finish_reason rather than being relabeled "error"
+        (which downstream serializes as an InternalServerError chunk)."""
+        texts = ["<tool_call>", "partial cont"]
+        results = list(
+            parse_tool_calls(
+                _make_responses(texts),
+                _dummy_parser,
+                tools=None,
+            )
+        )
+
+        assert len(results) == 1
+        assert isinstance(results[0], GenerationResponse)
+        assert results[0].text == "<tool_call>partial cont"
+        assert results[0].finish_reason == "stop"
+
     def test_tool_schema_coerces_string_arguments_to_expected_types(self):
         """Tool argument values should be coerced using provided JSON schema."""
 


### PR DESCRIPTION
## Problem

When a model stops generating mid-tool-call — e.g. it hits `max_tokens` before emitting the tool call's closing tag — `parse_tool_calls` overwrites the model's real `finish_reason` (`length`/`stop`) with `"error"`. Downstream, `map_responses_to_chunks` turns any `finish_reason == "error"` into an `ErrorChunk`, which the chat-completions adapter serializes as `{"error": {"type": "InternalServerError", "code": 500}}`.

So a routine, out-of-budget tool call is reported to clients as an internal server error rather than a truncated completion. Clients that treat that as an upstream/service failure (retrying, marking the endpoint unhealthy, failing over) then escalate a normal truncation into an apparent outage.

## Fix

In the "tool call parsing interrupted" branch, keep the model's real `finish_reason` and yield the accumulated partial tool-call text. A truncated tool call now streams back as a standard `finish_reason: "length"` completion (partial text as content), so clients get normal OpenAI truncation semantics instead of an error event.

The separate failed-parse branch (complete tags that fail to parse into a tool call) is unchanged and still surfaces as an error.

## Test

Adds `test_truncated_tool_call_preserves_finish_reason` for an unclosed tool call cut off by the stop reason; the existing `test_failed_parse_yields_text` (genuine parse failure → error) still passes.
