### PR TITLE
networking: don't permanently drop discovery addresses on transient EHOSTUNREACH

### DIFF
--- a/rust/networking/src/discovery.rs
+++ b/rust/networking/src/discovery.rs
@@ -249,13 +249,15 @@ impl Discovery {
 
         let addrs = self.ifaces.lock().clone();
         debug!("announcing Hello({nonce:?}) to {addrs:?}");
-        // rev so .remove() doesn't break things
-        for (i, addr) in addrs.into_iter().enumerate().rev() {
+        for addr in addrs.into_iter().rev() {
             match self.sock.send_to(&buf, addr).await {
                 Ok(bytes) => trace!("sent {bytes} to {addr}"),
                 Err(e) if e.kind() == io::ErrorKind::HostUnreachable => {
-                    debug!("disabling discovery address {addr}: {e}");
-                    _ = self.ifaces.lock().swap_remove(i);
+                    // EHOSTUNREACH is transient on macOS (observed right after boot /
+                    // wake / link changes). Interfaces that actually disappear are
+                    // already pruned by the netwatcher callback via diff.removed, so
+                    // don't permanently drop the address here.
+                    debug!("transient host unreachable for {addr}: {e}");
                 }
                 Err(e) => debug!("failed to reach {addr}: {e}"),
             }


### PR DESCRIPTION
Fixes #2191

### Problem
`Discovery::announce()` treats `EHOSTUNREACH` from `send_to` as permanent and `swap_remove`s the address from the announce list. On macOS this errno occurs transiently (right after boot, wake, or link changes) on *all* interfaces at once — so within ~2 ticks the announce list drains to empty and peer discovery goes permanently silent. Nodes then only ever discover themselves and each elects itself Master. Details, instrumented timeline, and wire captures in #2191.

### Change
Treat `EHOSTUNREACH` as transient: log at `debug!` and keep the address. Permanent interface removal is already handled by the `netwatcher` callback via `update.diff.removed`, so the announce path doesn't need to prune.

### Testing
- `cargo check -p networking` clean.
- 4× Mac mini M4 (macOS 26.5.1), `main` @ `b5375f8c`: before the change, an instrumented build shows tick 1 sends OK, tick 2 gets `EHOSTUNREACH` on all 7 interfaces, announce list drains to `[]`, and `tcpdump -ni en0 udp port 52413` shows no beacons. With the change, Hello beacons egress `en0` steadily (1/s) and sends succeed on subsequent ticks (11/11 over a 14 s window on the same machine).
