### PR TITLE
fix: reserve memory headroom before prefill

### DIFF
--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -457,10 +457,7 @@ class KVPrefixCache:
 
         evicted_any = False
         # Evict LRU entries until below threshold
-        while (
-            len(self.caches) > 0
-            and self.get_memory_used_percentage() > threshold
-        ):
+        while len(self.caches) > 0 and self.get_memory_used_percentage() > threshold:
             lru_index = self._last_used.index(min(self._last_used))
             evicted_tokens = len(self.prompts[lru_index])
             self.prompts.pop(lru_index)

--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -46,6 +46,20 @@ def _default_memory_threshold() -> float:
 _MEMORY_THRESHOLD = float(
     os.environ.get("EXO_MEMORY_THRESHOLD", _default_memory_threshold())
 )
+# Prefill needs temporary activation memory in addition to the persistent KV cache.
+# Keep a configurable reserve before starting it instead of waiting for an OOM.
+_PREFILL_MEMORY_THRESHOLD = float(
+    os.environ.get(
+        "EXO_PREFILL_MEMORY_THRESHOLD",
+        max(0.0, _MEMORY_THRESHOLD - 0.10),
+    )
+)
+
+if not 0.0 <= _PREFILL_MEMORY_THRESHOLD <= _MEMORY_THRESHOLD:
+    raise ValueError(
+        "EXO_PREFILL_MEMORY_THRESHOLD must be between 0 and "
+        f"EXO_MEMORY_THRESHOLD ({_MEMORY_THRESHOLD})"
+    )
 
 
 class CacheSnapshot:
@@ -428,6 +442,16 @@ class KVPrefixCache:
 
     def _evict_if_needed(self):
         """Evict least recently used entries while memory usage is high."""
+        self._evict_until_below(_MEMORY_THRESHOLD, reason="memory usage")
+
+    def evict_for_prefill(self) -> None:
+        """Reserve activation headroom by evicting cached prefixes before prefill."""
+        self._evict_until_below(
+            _PREFILL_MEMORY_THRESHOLD,
+            reason="prefill activation headroom",
+        )
+
+    def _evict_until_below(self, threshold: float, *, reason: str) -> None:
         if len(self.caches) == 0:
             return
 
@@ -435,7 +459,7 @@ class KVPrefixCache:
         # Evict LRU entries until below threshold
         while (
             len(self.caches) > 0
-            and self.get_memory_used_percentage() > _MEMORY_THRESHOLD
+            and self.get_memory_used_percentage() > threshold
         ):
             lru_index = self._last_used.index(min(self._last_used))
             evicted_tokens = len(self.prompts[lru_index])
@@ -448,7 +472,8 @@ class KVPrefixCache:
 
             evicted_any = True
             logger.info(
-                f"KV cache evicted LRU entry ({evicted_tokens} tokens) due to memory usage"
+                f"KV cache evicted LRU entry ({evicted_tokens} tokens) "
+                f"for {reason} (target={threshold:.0%})"
             )
 
         if evicted_any:

--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -164,6 +164,9 @@ class ExoBatchGenerator:
         if self.kv_prefix_cache is not None and (
             not is_bench or task_params.use_prefix_cache
         ):
+            # Prefix entries are persistent allocations. Reclaim enough of them
+            # for prefill's temporary activations before copying a cache hit.
+            self.kv_prefix_cache.evict_for_prefill()
             cache, remaining_tokens, matched_index, is_exact_hit = (
                 self.kv_prefix_cache.get_kv_cache(
                     self.model, all_prompt_tokens, media_regions=media_regions

--- a/src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py
@@ -105,6 +105,31 @@ class TestKVPrefix:
         cache.clear()
         assert len(cache.prompts) == 0
 
+    def test_evict_for_prefill_reserves_activation_headroom(self) -> None:
+        cache = KVPrefixCache(None)
+        cache.prompts = [mx.array([1]), mx.array([2])]
+        cache.caches = [[KVCache()], [KVCache()]]
+        cache._snapshots = [None, None]
+        cache._media_regions = [[], []]
+        cache._last_used = [0, 1]
+        cache.prefill_tps = [1.0, 2.0]
+
+        with (
+            patch(
+                "exo.worker.engines.mlx.cache._PREFILL_MEMORY_THRESHOLD",
+                0.70,
+            ),
+            patch.object(
+                cache,
+                "get_memory_used_percentage",
+                side_effect=[0.80, 0.65],
+            ),
+        ):
+            cache.evict_for_prefill()
+
+        assert len(cache.caches) == 1
+        assert cache.prompts[0].item() == 2
+
 
 def _load_gpt_oss() -> tuple[Model, object]:
     from mlx_lm.utils import load_model


### PR DESCRIPTION
## Motivation

Persistent prefix-cache allocations can leave too little room for temporary prefill activations. Existing eviction only runs while adding a completed cache entry, after the dangerous allocation has already happened.

## Changes

- evict LRU prefix entries before cache lookup and local/remote prefill
- introduce `EXO_PREFILL_MEMORY_THRESHOLD`, defaulting to 10 percentage points below `EXO_MEMORY_THRESHOLD`
- validate the prefill watermark against the normal cache watermark
- preserve distributed max-pressure checks and reclaim MLX allocations after eviction
- add regression coverage for prefill-specific LRU eviction

## Testing

- `uv run pytest src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py -m "not slow"`
- `uv run basedpyright src/exo/worker/engines/mlx/cache.py src/exo/worker/engines/mlx/generator/batch_generate.py`
- `uv run ruff check src/exo/worker/engines/mlx/cache.py src/exo/worker/engines/mlx/generator/batch_generate.py src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py`

Fixes #2182