### PR TITLE
fix(tool-parsing): drop tool calls with leaked GLM arg markup

### DIFF
--- a/src/exo/worker/runner/llm_inference/tool_parsers.py
+++ b/src/exo/worker/runner/llm_inference/tool_parsers.py
@@ -3,6 +3,8 @@ import math
 from dataclasses import dataclass
 from typing import Any, Callable
 
+from loguru import logger
+
 from exo.api.types import ToolCallItem
 
 
@@ -193,10 +195,22 @@ def make_mlx_parser(
             text = text.removeprefix(tool_call_start)
             text = text.removesuffix(tool_call_end)
             parsed = tool_parser(text)
-            if isinstance(parsed, list):
-                return [ToolCallItem.model_validate(_flatten(p)) for p in parsed]
-            else:
-                return [ToolCallItem.model_validate(_flatten(parsed))]
+            raw_calls = parsed if isinstance(parsed, list) else [parsed]
+            items: list[ToolCallItem] = []
+            for call in raw_calls:
+                if _has_residual_markup(call):
+                    # The upstream parser hit malformed/partial markup and fell
+                    # back to a lenient path that left tool-call protocol
+                    # fragments (e.g. <arg_key> / <arg_value>) embedded in the
+                    # call name or arguments. Dispatching it would forward
+                    # corrupted arguments downstream, so drop it and let the
+                    # model regenerate the call.
+                    logger.warning(
+                        f"Dropping tool call with residual markup (parser={tool_call_start!r})"
+                    )
+                    continue
+                items.append(ToolCallItem.model_validate(_flatten(call)))
+            return items or None
 
         except Exception:
             return None
@@ -227,6 +241,49 @@ def _flatten(p: dict[str, Any]) -> dict[str, str]:
         k: json.dumps(v) if isinstance(v, (dict, list)) else str(v)  # pyright: ignore[reportAny]
         for k, v in p.items()  # pyright: ignore[reportAny]
     }
+
+
+# GLM-style argument delimiters that the GLM format parser consumes during a
+# clean parse and so must never survive into a parsed call's name or arguments.
+# When the parser meets malformed or partial markup it can fall back to a
+# lenient path that leaves these fragments embedded in argument keys or values
+# (observed: a key like "file<arg_key" and a value like
+# "page</arg_key><arg_value>5"); detecting them lets the caller drop the
+# corrupted call instead of forwarding garbage arguments downstream. Kept
+# narrow to the arg_key/arg_value family so other formats' legitimate
+# delimiters (e.g. qwen3_coder's <function=>/<parameter=>) are never flagged.
+_MARKUP_FRAGMENTS: tuple[str, ...] = (
+    "<arg_key",
+    "</arg_key>",
+    "<arg_value",
+    "</arg_value>",
+)
+
+
+def _contains_markup(text: str) -> bool:
+    return any(fragment in text for fragment in _MARKUP_FRAGMENTS)
+
+
+def _value_has_markup(value: Any) -> bool:  # pyright: ignore[reportAny]
+    if isinstance(value, dict):
+        return any(
+            (isinstance(k, str) and _contains_markup(k)) or _value_has_markup(v)  # pyright: ignore[reportAny]
+            for k, v in value.items()  # pyright: ignore[reportAny]
+        )
+    if isinstance(value, list):
+        return any(_value_has_markup(item) for item in value)  # pyright: ignore[reportAny]
+    if isinstance(value, str):
+        return _contains_markup(value)
+    return False
+
+
+def _has_residual_markup(parsed_call: dict[str, Any]) -> bool:
+    if not isinstance(parsed_call, dict):  # pyright: ignore[reportUnnecessaryIsInstance]
+        return False
+    name = parsed_call.get("name")  # pyright: ignore[reportAny]
+    if isinstance(name, str) and _contains_markup(name):
+        return True
+    return _value_has_markup(parsed_call.get("arguments"))
 
 
 def make_json_parser() -> ToolParser:

--- a/src/exo/worker/tests/unittests/test_runner/test_parse_tool_calls.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_parse_tool_calls.py
@@ -6,7 +6,10 @@ from typing import Any
 
 from exo.shared.types.worker.runner_response import GenerationResponse, ToolCallResponse
 from exo.worker.runner.llm_inference.model_output_parsers import parse_tool_calls
-from exo.worker.runner.llm_inference.tool_parsers import make_mlx_parser
+from exo.worker.runner.llm_inference.tool_parsers import (
+    _has_residual_markup,
+    make_mlx_parser,
+)
 
 
 def _make_responses(texts: list[str]) -> Generator[GenerationResponse]:
@@ -176,3 +179,69 @@ class TestParseToolCalls:
 
         args = json.loads(results[0].tool_calls[0].arguments)  # pyright: ignore[reportAny]
         assert args == {"action": "output", "id": "0"}
+
+
+def _markup_leak_parser(_text: str) -> dict[str, Any]:
+    """Mimics a format parser that leaked protocol markup into the call."""
+    return {
+        "name": "doc_read_page",
+        "arguments": {"file<arg_key": "page</arg_key><arg_value>5"},
+    }
+
+
+class TestResidualMarkupGuard:
+    """A call whose name/arguments still carry tool-call markup is dropped."""
+
+    def test_call_with_residual_markup_is_dropped(self):
+        results = list(
+            parse_tool_calls(
+                _make_responses(["<tool_call>", "junk", "</tool_call>"]),
+                make_mlx_parser("<tool_call>", "</tool_call>", _markup_leak_parser),
+                tools=None,
+            )
+        )
+
+        assert len(results) == 1
+        # Dropped rather than dispatched: yielded as text, not a ToolCallResponse.
+        assert isinstance(results[0], GenerationResponse)
+        assert results[0].text == "<tool_call>junk</tool_call>"
+
+    def test_clean_call_not_flagged(self):
+        assert (
+            _has_residual_markup(
+                {"name": "web_search", "arguments": {"query": "gold price 2026"}}
+            )
+            is False
+        )
+
+    def test_html_value_not_false_positive(self):
+        # A legitimate argument value containing HTML must not be flagged.
+        assert (
+            _has_residual_markup(
+                {"name": "web_fetch", "arguments": {"snippet": "<div>x</div>"}}
+            )
+            is False
+        )
+
+    def test_arg_value_fragment_in_value_flagged(self):
+        assert (
+            _has_residual_markup(
+                {"name": "doc_read_page", "arguments": {"x": "page</arg_key><arg_value>5"}}
+            )
+            is True
+        )
+
+    def test_fragment_in_key_flagged(self):
+        assert _has_residual_markup({"name": "fn", "arguments": {"file<arg_key": "5"}}) is True
+
+    def test_fragment_in_name_flagged(self):
+        assert _has_residual_markup({"name": "fn<arg_key", "arguments": {}}) is True
+
+    def test_nested_list_fragment_flagged(self):
+        assert (
+            _has_residual_markup({"name": "fn", "arguments": {"items": ["ok", "bad</arg_value>"]}})
+            is True
+        )
+
+    def test_non_dict_returns_false(self):
+        assert _has_residual_markup("not a dict") is False  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
## Problem

Corrupted tool-call arguments can reach the caller as data like:

```json
{"file<arg_key": "page</arg_key><arg_value>5"}
```

i.e. GLM `<arg_key>` / `<arg_value>` markup leaking into the parsed call's
argument **keys and values**.

## Root cause

When the GLM format parser meets malformed or partial markup (missing closing
tags, stray whitespace), its regex fails to extract clean key/value pairs and a
lenient fallback path leaves raw `<arg_key>`/`<arg_value>` fragments embedded in
the parsed dict. `_flatten()` then JSON-stringifies that dict without
validation, so the garbage arguments flow downstream to the tool caller.

## Fix

`make_mlx_parser` now inspects each upstream-parsed call's `name` and
`arguments` (recursively, dict/list/str) for residual GLM arg delimiters. A
call carrying any is **dropped** (with a warning log) so the model regenerates
it, rather than dispatching corrupted arguments.

The detected fragment set is kept deliberately narrow to the
`arg_key`/`arg_value` family, so:

- other formats' legitimate delimiters (e.g. `qwen3_coder`'s
  `<function=>` / `<parameter=>`) are never flagged, and
- ordinary HTML in an argument value (`<div>…</div>`) is not a false positive.

Well-formed tool calls are unaffected.

## Tests

`src/exo/worker/tests/unittests/test_runner/test_parse_tool_calls.py`:

- end-to-end: a parser that leaks markup → the call is dropped (yielded as text,
  not a `ToolCallResponse`);
- unit: `_has_residual_markup` flags fragments in name / key / value / nested
  list, and does **not** flag clean calls or HTML-bearing values.

```
uv run --extra mlx pytest src/exo/worker/tests/unittests/test_runner/ -q
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
