### PR TITLE
[Enhancement] Honor `tool_choice` (forced tool calls)

### DIFF
--- a/src/exo/api/adapters/chat_completions.py
+++ b/src/exo/api/adapters/chat_completions.py
@@ -162,6 +162,7 @@ async def chat_request_to_text_generation(
         seed=request.seed,
         stream=request.stream,
         tools=request.tools,
+        tool_choice=request.tool_choice,
         reasoning_effort=resolved_effort,
         enable_thinking=resolved_thinking,
         chat_template_messages=chat_template_messages

--- a/src/exo/shared/types/text_generation.py
+++ b/src/exo/shared/types/text_generation.py
@@ -114,6 +114,7 @@ class TextGenerationTaskParams(BaseModel, frozen=True):
     top_p: float | None = None
     stream: bool = False
     tools: list[dict[str, Any]] | None = None
+    tool_choice: str | dict[str, Any] | None = None
     bench: bool = False
     use_prefix_cache: bool = False
     top_k: int | None = None

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -544,27 +544,18 @@ def _forced_tool_call_prefill(
 ) -> str | None:
     """Assistant prefill that forces a tool call when tool_choice requires one.
 
-    Returns the tool-call start marker (optionally seeded with the chosen
-    function name) so the model is forced to emit that call, or None when
-    tool_choice leaves the model free or the template has no inferable parser.
+    Returns the model's tool-call start marker so the model is forced to
+    continue with a tool call in its own format, or None when tool_choice
+    leaves the model free or the model has no tool-call marker. The parser is
+    seeded to start inside the call via detect_tool_call_prompt_suffix.
     """
     choice = task_params.tool_choice
     if not task_params.tools or choice is None or choice in ("auto", "none"):
         return None
-    chat_template = getattr(tokenizer, "chat_template", None)
-    if not isinstance(chat_template, str):
+    start = getattr(tokenizer, "tool_call_start", None)
+    if not isinstance(start, str) or not start:
         return None
-    from exo.worker.runner.llm_inference.tool_parsers import infer_tool_parser
-
-    parser = infer_tool_parser(chat_template)
-    if parser is None:
-        return None
-    if isinstance(choice, dict):
-        function = choice.get("function")
-        name = function.get("name") if isinstance(function, dict) else None
-        if isinstance(name, str) and name:
-            return f'{parser.start_parsing}\n{{"name": {json.dumps(name)}, "arguments": '
-    return parser.start_parsing
+    return start
 
 
 def render_chat_template(
@@ -744,6 +735,16 @@ def detect_thinking_prompt_suffix(prompt: str, tokenizer: TokenizerWrapper) -> b
     think_token = tokenizer.think_start
 
     return think_token is not None and prompt.rstrip().endswith(think_token)
+
+
+def detect_tool_call_prompt_suffix(prompt: str, tokenizer: TokenizerWrapper) -> bool:
+    """
+    Detect if the prompt ends with a tool-call opening tag (a forced
+    tool_choice prefill) so the parser starts inside the tool call.
+    """
+    start = getattr(tokenizer, "tool_call_start", None)
+
+    return isinstance(start, str) and bool(start) and prompt.rstrip().endswith(start)
 
 
 def fix_unmatched_think_end_tokens(

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -538,6 +538,35 @@ def consolidate_system_messages(
     return formatted_messages
 
 
+def _forced_tool_call_prefill(
+    tokenizer: TokenizerWrapper,
+    task_params: TextGenerationTaskParams,
+) -> str | None:
+    """Assistant prefill that forces a tool call when tool_choice requires one.
+
+    Returns the tool-call start marker (optionally seeded with the chosen
+    function name) so the model is forced to emit that call, or None when
+    tool_choice leaves the model free or the template has no inferable parser.
+    """
+    choice = task_params.tool_choice
+    if not task_params.tools or choice is None or choice in ("auto", "none"):
+        return None
+    chat_template = getattr(tokenizer, "chat_template", None)
+    if not isinstance(chat_template, str):
+        return None
+    from exo.worker.runner.llm_inference.tool_parsers import infer_tool_parser
+
+    parser = infer_tool_parser(chat_template)
+    if parser is None:
+        return None
+    if isinstance(choice, dict):
+        function = choice.get("function")
+        name = function.get("name") if isinstance(function, dict) else None
+        if isinstance(name, str) and name:
+            return f'{parser.start_parsing}\n{{"name": {json.dumps(name)}, "arguments": '
+    return parser.start_parsing
+
+
 def render_chat_template(
     tokenizer: TokenizerWrapper,
     messages: list[dict[str, Any]],
@@ -559,6 +588,9 @@ def render_chat_template(
     if formatted_messages and formatted_messages[-1].get("role") == "assistant":
         partial_assistant_content = cast(str, formatted_messages[-1].get("content", ""))
         formatted_messages = formatted_messages[:-1]
+
+    if not partial_assistant_content:
+        partial_assistant_content = _forced_tool_call_prefill(tokenizer, task_params)
 
     if _needs_dsml_encoding(task_params):
         from exo.worker.engines.mlx.vendor.dsml_encoding import encode_messages

--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -26,6 +26,7 @@ from exo.shared.types.worker.runner_response import GenerationResponse, ToolCall
 from exo.worker.engines.mlx.types import Model
 from exo.worker.engines.mlx.utils_mlx import (
     detect_thinking_prompt_suffix,
+    detect_tool_call_prompt_suffix,
 )
 from exo.worker.engines.mlx.vendor.dsml_encoding import parse_dsml_output
 from exo.worker.runner.bootstrap import logger
@@ -106,7 +107,12 @@ def apply_all_parsers(
             )
 
         if tool_parser:
-            generator = parse_tool_calls(generator, tool_parser, tools)
+            generator = parse_tool_calls(
+                generator,
+                tool_parser,
+                tools,
+                starts_in_tool_call=detect_tool_call_prompt_suffix(prompt, tokenizer),
+            )
 
     generator = count_reasoning_tokens(generator)
 
@@ -417,9 +423,14 @@ def parse_tool_calls(
     responses: Generator[GenerationResponse | None],
     tool_parser: ToolParser,
     tools: list[dict[str, Any]] | None,
+    starts_in_tool_call: bool = False,
 ) -> Generator[GenerationResponse | ToolCallResponse | None]:
-    in_tool_call = False
-    tool_call_text_parts: list[str] = []
+    in_tool_call = starts_in_tool_call
+    # A forced tool_choice prefill puts the start marker in the prompt, not the
+    # output, so seed it here to keep the parsed call well-formed.
+    tool_call_text_parts: list[str] = (
+        [tool_parser.start_parsing] if starts_in_tool_call else []
+    )
     accumulated_tool_calls: list[ToolCallItem] = []
 
     for response in responses:

--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -426,8 +426,6 @@ def parse_tool_calls(
     starts_in_tool_call: bool = False,
 ) -> Generator[GenerationResponse | ToolCallResponse | None]:
     in_tool_call = starts_in_tool_call
-    # A forced tool_choice prefill puts the start marker in the prompt, not the
-    # output, so seed it here to keep the parsed call well-formed.
     tool_call_text_parts: list[str] = (
         [tool_parser.start_parsing] if starts_in_tool_call else []
     )

--- a/src/exo/worker/tests/unittests/test_mlx/test_tool_choice_prefill.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_tool_choice_prefill.py
@@ -1,0 +1,87 @@
+"""tool_choice forces a tool call via an assistant prefill marker."""
+
+import pytest
+
+pytest.importorskip("mlx")
+
+from types import SimpleNamespace
+
+from exo.shared.types.common import ModelId
+from exo.shared.types.text_generation import (
+    InputMessage,
+    InputMessageContent,
+    TextGenerationTaskParams,
+)
+from exo.worker.engines.mlx.utils_mlx import _forced_tool_call_prefill
+
+# Minimal fragment that infer_tool_parser recognizes as the Hermes/Qwen format.
+_TEMPLATE = "{{ '<tool_call>' }}{{ tool_call.name }}{{ '</tool_call>' }}"
+_TOOLS = [{"type": "function", "function": {"name": "bash", "parameters": {}}}]
+
+
+def _params(*, tools=None, tool_choice=None):
+    return TextGenerationTaskParams(
+        model=ModelId("test/model"),
+        input=[InputMessage(role="user", content=InputMessageContent("hi"))],
+        tools=tools,
+        tool_choice=tool_choice,
+    )
+
+
+def _tokenizer(template):
+    return SimpleNamespace(chat_template=template)
+
+
+def test_named_function_seeds_the_call():
+    prefill = _forced_tool_call_prefill(
+        _tokenizer(_TEMPLATE),
+        _params(
+            tools=_TOOLS,
+            tool_choice={"type": "function", "function": {"name": "bash"}},
+        ),
+    )
+    assert prefill == '<tool_call>\n{"name": "bash", "arguments": '
+
+
+def test_required_forces_some_call():
+    prefill = _forced_tool_call_prefill(
+        _tokenizer(_TEMPLATE), _params(tools=_TOOLS, tool_choice="required")
+    )
+    assert prefill == "<tool_call>"
+
+
+def test_auto_leaves_the_model_free():
+    assert (
+        _forced_tool_call_prefill(
+            _tokenizer(_TEMPLATE), _params(tools=_TOOLS, tool_choice="auto")
+        )
+        is None
+    )
+
+
+def test_none_choice_is_noop():
+    assert (
+        _forced_tool_call_prefill(
+            _tokenizer(_TEMPLATE), _params(tools=_TOOLS, tool_choice=None)
+        )
+        is None
+    )
+
+
+def test_no_tools_is_noop():
+    assert (
+        _forced_tool_call_prefill(
+            _tokenizer(_TEMPLATE), _params(tools=None, tool_choice="required")
+        )
+        is None
+    )
+
+
+def test_uninferable_template_is_noop():
+    assert (
+        _forced_tool_call_prefill(
+            _tokenizer("no tool markers here"),
+            _params(tools=_TOOLS, tool_choice="required"),
+        )
+        is None
+    )

--- a/src/exo/worker/tests/unittests/test_mlx/test_tool_choice_prefill.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_tool_choice_prefill.py
@@ -89,5 +89,9 @@ def test_model_without_tool_marker_is_noop():
 
 
 def test_prompt_suffix_detected_when_prefill_present():
-    assert detect_tool_call_prompt_suffix("...<|im_start|>assistant\n<tool_call>", _tokenizer(_START))
-    assert not detect_tool_call_prompt_suffix("...<|im_start|>assistant\n", _tokenizer(_START))
+    assert detect_tool_call_prompt_suffix(
+        "...<|im_start|>assistant\n<tool_call>", _tokenizer(_START)
+    )
+    assert not detect_tool_call_prompt_suffix(
+        "...<|im_start|>assistant\n", _tokenizer(_START)
+    )

--- a/src/exo/worker/tests/unittests/test_mlx/test_tool_choice_prefill.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_tool_choice_prefill.py
@@ -12,10 +12,12 @@ from exo.shared.types.text_generation import (
     InputMessageContent,
     TextGenerationTaskParams,
 )
-from exo.worker.engines.mlx.utils_mlx import _forced_tool_call_prefill
+from exo.worker.engines.mlx.utils_mlx import (
+    _forced_tool_call_prefill,
+    detect_tool_call_prompt_suffix,
+)
 
-# Minimal fragment that infer_tool_parser recognizes as the Hermes/Qwen format.
-_TEMPLATE = "{{ '<tool_call>' }}{{ tool_call.name }}{{ '</tool_call>' }}"
+_START = "<tool_call>"
 _TOOLS = [{"type": "function", "function": {"name": "bash", "parameters": {}}}]
 
 
@@ -28,32 +30,32 @@ def _params(*, tools=None, tool_choice=None):
     )
 
 
-def _tokenizer(template):
-    return SimpleNamespace(chat_template=template)
+def _tokenizer(tool_call_start):
+    return SimpleNamespace(tool_call_start=tool_call_start)
 
 
-def test_named_function_seeds_the_call():
+def test_named_function_forces_the_start_marker():
     prefill = _forced_tool_call_prefill(
-        _tokenizer(_TEMPLATE),
+        _tokenizer(_START),
         _params(
             tools=_TOOLS,
             tool_choice={"type": "function", "function": {"name": "bash"}},
         ),
     )
-    assert prefill == '<tool_call>\n{"name": "bash", "arguments": '
+    assert prefill == _START
 
 
-def test_required_forces_some_call():
+def test_required_forces_the_start_marker():
     prefill = _forced_tool_call_prefill(
-        _tokenizer(_TEMPLATE), _params(tools=_TOOLS, tool_choice="required")
+        _tokenizer(_START), _params(tools=_TOOLS, tool_choice="required")
     )
-    assert prefill == "<tool_call>"
+    assert prefill == _START
 
 
 def test_auto_leaves_the_model_free():
     assert (
         _forced_tool_call_prefill(
-            _tokenizer(_TEMPLATE), _params(tools=_TOOLS, tool_choice="auto")
+            _tokenizer(_START), _params(tools=_TOOLS, tool_choice="auto")
         )
         is None
     )
@@ -62,7 +64,7 @@ def test_auto_leaves_the_model_free():
 def test_none_choice_is_noop():
     assert (
         _forced_tool_call_prefill(
-            _tokenizer(_TEMPLATE), _params(tools=_TOOLS, tool_choice=None)
+            _tokenizer(_START), _params(tools=_TOOLS, tool_choice=None)
         )
         is None
     )
@@ -71,17 +73,21 @@ def test_none_choice_is_noop():
 def test_no_tools_is_noop():
     assert (
         _forced_tool_call_prefill(
-            _tokenizer(_TEMPLATE), _params(tools=None, tool_choice="required")
+            _tokenizer(_START), _params(tools=None, tool_choice="required")
         )
         is None
     )
 
 
-def test_uninferable_template_is_noop():
+def test_model_without_tool_marker_is_noop():
     assert (
         _forced_tool_call_prefill(
-            _tokenizer("no tool markers here"),
-            _params(tools=_TOOLS, tool_choice="required"),
+            _tokenizer(None), _params(tools=_TOOLS, tool_choice="required")
         )
         is None
     )
+
+
+def test_prompt_suffix_detected_when_prefill_present():
+    assert detect_tool_call_prompt_suffix("...<|im_start|>assistant\n<tool_call>", _tokenizer(_START))
+    assert not detect_tool_call_prompt_suffix("...<|im_start|>assistant\n", _tokenizer(_START))


### PR DESCRIPTION
## Motivation

`ChatCompletionRequest.tool_choice` is accepted on the wire (`api.py`) but is never read on the way to generation, so `"required"` and `{"type": "function", "function": {"name": ...}}` are silently ignored. 

This means the model always chooses whether and which tool to call and in turn it makes tool use non-deterministic, which is a problem for structured extraction, agent reliability, and any integration test that needs a specific tool call to happen.

## Changes

- `shared/types/text_generation.py`: added a `tool_choice: str | dict[str, Any] | None` field to `TextGenerationTaskParams`.
- `api/adapters/chat_completions.py`: thread `tool_choice=request.tool_choice` into the task params (it was previously dropped).
- `worker/engines/mlx/utils_mlx.py`:
  - `_forced_tool_call_prefill(...)`: when `tool_choice` is `"required"` or names a function and tools are present, return the model's own `tokenizer.tool_call_start` marker.
  - In `render_chat_template`, use that as the assistant prefill (when there isn't already an explicit assistant prefill).
  - `detect_tool_call_prompt_suffix(prompt, tokenizer)`: a twin of the existing `detect_thinking_prompt_suffix` — true when the prompt ends with the tool-call start marker.
- `worker/runner/llm_inference/model_output_parsers.py`: `parse_tool_calls` gains `starts_in_tool_call` (default `False`); `apply_all_parsers` seeds it from `detect_tool_call_prompt_suffix`, exactly like the thinking path seeds `starts_in_thinking`.
- `worker/tests/unittests/test_mlx/test_tool_choice_prefill.py`: unit tests for the prefill + suffix detection.

## Why It Works

Forcing a tool call is just **assistant prefilling**, which the engine already supports: a trailing assistant message is stripped before templating and re-appended after (`render_chat_template`). 

Prefilling the model's own `tool_call_start` marker forces it to continue in its *native* tool-call format (e.g. Qwen's `<tool_call><function=...>` XML, not a hardcoded JSON shape).

The one subtlety: the forced marker lands in the *prompt*, so it is not present at the start of the *output* stream, and `parse_tool_calls` detects a call via `response.text.startswith(tool_call_start)`. 

The thinking path already solves this exact problem with `detect_thinking_prompt_suffix` + `starts_in_thinking`; this change mirrors it (`detect_tool_call_prompt_suffix` + `starts_in_tool_call`), seeding the parser to begin inside the call and pre-loading the start marker so the parsed call is well formed. 

No new decoding machinery, no per-model format assumptions.

## Test Plan

### Manual Testing
- Hardware: 2-node EXO ring (M3 Ultra Mac Studio (96GB) + Mac Mini M4 Pro (24GB)), pipeline parallelism, serving `mlx-community/Qwen3.5-9B-8bit` (node wired limit ~77 GiB, group size 2).

- What I did:
  - Sent a deliberately tool-irrelevant prompt — `"What is your name?"` — with a single `bash` tool and `tool_choice: {"type":"function","function":{"name":"bash"}}`.
  - **Before** this change: `finish_reason: stop`, empty content, `tool_calls: null` (the model declines the tool; a naive JSON prefill instead stalls after 1 token because the format doesn't match Qwen's XML).
  - **After** this change: `finish_reason: tool_calls` with a real `{"name": "bash", "arguments": "{\"command\": \"whoami\"}"}` — the model was forced into the tool call it would never otherwise make.
  - Sanity checked that `tool_choice` absent / `"auto"` is unchanged (model chooses freely).

### Automated Testing
- Added `test_tool_choice_prefill.py` (7 tests): named-function and `"required"` both return the start marker; `"auto"`/`None`/no-tools/no-marker are no-ops; `detect_tool_call_prompt_suffix` is true only when the prompt ends with the marker.
- Run: `uv run pytest src/exo/worker/tests/unittests/test_mlx/test_tool_choice_prefill.py`