### PR TITLE
feat(api): support configurable host binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,14 @@ This starts the exo dashboard and API at http://localhost:52415/
 
 **Configuration Options:**
 
+- `--api-host` / `--api-port`: Set the host and port for the HTTP API. These can also be set in `~/.config/exo/config.toml` on Linux or `~/.exo/config.toml` on macOS:
+
+  ```toml
+  [api]
+  host = "127.0.0.1"
+  port = 52415
+  ```
+
 - `--no-worker`: Run exo without the worker component. Useful for coordinator-only nodes that handle networking and orchestration but don't execute inference tasks. This is helpful for machines without sufficient GPU resources but with good network connectivity.
 
   ```bash

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -240,6 +240,7 @@ class API:
         self,
         node_id: NodeId,
         *,
+        host: str,
         port: int,
         event_receiver: Receiver[IndexedEvent],
         command_sender: Sender[ForwarderCommand],
@@ -256,6 +257,7 @@ class API:
         self.election_receiver = election_receiver
         self.node_id: NodeId = node_id
         self.last_completed_election: int = 0
+        self.host = host
         self.port = port
         self._sent_image_hashes: set[str] = set()
 
@@ -1939,7 +1941,7 @@ class API:
 
     async def run_api(self, ev: anyio.Event):
         cfg = Config()
-        cfg.bind = [f"0.0.0.0:{self.port}"]
+        cfg.bind = [f"{self.host}:{self.port}"]
         # nb: shared.logging needs updating if any of this changes
         cfg.accesslog = None
         cfg.errorlog = "-"

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -5,14 +5,14 @@ import resource
 import signal
 import sys
 from dataclasses import dataclass, field
-from typing import Self
+from typing import Self, cast
 
 import anyio
 from anyio.lowlevel import checkpoint as anyio_checkpoint
 from daemon import DaemonContext  # pyright: ignore[reportMissingTypeStubs]
 from exo_rs import Pidfile, PidfileError
 from loguru import logger
-from pydantic import PositiveInt
+from pydantic import Field
 
 import exo.routing.topics as topics
 from exo import __version__
@@ -22,6 +22,7 @@ from exo.download.impl_shard_downloader import exo_shard_downloader
 from exo.master.main import Master
 from exo.routing.event_router import EventRouter
 from exo.routing.router import Router, get_node_zid
+from exo.shared.config import ApiConfig, NodeConfig
 from exo.shared.constants import EXO_DEFAULT_MODELS_DIR, EXO_LOG, EXO_PID_FILE
 from exo.shared.election import Election, ElectionResult
 from exo.shared.logging import logger_cleanup, logger_setup
@@ -92,7 +93,8 @@ class Node:
         if args.spawn_api:
             api = API(
                 node_id,
-                port=args.api_port,
+                host=args.api.host,
+                port=args.api.port,
                 event_receiver=event_router.receiver(),
                 command_sender=router.sender(topics.COMMANDS),
                 download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
@@ -108,7 +110,7 @@ class Node:
                 event_sender=event_router.sender(),
                 command_sender=router.sender(topics.COMMANDS),
                 download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
-                api_port=args.api_port,
+                api_port=args.api.port,
             )
         else:
             worker = None
@@ -149,7 +151,7 @@ class Node:
             api,
             node_id,
             args.offline,
-            args.api_port,
+            args.api.port,
         )
 
     async def run(self):
@@ -381,7 +383,7 @@ class Args(FrozenModel):
     verbosity: int = 0
     force_master: bool = False
     spawn_api: bool = False
-    api_port: PositiveInt = 52415
+    api: ApiConfig = Field(default_factory=ApiConfig)
     tb_only: bool = False
     no_worker: bool = False
     no_downloads: bool = False
@@ -396,6 +398,7 @@ class Args(FrozenModel):
 
     @classmethod
     def parse(cls) -> Self:
+        config = NodeConfig.load()
         parser = argparse.ArgumentParser(prog="EXO")
         default_verbosity = 0
         parser.add_argument(
@@ -425,10 +428,18 @@ class Args(FrozenModel):
             dest="spawn_api",
         )
         parser.add_argument(
+            "--api-host",
+            type=str,
+            dest="api_host",
+            default=config.api.host,
+            help="HTTP API host to bind.",
+        )
+        parser.add_argument(
             "--api-port",
             type=int,
             dest="api_port",
-            default=52415,
+            default=config.api.port,
+            help="HTTP API port.",
         )
         parser.add_argument(
             "--no-worker",
@@ -500,5 +511,12 @@ class Args(FrozenModel):
             help="Force MLX FAST_SYNCH off",
         )
 
-        args = parser.parse_args()
-        return cls(**vars(args))  # pyright: ignore[reportAny] - We are intentionally validating here, we can't do it statically
+        parsed_args = cast("dict[str, object]", vars(parser.parse_args()))
+        api_host_value = parsed_args.pop("api_host")
+        api_port_value = parsed_args.pop("api_port")
+        if not isinstance(api_host_value, str):
+            raise TypeError("api_host must be a string")
+        if not isinstance(api_port_value, int):
+            raise TypeError("api_port must be an integer")
+        parsed_args["api"] = ApiConfig(host=api_host_value, port=api_port_value)
+        return cls.model_validate(parsed_args)

--- a/src/exo/shared/config.py
+++ b/src/exo/shared/config.py
@@ -1,0 +1,77 @@
+import os
+import tomllib
+from pathlib import Path
+
+import anyio
+from loguru import logger
+from pydantic import Field, PositiveInt, ValidationError
+
+from exo.utils.pydantic_ext import FrozenModel, TaggedModel
+
+
+class ApiConfig(FrozenModel):
+    host: str = "0.0.0.0"
+    port: PositiveInt = 52415
+
+
+class NodeConfig(TaggedModel):
+    """Node configuration from EXO_CONFIG_FILE, loaded once at startup."""
+
+    api: ApiConfig = Field(default_factory=ApiConfig)
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> "NodeConfig":
+        if path is None:
+            from exo.shared.constants import EXO_CONFIG_FILE
+
+            path = EXO_CONFIG_FILE
+
+        if not path.exists():
+            return _apply_env_overrides(cls())
+
+        try:
+            contents = path.read_text(encoding="utf-8")
+            data = tomllib.loads(contents) if contents.strip() else {}
+            config = cls.model_validate(data)
+        except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError) as exception:
+            raise RuntimeError(f"Failed to read exo config file at {path}") from exception
+        except ValidationError as exception:
+            raise RuntimeError(f"Invalid exo config file at {path}") from exception
+
+        return _apply_env_overrides(config)
+
+    @classmethod
+    async def gather(cls) -> "NodeConfig | None":
+        from exo.shared.constants import EXO_CONFIG_FILE
+
+        cfg_file = anyio.Path(EXO_CONFIG_FILE)
+        await cfg_file.parent.mkdir(parents=True, exist_ok=True)
+        await cfg_file.touch(exist_ok=True)
+        try:
+            return cls.load(EXO_CONFIG_FILE)
+        except RuntimeError as exception:
+            logger.opt(exception=exception).warning("Invalid config file, skipping...")
+            return None
+
+
+def _apply_env_overrides(config: NodeConfig) -> NodeConfig:
+    return NodeConfig(
+        api=ApiConfig(
+            host=_env_str("EXO_API_HOST") or config.api.host,
+            port=_env_int("EXO_API_PORT") or config.api.port,
+        )
+    )
+
+
+def _env_str(name: str) -> str | None:
+    return os.getenv(name)
+
+
+def _env_int(name: str) -> int | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError as exception:
+        raise RuntimeError(f"{name} must be an integer") from exception

--- a/src/exo/shared/tests/test_config.py
+++ b/src/exo/shared/tests/test_config.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pytest
+
+from exo.shared.config import NodeConfig
+
+
+@pytest.fixture(autouse=True)
+def _clear_config_env(  # pyright: ignore[reportUnusedFunction]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EXO_API_HOST", raising=False)
+    monkeypatch.delenv("EXO_API_PORT", raising=False)
+
+
+def test_node_config_reads_api_table(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+        [api]
+        host = "127.0.0.1"
+        port = 52416
+        """,
+        encoding="utf-8",
+    )
+
+    config = NodeConfig.load(config_path)
+
+    assert config.api.host == "127.0.0.1"
+    assert config.api.port == 52416
+
+
+def test_node_config_applies_environment_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+        [api]
+        host = "127.0.0.1"
+        port = 52416
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("EXO_API_HOST", "0.0.0.0")
+    monkeypatch.setenv("EXO_API_PORT", "52417")
+
+    config = NodeConfig.load(config_path)
+
+    assert config.api.host == "0.0.0.0"
+    assert config.api.port == 52417
+
+
+def test_node_config_missing_file_uses_defaults(tmp_path: Path) -> None:
+    config = NodeConfig.load(tmp_path / "missing.toml")
+
+    assert config.api.host == "0.0.0.0"
+    assert config.api.port == 52415

--- a/src/exo/utils/info_gatherer/info_gatherer.py
+++ b/src/exo/utils/info_gatherer/info_gatherer.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import sys
-import tomllib
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from subprocess import CalledProcessError
@@ -13,7 +12,8 @@ from anyio.streams.buffered import BufferedByteReceiveStream
 from loguru import logger
 from pydantic import ValidationError
 
-from exo.shared.constants import EXO_CONFIG_FILE, EXO_DEFAULT_MODELS_DIR
+from exo.shared.config import NodeConfig
+from exo.shared.constants import EXO_DEFAULT_MODELS_DIR
 from exo.shared.types.backends import Backend
 from exo.shared.types.memory import Memory
 from exo.shared.types.profiling import (
@@ -290,24 +290,6 @@ class ThunderboltBridgeInfo(TaggedModel):
         except Exception as e:
             logger.opt(exception=e).warning("Failed to gather Thunderbolt Bridge info")
             return None
-
-
-class NodeConfig(TaggedModel):
-    """Node configuration from EXO_CONFIG_FILE, reloaded from the file only at startup. Other changes should come in through the API and propagate from there"""
-
-    @classmethod
-    async def gather(cls) -> Self | None:
-        cfg_file = anyio.Path(EXO_CONFIG_FILE)
-        await cfg_file.parent.mkdir(parents=True, exist_ok=True)
-        await cfg_file.touch(exist_ok=True)
-        async with await cfg_file.open("rb") as f:
-            try:
-                contents = (await f.read()).decode("utf-8")
-                data = tomllib.loads(contents)
-                return cls.model_validate(data)
-            except (tomllib.TOMLDecodeError, UnicodeDecodeError, ValidationError):
-                logger.warning("Invalid config file, skipping...")
-                return None
 
 
 class MiscData(TaggedModel):


### PR DESCRIPTION
## Summary
- Adds typed config loading for the HTTP API host and port.
- Threads the configured host into Hypercorn instead of always binding every interface.
- Keeps the default `0.0.0.0:52415` behavior unchanged, while making loopback-only and reverse-proxy deployments straightforward.

## Test Plan
- Focused type, lint, and config tests.