### PR TITLE
feat: report CUDA GPU VRAM as node memory on Linux

### DIFF
--- a/src/exo/shared/types/profiling.py
+++ b/src/exo/shared/types/profiling.py
@@ -1,4 +1,5 @@
 import shutil
+import subprocess
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal, Self
@@ -38,6 +39,66 @@ class MemoryUsage(FrozenModel):
             swap_total=sm.total,
             swap_available=sm.free,
         )
+
+    @classmethod
+    def from_cuda(cls, *, override_memory: int | None) -> Self | None:
+        """Report a CUDA GPU's VRAM as the node's memory.
+
+        On a discrete NVIDIA GPU the memory that actually bounds MLX inference is
+        the GPU's VRAM, not system RAM (unlike Apple Silicon's unified memory).
+        Returns None when no GPU/VRAM can be queried so the caller can fall back
+        to :meth:`from_psutil`.
+        """
+        vram = _query_cuda_vram_bytes()
+        if vram is None:
+            return None
+        total_vram, free_vram = vram
+        sm = psutil.swap_memory()
+        return cls.from_bytes(
+            ram_total=total_vram,
+            ram_available=free_vram if override_memory is None else override_memory,
+            swap_total=sm.total,
+            swap_available=sm.free,
+        )
+
+
+def _query_cuda_vram_bytes() -> tuple[int, int] | None:
+    """Total and free VRAM in bytes for the first CUDA GPU via ``nvidia-smi``.
+
+    Returns None if ``nvidia-smi`` is absent or its output cannot be parsed.
+    """
+    nvidia_smi = shutil.which("nvidia-smi")
+    if nvidia_smi is None:
+        return None
+    try:
+        completed = subprocess.run(
+            [
+                nvidia_smi,
+                "--query-gpu=memory.total,memory.free",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+    lines = completed.stdout.strip().splitlines()
+    if not lines:
+        return None
+    fields = lines[0].split(",")
+    if len(fields) != 2:
+        return None
+    try:
+        total_mebibytes = int(fields[0].strip())
+        free_mebibytes = int(fields[1].strip())
+    except ValueError:
+        return None
+
+    mebibyte = 1024 * 1024
+    return total_mebibytes * mebibyte, free_mebibytes * mebibyte
 
 
 class DiskUsage(FrozenModel):

--- a/src/exo/utils/info_gatherer/info_gatherer.py
+++ b/src/exo/utils/info_gatherer/info_gatherer.py
@@ -399,6 +399,24 @@ GatheredInfo = (
 )
 
 
+def _mlx_uses_cuda_gpu() -> bool:
+    """True when MLX's default device is a (CUDA) GPU on a non-Darwin host.
+
+    Used to decide whether to report GPU VRAM instead of system RAM as the
+    node's memory. On Apple Silicon the GPU path is handled by macmon, and on a
+    Linux CPU (mlx-cpu) build the default device is the CPU, so both correctly
+    fall through to psutil system RAM.
+    """
+    if IS_DARWIN:
+        return False
+    try:
+        import mlx.core as mx
+
+        return "gpu" in str(mx.default_device()).lower()
+    except Exception:
+        return False
+
+
 @dataclass
 class InfoGatherer:
     info_sender: Sender[GatheredInfo]
@@ -518,11 +536,17 @@ class InfoGatherer:
             if override_memory_env
             else None
         )
+        report_vram = _mlx_uses_cuda_gpu()
+        if report_vram:
+            logger.info("CUDA MLX backend detected; reporting GPU VRAM as node memory")
         while True:
             try:
-                await self.info_sender.send(
-                    MemoryUsage.from_psutil(override_memory=override_memory)
-                )
+                usage: MemoryUsage | None = None
+                if report_vram:
+                    usage = MemoryUsage.from_cuda(override_memory=override_memory)
+                if usage is None:
+                    usage = MemoryUsage.from_psutil(override_memory=override_memory)
+                await self.info_sender.send(usage)
             except Exception as e:
                 logger.opt(exception=e).warning("Error gathering memory usage")
             await anyio.sleep(memory_poll_rate)


### PR DESCRIPTION
## Problem

On Linux, exo reports psutil **system RAM** as a node's total/available memory regardless of the active MLX backend. For a discrete NVIDIA GPU, the memory that actually bounds MLX inference is the GPU's **VRAM**, not system RAM (unlike Apple Silicon's unified memory). Result: the dashboard over-reports memory, and the master can place shards too large for the GPU → OOM at model load.

## Fix

Report GPU VRAM (**total** → dashboard, **free** → placement) when MLX's default device is a CUDA GPU, via `nvidia-smi`. Falls back to psutil system RAM on CPU (`mlx-cpu`) builds, on Apple Silicon (handled by macmon), or when `nvidia-smi` is unavailable — so existing setups are unaffected.

- `profiling.py`: add `MemoryUsage.from_cuda()` + `_query_cuda_vram_bytes()`
- `info_gatherer.py`: add `_mlx_uses_cuda_gpu()` gate; the Linux memory monitor prefers VRAM when the CUDA backend is active

## Testing

Verified on an RTX 4070 (12 GB) node running the `cuda13` extra: node now advertises ~12.9 GB total / ~11.5 GB free instead of 32 GB system RAM. `ruff` and `basedpyright` pass.
