### PR TITLE
fix: tolerate mask keyword arguments on ArraysCache for hybrid-model shards

### DIFF
--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -243,6 +243,25 @@ def get_layers(inner_model_instance: nn.Module) -> list[_LayerCallable]:
     return layers
 
 
+# When a pipeline shard contains no full-attention layer (possible for small
+# shards of hybrid models such as Qwen3.5, whose full-attention layers occur
+# every 4th layer), fa_idx falls on an SSM cache entry. create_attention_mask
+# then calls ArraysCache.make_mask with return_array/window_size keyword
+# arguments that its signature rejects, crashing the runner with a TypeError.
+# The resulting mask is unused on all-linear shards, so ignoring the keyword
+# arguments is safe.
+_original_arrays_cache_make_mask = ArraysCache.make_mask
+
+
+def _keyword_tolerant_arrays_cache_make_mask(
+    self: ArraysCache, sequence_length: int, **_ignored: object
+) -> object:
+    return _original_arrays_cache_make_mask(self, sequence_length)
+
+
+ArraysCache.make_mask = _keyword_tolerant_arrays_cache_make_mask  # type: ignore[method-assign,assignment]
+
+
 def _patch_hybrid_cache(
     model: Qwen3_5TextModel | Qwen3NextModel | NemotronHModel,
     fa_idx: int,


### PR DESCRIPTION
## Summary

Pipeline shards of hybrid models (e.g. Qwen3.5, whose full-attention layers occur periodically among linear-attention layers) can contain **no full-attention layer**. In that case `fa_idx` points at an `ArraysCache` entry, and `create_attention_mask` calls `cache.make_mask(N, return_array=..., window_size=...)`, which `ArraysCache.make_mask(N)` rejects:

```
TypeError: ArraysCache.make_mask() got an unexpected keyword argument 'return_array'
```

This crashes the runner deterministically during warmup for affected shard layouts (observed on a 2-layer shard of Qwen3.5-397B-A17B-8bit in a 4-node pipeline), and the instance enters a teardown/recreate loop. The existing per-instance workaround in `_patch_hybrid_cache` does not cover all call paths, so this makes `ArraysCache.make_mask` keyword-tolerant at class level, matching the file's existing patch style. The mask produced for all-linear shards is unused, so ignoring the keywords is safe.

## Test plan

- [x] `uv run pytest src/exo/worker/tests/unittests/test_mlx/test_auto_parallel.py` (4 passed)
- [x] `uv run basedpyright` / `uv run ruff check` clean on the changed file
- [x] Verified on a real 4-node cluster: the previously-crashing shard layout now completes warmup and serves generation
