### PR TITLE
perf: faster pipeline decode: TPS 10%-40% and Layer loading 60%+ (token relay + bandwidth-aware placement)

### DIFF
--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -490,6 +490,7 @@ class API:
                 current_instances=self.state.instances,
                 download_status=self.state.downloads,
                 node_rdma_ctl=self.state.node_rdma_ctl,
+                node_identities=self.state.node_identities,
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -555,6 +556,7 @@ class API:
                     required_nodes=required_nodes,
                     download_status=self.state.downloads,
                     node_rdma_ctl=self.state.node_rdma_ctl,
+                    node_identities=self.state.node_identities,
                 )
             except ValueError as exc:
                 if (model_card.model_id, sharding, instance_meta, 0) not in seen:

--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -378,6 +378,7 @@ class Master:
                                 self.state.node_backends,
                                 download_status=self.state.downloads,
                                 node_rdma_ctl=self.state.node_rdma_ctl,
+                                node_identities=self.state.node_identities,
                             )
                             transition_events = get_transition_events(
                                 self.state.instances, placement, self.state.tasks

--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -29,7 +29,12 @@ from exo.shared.types.events import (
     TaskStatusUpdated,
 )
 from exo.shared.types.memory import Memory
-from exo.shared.types.profiling import MemoryUsage, NodeNetworkInfo, NodeRdmaCtlStatus
+from exo.shared.types.profiling import (
+    MemoryUsage,
+    NodeIdentity,
+    NodeNetworkInfo,
+    NodeRdmaCtlStatus,
+)
 from exo.shared.types.tasks import Task, TaskId, TaskStatus
 from exo.shared.types.worker.downloads import (
     DownloadCompleted,
@@ -113,6 +118,7 @@ def place_instance(
     required_nodes: set[NodeId] | None = None,
     download_status: Mapping[NodeId, Sequence[DownloadProgress]] | None = None,
     node_rdma_ctl: Mapping[NodeId, NodeRdmaCtlStatus] | None = None,
+    node_identities: Mapping[NodeId, NodeIdentity] | None = None,
 ) -> dict[InstanceId, Instance]:
     cycles = topology.get_cycles()
     candidate_cycles = list(filter(lambda it: len(it) >= command.min_nodes, cycles))
@@ -252,7 +258,11 @@ def place_instance(
         )
 
     shard_assignments = get_shard_assignments(
-        command.model_card, selected_cycle, command.sharding, node_memory
+        command.model_card,
+        selected_cycle,
+        command.sharding,
+        node_memory,
+        node_identities,
     )
 
     cycle_digraph: Topology = topology.get_subgraph_from_nodes(selected_cycle.node_ids)

--- a/src/exo/master/placement_utils.py
+++ b/src/exo/master/placement_utils.py
@@ -6,7 +6,7 @@ from exo.shared.models.model_cards import ModelCard
 from exo.shared.topology import Topology
 from exo.shared.types.common import Host, NodeId
 from exo.shared.types.memory import Memory
-from exo.shared.types.profiling import MemoryUsage, NodeNetworkInfo
+from exo.shared.types.profiling import MemoryUsage, NodeIdentity, NodeNetworkInfo
 from exo.shared.types.topology import Cycle, RDMAConnection, SocketConnection
 from exo.shared.types.worker.runners import RunnerId, ShardAssignments
 from exo.shared.types.worker.shards import (
@@ -42,6 +42,93 @@ def get_smallest_cycles(
 ) -> list[Cycle]:
     min_nodes = min(len(cycle) for cycle in cycles)
     return [cycle for cycle in cycles if len(cycle) == min_nodes]
+
+
+# Approximate GPU memory bandwidth (GB/s) by chip/GPU name substring. Decode
+# is memory-bandwidth bound, so pipeline stage time is proportional to the
+# bytes of weights a node reads per token divided by its bandwidth. Substring
+# order matters: more specific names (e.g. "M3 Ultra") must precede less
+# specific ones (e.g. "M3").
+_MEMORY_BANDWIDTH_GBPS_BY_CHIP_SUBSTRING: tuple[tuple[str, float], ...] = (
+    ("M4 Ultra", 1092.0),
+    ("M3 Ultra", 819.0),
+    ("M2 Ultra", 800.0),
+    ("M1 Ultra", 800.0),
+    ("M4 Max", 546.0),
+    ("M3 Max", 400.0),
+    ("M2 Max", 400.0),
+    ("M1 Max", 400.0),
+    ("M4 Pro", 273.0),
+    ("M3 Pro", 150.0),
+    ("M2 Pro", 200.0),
+    ("M1 Pro", 200.0),
+    ("M4", 120.0),
+    ("M3", 100.0),
+    ("M2", 100.0),
+    ("M1", 68.0),
+    ("GB10", 273.0),  # NVIDIA DGX Spark
+    ("RTX 5090", 1792.0),
+    ("RTX 5080", 960.0),
+    ("RTX 4090", 1008.0),
+    ("RTX 4080", 717.0),
+    ("RTX 3090", 936.0),
+    ("RTX 3080", 760.0),
+)
+
+
+def estimate_memory_bandwidth_gigabytes_per_second(
+    node_identity: NodeIdentity,
+) -> float | None:
+    """Estimated GPU memory bandwidth for a node, or None when unrecognised."""
+    chip_name = node_identity.chip_id.lower()
+    for chip_substring, bandwidth in _MEMORY_BANDWIDTH_GBPS_BY_CHIP_SUBSTRING:
+        if chip_substring.lower() in chip_name:
+            return bandwidth
+    return None
+
+
+def allocate_layers_by_throughput(
+    total_layers: int,
+    node_throughputs: list[float],
+    max_layers_per_node: list[int],
+) -> list[int]:
+    """Split layers to minimise summed per-stage decode time.
+
+    Per-token pipeline decode latency is the sum of every stage's compute
+    time, and stage time is (layers on node) / (node throughput), so the sum
+    is minimised by loading the fastest nodes to their memory capacity first.
+    Every node keeps at least one layer (a pipeline stage cannot be empty).
+    Raises ValueError when allocation is impossible; handled by the placement
+    caller (``place_instance``) which surfaces it to the API.
+    """
+    n = len(node_throughputs)
+    if n == 0:
+        raise ValueError("Cannot allocate layers to an empty node list")
+    if total_layers < n:
+        raise ValueError(
+            f"Cannot distribute {total_layers} layers across {n} nodes "
+            "(need at least 1 layer per node)"
+        )
+    if any(cap < 1 for cap in max_layers_per_node):
+        raise ValueError(
+            "Every pipeline node must have memory capacity for at least one layer"
+        )
+    if sum(max_layers_per_node) < total_layers:
+        raise ValueError(
+            f"Selected nodes only have capacity for {sum(max_layers_per_node)} of "
+            f"{total_layers} layers"
+        )
+
+    result = [1] * n
+    remaining = total_layers - n
+    for i in sorted(range(n), key=lambda i: node_throughputs[i], reverse=True):
+        take = min(max_layers_per_node[i] - result[i], remaining)
+        result[i] += take
+        remaining -= take
+        if remaining == 0:
+            break
+    assert remaining == 0
+    return result
 
 
 def allocate_layers_proportionally(
@@ -98,13 +185,38 @@ def _allocate_and_validate_layers(
     node_memory: Mapping[NodeId, MemoryUsage],
     total_memory: Memory,
     model_card: ModelCard,
+    node_identities: Mapping[NodeId, NodeIdentity] | None = None,
 ) -> list[int]:
-    layer_allocations = allocate_layers_proportionally(
-        total_layers=model_card.n_layers,
-        memory_fractions=[
-            node_memory[node_id].ram_available / total_memory for node_id in node_ids
-        ],
-    )
+    node_bandwidths = [
+        estimate_memory_bandwidth_gigabytes_per_second(
+            (node_identities or {}).get(node_id, NodeIdentity())
+        )
+        for node_id in node_ids
+    ]
+
+    if all(bandwidth is not None for bandwidth in node_bandwidths):
+        # Decode throughput is bounded by the sum of per-stage times, so load
+        # the highest-bandwidth nodes first (capped by their memory).
+        layer_allocations = allocate_layers_by_throughput(
+            total_layers=model_card.n_layers,
+            node_throughputs=[
+                bandwidth for bandwidth in node_bandwidths if bandwidth is not None
+            ],
+            max_layers_per_node=[
+                (node_memory[node_id].ram_available.in_bytes * model_card.n_layers)
+                // model_card.storage_size.in_bytes
+                for node_id in node_ids
+            ],
+        )
+    else:
+        # Unknown hardware: fall back to memory-proportional allocation.
+        layer_allocations = allocate_layers_proportionally(
+            total_layers=model_card.n_layers,
+            memory_fractions=[
+                node_memory[node_id].ram_available / total_memory
+                for node_id in node_ids
+            ],
+        )
 
     total_storage = model_card.storage_size
     total_layers = model_card.n_layers
@@ -126,6 +238,7 @@ def get_shard_assignments_for_pipeline_parallel(
     model_card: ModelCard,
     cycle: Cycle,
     node_memory: Mapping[NodeId, MemoryUsage],
+    node_identities: Mapping[NodeId, NodeIdentity] | None = None,
 ) -> ShardAssignments:
     """Create shard assignments for pipeline parallel execution."""
     world_size = len(cycle)
@@ -134,7 +247,9 @@ def get_shard_assignments_for_pipeline_parallel(
     if use_cfg_parallel:
         return _get_shard_assignments_for_cfg_parallel(model_card, cycle, node_memory)
     else:
-        return _get_shard_assignments_for_pure_pipeline(model_card, cycle, node_memory)
+        return _get_shard_assignments_for_pure_pipeline(
+            model_card, cycle, node_memory, node_identities
+        )
 
 
 def _get_shard_assignments_for_cfg_parallel(
@@ -204,13 +319,14 @@ def _get_shard_assignments_for_pure_pipeline(
     model_card: ModelCard,
     cycle: Cycle,
     node_memory: Mapping[NodeId, MemoryUsage],
+    node_identities: Mapping[NodeId, NodeIdentity] | None = None,
 ) -> ShardAssignments:
     """Create shard assignments for pure pipeline execution."""
     _validate_cycle(cycle)
     total_memory = _compute_total_memory(cycle.node_ids, node_memory)
 
     layer_allocations = _allocate_and_validate_layers(
-        cycle.node_ids, node_memory, total_memory, model_card
+        cycle.node_ids, node_memory, total_memory, model_card, node_identities
     )
 
     runner_to_shard: dict[RunnerId, ShardMetadata] = {}
@@ -278,6 +394,7 @@ def get_shard_assignments(
     cycle: Cycle,
     sharding: Sharding,
     node_memory: Mapping[NodeId, MemoryUsage],
+    node_identities: Mapping[NodeId, NodeIdentity] | None = None,
 ) -> ShardAssignments:
     match sharding:
         case Sharding.Pipeline:
@@ -285,6 +402,7 @@ def get_shard_assignments(
                 model_card=model_card,
                 cycle=cycle,
                 node_memory=node_memory,
+                node_identities=node_identities,
             )
         case Sharding.Tensor:
             return get_shard_assignments_for_tensor_parallel(
@@ -336,6 +454,18 @@ def _find_connection_ip(
             yield connection.sink_multiaddr.ip_address
 
 
+# Nominal link speeds (Mb/s) used when the OS does not report a negotiated
+# speed. Ordering preserves the previous ring preference:
+# thunderbolt > maybe_ethernet > ethernet > wifi > unknown.
+_NOMINAL_LINK_SPEED_MEGABITS: Mapping[str, int] = {
+    "thunderbolt": 40_000,
+    "maybe_ethernet": 10_000,
+    "ethernet": 1_000,
+    "wifi": 300,
+    "unknown": 100,
+}
+
+
 def find_ip_prioritised(
     node_id: NodeId,
     other_node_id: NodeId,
@@ -345,37 +475,44 @@ def find_ip_prioritised(
 ) -> str | None:
     """Find an IP address between nodes with prioritization.
 
-    Priority: ethernet > wifi > unknown > thunderbolt
+    Ring links prefer the fastest interface: the negotiated link speed when
+    the node reports one (Linux sysfs), otherwise a nominal per-type speed.
+    RDMA coordinators prefer ethernet.
     """
     ips = list(_find_connection_ip(node_id, other_node_id, cycle_digraph))
     if not ips:
         return None
     other_network = node_network.get(other_node_id, NodeNetworkInfo())
-    ip_to_type = {
-        iface.ip_address: iface.interface_type for iface in other_network.interfaces
-    }
+    ip_to_interface = {iface.ip_address: iface for iface in other_network.interfaces}
 
-    # Ring should prioritise fastest connection. As a best-effort, we prioritise TB.
-    # TODO: Profile and get actual connection speeds.
     if ring:
-        priority = {
-            "thunderbolt": 0,
-            "maybe_ethernet": 1,
-            "ethernet": 2,
-            "wifi": 3,
-            "unknown": 4,
-        }
+
+        def effective_link_speed_megabits(ip: str) -> int:
+            interface = ip_to_interface.get(ip)
+            if interface is None:
+                return _NOMINAL_LINK_SPEED_MEGABITS["unknown"]
+            if interface.link_speed_megabits is not None:
+                return interface.link_speed_megabits
+            return _NOMINAL_LINK_SPEED_MEGABITS.get(
+                interface.interface_type, _NOMINAL_LINK_SPEED_MEGABITS["unknown"]
+            )
+
+        return max(ips, key=effective_link_speed_megabits)
 
     # RDMA prefers ethernet coordinator
-    else:
-        priority = {
-            "ethernet": 0,
-            "wifi": 1,
-            "unknown": 2,
-            "maybe_ethernet": 3,
-            "thunderbolt": 4,
-        }
-    return min(ips, key=lambda ip: priority.get(ip_to_type.get(ip, "unknown"), 2))
+    priority = {
+        "ethernet": 0,
+        "wifi": 1,
+        "unknown": 2,
+        "maybe_ethernet": 3,
+        "thunderbolt": 4,
+    }
+
+    def interface_type_for_ip(ip: str) -> str:
+        interface = ip_to_interface.get(ip)
+        return interface.interface_type if interface is not None else "unknown"
+
+    return min(ips, key=lambda ip: priority.get(interface_type_for_ip(ip), 2))
 
 
 def get_mlx_ring_hosts_by_node(

--- a/src/exo/master/tests/test_throughput_allocation.py
+++ b/src/exo/master/tests/test_throughput_allocation.py
@@ -1,0 +1,236 @@
+import pytest
+
+from exo.master.placement import place_instance
+from exo.master.placement_utils import (
+    allocate_layers_by_throughput,
+    estimate_memory_bandwidth_gigabytes_per_second,
+    find_ip_prioritised,
+)
+from exo.master.tests.conftest import (
+    create_node_memory,
+    create_node_network,
+    create_socket_connection,
+)
+from exo.shared.models.model_cards import ModelCard, ModelId, ModelTask
+from exo.shared.topology import Topology
+from exo.shared.types.backends import Backend
+from exo.shared.types.commands import PlaceInstance
+from exo.shared.types.common import CommandId, NodeId
+from exo.shared.types.memory import Memory
+from exo.shared.types.profiling import (
+    NetworkInterfaceInfo,
+    NodeIdentity,
+    NodeNetworkInfo,
+)
+from exo.shared.types.topology import Connection
+from exo.shared.types.worker.instances import InstanceMeta
+from exo.shared.types.worker.shards import Sharding
+
+
+def test_allocate_layers_by_throughput_fills_fastest_first() -> None:
+    allocations = allocate_layers_by_throughput(
+        total_layers=12,
+        node_throughputs=[819.0, 273.0, 800.0],
+        max_layers_per_node=[4, 4, 8],
+    )
+    assert allocations == [4, 1, 7]
+    assert sum(allocations) == 12
+
+
+def test_allocate_layers_by_throughput_keeps_one_layer_per_node() -> None:
+    allocations = allocate_layers_by_throughput(
+        total_layers=3,
+        node_throughputs=[1000.0, 1.0, 1.0],
+        max_layers_per_node=[3, 3, 3],
+    )
+    assert allocations == [1, 1, 1]
+
+
+def test_allocate_layers_by_throughput_rejects_insufficient_capacity() -> None:
+    with pytest.raises(ValueError, match="capacity"):
+        _ = allocate_layers_by_throughput(
+            total_layers=10,
+            node_throughputs=[100.0, 100.0],
+            max_layers_per_node=[4, 4],
+        )
+
+
+def test_estimate_memory_bandwidth_matches_known_chips() -> None:
+    assert (
+        estimate_memory_bandwidth_gigabytes_per_second(
+            NodeIdentity(chip_id="Apple M3 Ultra")
+        )
+        == 819.0
+    )
+    assert (
+        estimate_memory_bandwidth_gigabytes_per_second(
+            NodeIdentity(chip_id="NVIDIA GB10")
+        )
+        == 273.0
+    )
+    assert (
+        estimate_memory_bandwidth_gigabytes_per_second(
+            NodeIdentity(chip_id="NVIDIA GeForce RTX 3090")
+        )
+        == 936.0
+    )
+    assert (
+        estimate_memory_bandwidth_gigabytes_per_second(
+            NodeIdentity(chip_id="Unknown Chip")
+        )
+        is None
+    )
+
+
+def _fully_connected_three_node_topology() -> tuple[Topology, NodeId, NodeId, NodeId]:
+    node_a, node_b, node_c = NodeId(), NodeId(), NodeId()
+    topology = Topology()
+    for node_id in (node_a, node_b, node_c):
+        topology.add_node(node_id)
+    pairs = [
+        (node_a, node_b),
+        (node_b, node_c),
+        (node_c, node_a),
+        (node_b, node_a),
+        (node_c, node_b),
+        (node_a, node_c),
+    ]
+    for index, (source, sink) in enumerate(pairs):
+        topology.add_connection(
+            Connection(
+                source=source, sink=sink, edge=create_socket_connection(index + 1)
+            )
+        )
+    return topology, node_a, node_b, node_c
+
+
+def test_pipeline_placement_uses_bandwidth_when_identities_known() -> None:
+    topology, node_a, node_b, node_c = _fully_connected_three_node_topology()
+    model_card = ModelCard(
+        model_id=ModelId("test-model"),
+        storage_size=Memory.from_bytes(1500),
+        n_layers=12,
+        hidden_size=30,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+        backends=[Backend.MlxMetal],
+    )
+    command = PlaceInstance(
+        command_id=CommandId(),
+        model_card=model_card,
+        sharding=Sharding.Pipeline,
+        instance_meta=InstanceMeta.MlxRing,
+        min_nodes=3,
+    )
+    node_memory = {
+        node_a: create_node_memory(500),
+        node_b: create_node_memory(500),
+        node_c: create_node_memory(1000),
+    }
+    node_network = {node_id: create_node_network() for node_id in node_memory}
+    node_backends = {node_id: [Backend.MlxMetal] for node_id in node_memory}
+    node_identities = {
+        node_a: NodeIdentity(chip_id="Apple M3 Ultra"),
+        node_b: NodeIdentity(chip_id="NVIDIA GB10"),
+        node_c: NodeIdentity(chip_id="Apple M2 Ultra"),
+    }
+
+    placements = place_instance(
+        command,
+        topology,
+        {},
+        node_memory,
+        node_network,
+        node_backends,
+        node_identities=node_identities,
+    )
+
+    assert len(placements) == 1
+    instance = next(iter(placements.values()))
+
+    def layer_count(node_id: NodeId) -> int:
+        runner_id = instance.shard_assignments.node_to_runner[node_id]
+        shard = instance.shard_assignments.runner_to_shard[runner_id]
+        return shard.end_layer - shard.start_layer
+
+    # Fastest nodes are filled to their memory caps first; the slow GB10
+    # keeps the single layer every pipeline stage requires.
+    assert layer_count(node_a) == 4
+    assert layer_count(node_b) == 1
+    assert layer_count(node_c) == 7
+
+
+def _two_node_topology_with_two_links(
+    thunderbolt_ip: str, ethernet_ip: str
+) -> tuple[Topology, NodeId, NodeId]:
+    node_a, node_b = NodeId(), NodeId()
+    topology = Topology()
+    topology.add_node(node_a)
+    topology.add_node(node_b)
+    for ip in (thunderbolt_ip, ethernet_ip):
+        last_octet = int(ip.rsplit(".", 1)[1])
+        topology.add_connection(
+            Connection(
+                source=node_a,
+                sink=node_b,
+                edge=create_socket_connection(last_octet),
+            )
+        )
+    return topology, node_a, node_b
+
+
+def test_find_ip_prioritised_prefers_measured_link_speed_for_ring() -> None:
+    thunderbolt_ip, ethernet_ip = "169.254.0.8", "169.254.0.9"
+    topology, node_a, node_b = _two_node_topology_with_two_links(
+        thunderbolt_ip, ethernet_ip
+    )
+    node_network = {
+        node_b: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="en5",
+                    ip_address=thunderbolt_ip,
+                    interface_type="thunderbolt",
+                ),
+                NetworkInterfaceInfo(
+                    name="enp1s0f0",
+                    ip_address=ethernet_ip,
+                    interface_type="ethernet",
+                    link_speed_megabits=200_000,
+                ),
+            ]
+        )
+    }
+
+    selected_ip = find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+
+    # 200 GbE with a measured speed beats thunderbolt's nominal 40 Gb/s.
+    assert selected_ip == ethernet_ip
+
+
+def test_find_ip_prioritised_falls_back_to_nominal_speeds_for_ring() -> None:
+    thunderbolt_ip, ethernet_ip = "169.254.0.8", "169.254.0.9"
+    topology, node_a, node_b = _two_node_topology_with_two_links(
+        thunderbolt_ip, ethernet_ip
+    )
+    node_network = {
+        node_b: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="en5",
+                    ip_address=thunderbolt_ip,
+                    interface_type="thunderbolt",
+                ),
+                NetworkInterfaceInfo(
+                    name="en0",
+                    ip_address=ethernet_ip,
+                    interface_type="ethernet",
+                ),
+            ]
+        )
+    }
+
+    selected_ip = find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+
+    # Without measured speeds the previous type preference is preserved.
+    assert selected_ip == thunderbolt_ip

--- a/src/exo/shared/types/profiling.py
+++ b/src/exo/shared/types/profiling.py
@@ -73,6 +73,9 @@ class NetworkInterfaceInfo(FrozenModel):
     name: str
     ip_address: str
     interface_type: InterfaceType = "unknown"
+    # Negotiated link speed in megabits per second (None when the OS cannot
+    # report it, e.g. Wi-Fi on some platforms or virtual interfaces).
+    link_speed_megabits: int | None = None
 
 
 class NodeIdentity(FrozenModel):

--- a/src/exo/utils/info_gatherer/system_info.py
+++ b/src/exo/utils/info_gatherer/system_info.py
@@ -1,6 +1,7 @@
 import platform
 import socket
 import sys
+from pathlib import Path
 from subprocess import CalledProcessError
 
 import psutil
@@ -90,17 +91,53 @@ async def _get_interface_types_from_networksetup() -> dict[str, InterfaceType]:
     return types
 
 
+def _classify_linux_interface(
+    interface_name: str,
+) -> tuple[InterfaceType, int | None]:
+    """Classify a Linux interface via sysfs and report its negotiated link speed.
+
+    ``/sys/class/net/<iface>/speed`` holds the negotiated speed in Mb/s for
+    wired links (reads fail or report a non-positive value for wireless,
+    virtual, or down interfaces). The distinction matters for ring host
+    selection: e.g. a DGX Spark exposes both a management ethernet port and
+    200 GbE ConnectX ports, and only the link speed tells them apart.
+    """
+    sysfs_path = Path("/sys/class/net") / interface_name
+    if (sysfs_path / "wireless").exists():
+        return "wifi", None
+
+    link_speed_megabits: int | None = None
+    try:
+        link_speed_megabits = int((sysfs_path / "speed").read_text().strip())
+    except (OSError, ValueError):
+        link_speed_megabits = None
+    if link_speed_megabits is not None and link_speed_megabits <= 0:
+        link_speed_megabits = None
+
+    # A "device" symlink marks a physical (non-virtual) interface.
+    if (sysfs_path / "device").exists():
+        return "ethernet", link_speed_megabits
+    return "unknown", link_speed_megabits
+
+
 async def get_network_interfaces() -> list[NetworkInterfaceInfo]:
     """
-    Retrieves detailed network interface information on macOS.
-    Parses output from 'networksetup -listallhardwareports' and 'ifconfig'
-    to determine interface names, IP addresses, and types (ethernet, wifi, vpn, other).
+    Retrieves detailed network interface information.
+
+    On macOS, parses 'networksetup -listallhardwareports' output to determine
+    interface types (ethernet, wifi, thunderbolt). On Linux, classifies
+    interfaces via sysfs and reports their negotiated link speed.
     Returns a list of NetworkInterfaceInfo objects.
     """
     interfaces_info: list[NetworkInterfaceInfo] = []
     interface_types = await _get_interface_types_from_networksetup()
+    is_linux = sys.platform == "linux"
 
     for iface, services in psutil.net_if_addrs().items():
+        interface_type = interface_types.get(iface, "unknown")
+        link_speed_megabits: int | None = None
+        if is_linux:
+            interface_type, link_speed_megabits = _classify_linux_interface(iface)
         for service in services:
             match service.family:
                 case socket.AF_INET | socket.AF_INET6:
@@ -108,7 +145,8 @@ async def get_network_interfaces() -> list[NetworkInterfaceInfo]:
                         NetworkInterfaceInfo(
                             name=iface,
                             ip_address=service.address,
-                            interface_type=interface_types.get(iface, "unknown"),
+                            interface_type=interface_type,
+                            link_speed_megabits=link_speed_megabits,
                         )
                     )
                 case _:
@@ -117,13 +155,39 @@ async def get_network_interfaces() -> list[NetworkInterfaceInfo]:
     return interfaces_info
 
 
+async def _get_cuda_gpu_name() -> str | None:
+    """Name of the first CUDA GPU via nvidia-smi (e.g. "NVIDIA GeForce RTX 3090").
+
+    Returns None when nvidia-smi is unavailable or fails.
+    """
+    try:
+        process = await run_process(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            check=False,
+        )
+    except (CalledProcessError, OSError):
+        return None
+    if process.returncode != 0:
+        return None
+    first_line = process.stdout.decode("utf-8", errors="replace").strip().splitlines()
+    return first_line[0].strip() if first_line else None
+
+
 async def get_model_and_chip() -> tuple[str, str]:
-    """Get Mac system information using system_profiler."""
+    """Get system model and chip information.
+
+    On macOS this uses system_profiler. On other platforms the chip is the
+    CUDA GPU name when one is present (it identifies the accelerator that
+    actually runs inference, which placement uses to estimate memory
+    bandwidth).
+    """
     model = "Unknown Model"
     chip = "Unknown Chip"
 
-    # TODO: better non mac support
     if sys.platform != "darwin":
+        gpu_name = await _get_cuda_gpu_name()
+        if gpu_name is not None:
+            chip = gpu_name
         return (model, chip)
 
     try:

--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -1,8 +1,10 @@
+import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator
+from dataclasses import dataclass
 from functools import partial
 from inspect import signature
-from typing import TYPE_CHECKING, Literal, Protocol, cast
+from typing import TYPE_CHECKING, Literal, Protocol, cast, final
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -67,6 +69,50 @@ from exo.worker.runner.bootstrap import logger
 
 if TYPE_CHECKING:
     from mlx_lm.models.cache import Cache
+
+
+@final
+class PipelineDecodeTimings:
+    """Accumulates per-token pipeline communication timings during decode.
+
+    Timings are collected inside ``PipelineFirstLayer`` / ``PipelineLastLayer``
+    and logged as a rolling summary every ``log_every`` decode steps, so a
+    ``-vv`` run attributes per-token latency to recv / send / gather phases.
+    """
+
+    def __init__(self, log_every: int = 64) -> None:
+        self.log_every = log_every
+        self.recv_seconds = 0.0
+        self.send_seconds = 0.0
+        self.gather_seconds = 0.0
+        self.steps = 0
+
+    def record_recv(self, seconds: float) -> None:
+        self.recv_seconds += seconds
+
+    def record_send(self, seconds: float) -> None:
+        self.send_seconds += seconds
+
+    def record_gather_and_advance(self, seconds: float) -> None:
+        """The gather (or relay) phase runs once per decode step, so it also
+        advances the step counter and emits the periodic summary."""
+        self.gather_seconds += seconds
+        self.steps += 1
+        if self.steps % self.log_every == 0:
+            per_step_ms = 1000.0 / self.log_every
+            logger.debug(
+                "pipeline decode comm (avg over "
+                f"{self.log_every} tokens): "
+                f"recv={self.recv_seconds * per_step_ms:.2f}ms "
+                f"send={self.send_seconds * per_step_ms:.2f}ms "
+                f"gather={self.gather_seconds * per_step_ms:.2f}ms"
+            )
+            self.recv_seconds = 0.0
+            self.send_seconds = 0.0
+            self.gather_seconds = 0.0
+
+
+decode_timings = PipelineDecodeTimings()
 
 
 _pending_prefill_sends: list[tuple[mx.array, int, mx.distributed.Group]] = []
@@ -134,8 +180,11 @@ class PipelineFirstLayer(CustomMlxLayer):
             # We want to avoid GPU timeout errors by evalling the distributed operation
             # so that it stays on CPU, which does not have a timeout.
             mx.eval(x)
+            recv_start = time.perf_counter()
             x = mx.distributed.recv_like(x, (self.r - 1), group=self.group)
             mx.eval(x)
+            if not self.is_prefill:
+                decode_timings.record_recv(time.perf_counter() - recv_start)
         return self.original_layer(x, *args, **kwargs)
 
 
@@ -154,6 +203,7 @@ class PipelineLastLayer(CustomMlxLayer):
         self.original_layer_signature = signature(self.original_layer.__call__)
         self.is_prefill: bool = False
         self.queue_sends: bool = False
+        self.token_relay: bool = False
 
     def __call__(self, x: mx.array, *args: object, **kwargs: object) -> mx.array:
         cache = self.original_layer_signature.bind_partial(
@@ -167,6 +217,7 @@ class PipelineLastLayer(CustomMlxLayer):
         mx.eval(output)
 
         if self.r != self.s - 1:
+            send_start = time.perf_counter()
             if self.queue_sends:
                 _pending_prefill_sends.append(
                     (output, (self.r + 1) % self.s, self.group)
@@ -184,12 +235,21 @@ class PipelineLastLayer(CustomMlxLayer):
             mx.eval(output)
             if cache is not None and hasattr(_cache, "keys"):  # type: ignore
                 mx.eval(_cache.keys)  # type: ignore
+            if not self.is_prefill:
+                decode_timings.record_send(time.perf_counter() - send_start)
 
-        if not self.is_prefill:
+        if not self.is_prefill and not self.token_relay:
+            # Legacy lockstep decode: every rank gathers the last stage's
+            # activation so all ranks compute identical logits and sample the
+            # same token. With token relay enabled the last rank samples alone
+            # and circulates only the token id (see relay_sampled_tokens), so
+            # this full-hidden-state collective is skipped.
+            gather_start = time.perf_counter()
             output = mx.distributed.all_gather(output, group=self.group)[
                 -output.shape[0] :
             ]
             mx.eval(output)
+            decode_timings.record_gather_and_advance(time.perf_counter() - gather_start)
 
         return output
 
@@ -204,6 +264,74 @@ def set_pipeline_queue_sends(model: nn.Module, queue_sends: bool) -> None:
     for layer in model.layers:  # type: ignore
         if isinstance(layer, PipelineLastLayer):
             layer.queue_sends = queue_sends
+
+
+def set_pipeline_token_relay(model: nn.Module, token_relay: bool) -> None:
+    """Toggle token-relay decode for a pipeline-parallel model.
+
+    When enabled, decode skips the per-token all_gather of the final hidden
+    state: only the last pipeline rank computes final norm / lm_head and
+    samples, and the sampled token ids are circulated with
+    ``relay_sampled_tokens``. Must only be enabled while every rank agrees to
+    call ``relay_sampled_tokens`` after each decode step, otherwise ranks
+    deadlock or diverge.
+    """
+    for layer in model.layers:  # type: ignore
+        if isinstance(layer, PipelineLastLayer):
+            layer.token_relay = token_relay
+
+
+@final
+@dataclass(frozen=True)
+class PipelineRelayContext:
+    """Rank/group facts needed to relay sampled tokens between pipeline ranks."""
+
+    group: mx.distributed.Group
+    device_rank: int
+    world_size: int
+
+    @property
+    def is_last_rank(self) -> bool:
+        return self.device_rank == self.world_size - 1
+
+
+def get_active_relay_context(model: nn.Module) -> PipelineRelayContext | None:
+    """Return the relay context when token-relay decode is currently enabled.
+
+    Returns None for non-pipeline models and for pipeline models with the
+    legacy all_gather decode active.
+    """
+    layers = cast(list[object], getattr(model, "layers", []))
+    for layer in layers:
+        if isinstance(layer, PipelineLastLayer):
+            if not layer.token_relay or layer.is_prefill:
+                return None
+            return PipelineRelayContext(
+                group=layer.group, device_rank=layer.r, world_size=layer.s
+            )
+    return None
+
+
+def relay_sampled_tokens(
+    sampled: mx.array, relay_context: PipelineRelayContext
+) -> mx.array:
+    """Circulate the last rank's sampled token ids to every pipeline rank.
+
+    All ranks contribute a same-shape int32 vector (only the last rank's
+    values are meaningful) and take the last rank's slice from the gathered
+    result. This replaces the per-token all_gather of the full hidden state
+    with a collective over ``batch_size`` token ids.
+    """
+    gather_start = time.perf_counter()
+    contribution = sampled.astype(mx.int32)
+    mx.eval(contribution)
+    gathered = mx.distributed.all_gather(contribution, group=relay_context.group)
+    mx.eval(gathered)
+    batch_size = contribution.shape[0]
+    last_rank_offset = (relay_context.world_size - 1) * batch_size
+    relayed = gathered[last_rank_offset : last_rank_offset + batch_size]
+    decode_timings.record_gather_and_advance(time.perf_counter() - gather_start)
+    return relayed
 
 
 def get_inner_model(model: nn.Module) -> nn.Module:
@@ -407,6 +535,15 @@ def patch_pipeline_model[T](model: T, group: mx.distributed.Group) -> T:
         **kwargs: object,
     ) -> mx.array:
         logits: mx.array = original_call(self, *args, **kwargs)  # type: ignore
+
+        relay_context = get_active_relay_context(cast(nn.Module, self))
+        if relay_context is not None and not relay_context.is_last_rank:
+            # Token-relay decode: this rank's final hidden state is not the
+            # last pipeline stage's, so its logits are meaningless. Returning
+            # a detached zeros array drops the final norm / lm_head from the
+            # lazy graph entirely — they are never computed on this rank.
+            logits = mx.zeros_like(logits)
+
         cache = call_signature.bind_partial(self, *args, **kwargs).arguments.get(
             "cache", None
         )

--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -26,6 +26,10 @@ from exo.api.types import (
 from exo.shared.types.memory import Memory
 from exo.shared.types.text_generation import TextGenerationTaskParams
 from exo.shared.types.worker.runner_response import GenerationResponse
+from exo.worker.engines.mlx.auto_parallel import (
+    PipelineLastLayer,
+    set_pipeline_token_relay,
+)
 from exo.worker.engines.mlx.cache import (
     CacheSnapshot,
     KVPrefixCache,
@@ -48,6 +52,7 @@ from exo.worker.engines.mlx.patches.opt_batch_gen import (
 from exo.worker.engines.mlx.types import KVCacheType, Model
 from exo.worker.engines.mlx.utils_mlx import (
     fix_unmatched_think_end_tokens,
+    mx_ranks_agree_on_value,
     system_prompt_token_count,
 )
 from exo.worker.engines.mlx.vision import (
@@ -100,6 +105,7 @@ class ExoBatchGenerator:
 
     _mlx_gen: MlxBatchGenerator = field(init=False)
     _active_tasks: dict[int, _EngineTask] = field(default_factory=dict, init=False)
+    _supports_token_relay: bool = field(init=False)
 
     def __post_init__(self) -> None:
         self._mlx_gen = MlxBatchGenerator(
@@ -108,6 +114,9 @@ class ExoBatchGenerator:
             prefill_step_size=4096,
         )
         self._step_count = 0
+        self._supports_token_relay = self.group is not None and any(
+            isinstance(layer, PipelineLastLayer) for layer in self.model.layers
+        )
 
     @property
     def has_work(self) -> bool:
@@ -170,7 +179,18 @@ class ExoBatchGenerator:
                 )
             )
             prefix_hit_length = len(all_prompt_tokens) - len(remaining_tokens)
-            if prefix_hit_length > 0:
+            if not mx_ranks_agree_on_value(prefix_hit_length, self.group):
+                # Divergent restore positions would make ranks prefill
+                # different token counts and deadlock the pipeline.
+                logger.warning(
+                    "KV prefix cache hit lengths diverge across pipeline ranks; "
+                    "discarding the hit to keep prefill in lockstep"
+                )
+                cache = make_kv_cache(self.model)
+                prefix_hit_length = 0
+                matched_index = None
+                is_exact_hit = False
+            elif prefix_hit_length > 0:
                 logger.info(
                     f"KV cache hit: {prefix_hit_length}/{len(all_prompt_tokens)} tokens "
                     f"cached ({100 * prefix_hit_length / len(all_prompt_tokens):.1f}%)"
@@ -331,12 +351,22 @@ class ExoBatchGenerator:
             return []
 
         gb = self._mlx_gen._generation_batch
-        set_needs_topk(
-            gb,
-            any(t.task_params.logprobs for t in self._active_tasks.values()),
+        needs_logprobs = any(
+            t.task_params.logprobs for t in self._active_tasks.values()
+        )
+        set_needs_topk(gb, needs_logprobs)
+        # Token relay needs every rank's logits path untouched only on the last
+        # rank; requests that ask for logprobs need real logits on rank 0, so
+        # fall back to the legacy all_gather decode for those. The flag is
+        # reset after the step so prefill and warmup always use legacy paths.
+        set_pipeline_token_relay(
+            self.model, self._supports_token_relay and not needs_logprobs
         )
         _step_tic = time.perf_counter()
-        _, responses = self._mlx_gen.next()
+        try:
+            _, responses = self._mlx_gen.next()
+        finally:
+            set_pipeline_token_relay(self.model, False)
         _next_elapsed = time.perf_counter() - _step_tic
 
         topk = take_ready_topk(gb)

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -61,6 +61,7 @@ from exo.worker.engines.mlx.utils_mlx import (
     apply_chat_template,
     fix_unmatched_think_end_tokens,
     mx_barrier,
+    mx_ranks_agree_on_value,
     system_prompt_token_count,
 )
 from exo.worker.engines.mlx.vision import (
@@ -591,7 +592,19 @@ def mlx_generate(
             )
         )
         prefix_hit_length = len(all_prompt_tokens) - len(prompt_tokens)
-        if prefix_hit_length > 0:
+        if not mx_ranks_agree_on_value(prefix_hit_length, group):
+            # Divergent restore positions would make ranks prefill different
+            # token counts and deadlock the pipeline.
+            logger.warning(
+                "KV prefix cache hit lengths diverge across pipeline ranks; "
+                "discarding the hit to keep prefill in lockstep"
+            )
+            caches = make_kv_cache(model=model)
+            prompt_tokens = all_prompt_tokens
+            prefix_hit_length = 0
+            matched_index = None
+            is_exact_hit = False
+        elif prefix_hit_length > 0:
             logger.info(
                 f"KV cache hit: {prefix_hit_length}/{len(all_prompt_tokens)} tokens cached ({100 * prefix_hit_length / len(all_prompt_tokens):.1f}%)"
             )

--- a/src/exo/worker/engines/mlx/patches/opt_batch_gen.py
+++ b/src/exo/worker/engines/mlx/patches/opt_batch_gen.py
@@ -4,6 +4,11 @@ from typing import cast
 import mlx.core as mx
 from mlx_lm.generate import GenerationBatch
 
+from exo.worker.engines.mlx.auto_parallel import (
+    get_active_relay_context,
+    relay_sampled_tokens,
+)
+
 _PRECOMPUTE_TOP_K = 20
 
 
@@ -86,6 +91,12 @@ def _patched_step(self: GenerationBatch) -> tuple[list[int], list[mx.array]]:
         sampled = mx.concatenate(all_samples, axis=0)
     else:
         sampled = self.fallback_sampler(logprobs)
+
+    relay_context = get_active_relay_context(self.model)
+    if relay_context is not None:
+        # Token-relay decode: only the last pipeline rank sampled from real
+        # logits; circulate its token ids so every rank stays in lockstep.
+        sampled = relay_sampled_tokens(sampled, relay_context)
 
     self._next_tokens = sampled
     self._next_logprobs = logprobs

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -840,6 +840,27 @@ def mx_any(bool_: bool, group: mx.distributed.Group | None) -> bool:
     return num_true.item() > 0
 
 
+def mx_ranks_agree_on_value(value: int, group: mx.distributed.Group | None) -> bool:
+    """True when every rank in the group holds the same value.
+
+    Used to keep per-rank KV prefix cache decisions consistent: pipeline
+    shards of hybrid SSM/attention models can restore different prefix
+    lengths (SSM shards need state snapshots, attention-only shards do not),
+    and ranks prefilling different token counts deadlock the pipeline's
+    send/recv chain.
+    """
+    if group is None:
+        return True
+    gathered = mx.distributed.all_gather(
+        mx.array([value], dtype=mx.int32),
+        group=group,
+        stream=mx.default_stream(mx.Device(mx.cpu)),
+    )
+    mx.eval(gathered)
+    values = cast(list[int], gathered.tolist())
+    return min(values) == max(values)
+
+
 def mx_barrier(group: mx.distributed.Group | None):
     if group is None:
         return

--- a/src/exo/worker/tests/unittests/test_mlx/test_auto_parallel.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_auto_parallel.py
@@ -12,7 +12,10 @@ from exo.worker.engines.mlx.auto_parallel import (
     CustomMlxLayer,
     PipelineFirstLayer,
     PipelineLastLayer,
+    get_active_relay_context,
     patch_pipeline_model,
+    relay_sampled_tokens,
+    set_pipeline_token_relay,
 )
 from exo.worker.tests.unittests.test_mlx.conftest import MockLayer
 
@@ -64,6 +67,114 @@ def run_pipeline_device(
         result_queue.put((rank, success, result))  # pyright: ignore[reportAny]
     except Exception as e:
         result_queue.put((rank, False, str(e)))  # pyright: ignore[reportAny]
+
+
+def run_token_relay_device(
+    rank: int,
+    world_size: int,
+    hostfile_path: str,
+    result_queue: Any,  # pyright: ignore[reportAny]
+) -> None:
+    import os
+
+    os.environ["MLX_HOSTFILE"] = hostfile_path
+    os.environ["MLX_RANK"] = str(rank)
+
+    class MockLayerInner(mlx_nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+
+        def __call__(self, x: mx.array, *args: object, **kwargs: object) -> mx.array:
+            return x * 2
+
+    class MockModel(mlx_nn.Module):
+        def __init__(self, layers: list[mlx_nn.Module]) -> None:
+            super().__init__()
+            self.layers = layers
+
+        def __call__(self, x: mx.array, *args: object, **kwargs: object) -> mx.array:
+            for layer in self.layers:
+                x = layer(x, *args, **kwargs)
+            return x
+
+    try:
+        group = mx.distributed.init(backend="ring", strict=True)
+
+        mock = MockLayerInner()
+        first = PipelineFirstLayer(mock, r=rank, group=group)
+        composed = PipelineLastLayer(first, r=rank, s=world_size, group=group)
+
+        inner_model = MockModel([composed])
+        model = patch_pipeline_model(inner_model, group)
+        set_pipeline_token_relay(model, True)
+
+        x = mx.ones((1, 4))
+        logits = model(x)
+        mx.eval(logits)
+
+        # Non-last ranks return detached zeros; the last rank returns the
+        # real final activation (ones doubled once per pipeline stage, so the
+        # sum over the 4 elements is (1 << world_size) * 4).
+        local_sum = float(logits.sum().item())
+        expected_token = (1 << world_size) * 4
+        expected_sum = 0.0 if rank != world_size - 1 else float(expected_token)
+        local_correct = abs(local_sum - expected_sum) < 1e-6
+
+        # Every rank contributes a locally sampled token; after the relay all
+        # ranks must hold the last rank's token.
+        locally_sampled = mx.array([int(local_sum)])
+        relay_context = get_active_relay_context(model)
+        assert relay_context is not None
+        relayed = relay_sampled_tokens(locally_sampled, relay_context)
+        relay_correct = int(relayed.item()) == expected_token
+
+        result_queue.put((rank, local_correct and relay_correct, None))  # pyright: ignore[reportAny]
+    except Exception as e:
+        result_queue.put((rank, False, str(e)))  # pyright: ignore[reportAny]
+
+
+def test_token_relay_decode_circulates_last_rank_token() -> None:
+    ctx = mp.get_context("spawn")
+
+    world_size = 2
+    base_port = 29600
+
+    hosts = [f"127.0.0.1:{base_port + i}" for i in range(world_size)]
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(hosts, f)
+        hostfile_path = f.name
+
+    try:
+        result_queue: Any = ctx.Queue()
+
+        processes: list[Any] = []
+        for rank in range(world_size):
+            p = ctx.Process(
+                target=run_token_relay_device,
+                args=(rank, world_size, hostfile_path, result_queue),
+            )
+            p.start()
+            processes.append(p)
+
+        for p in processes:  # pyright: ignore[reportAny]
+            p.join(timeout=10)  # pyright: ignore[reportAny]
+
+        results: dict[int, bool] = {}
+        errors: dict[int, str] = {}
+        while not result_queue.empty():  # pyright: ignore[reportAny]
+            rank, success, error = result_queue.get()  # pyright: ignore[reportAny]
+            results[rank] = success
+            if error is not None:
+                errors[rank] = error
+
+        assert len(results) == world_size, (
+            f"Expected {world_size} results, got {len(results)}. Errors: {errors}"
+        )
+        for rank in range(world_size):
+            assert results[rank], f"Device {rank} failed: {errors.get(rank)}"
+    finally:
+        os.unlink(hostfile_path)
 
 
 def test_single_wrapper_delegates_attributes() -> None:


### PR DESCRIPTION
Multi-node pipeline decode currently pays three per-token costs that this PR removes or reduces:

1. **Token-relay decode** — during decode, every rank all_gathers the full hidden state and redundantly runs final norm + lm_head + sampling. With this change only the last pipeline rank samples; the sampled token id is circulated to all ranks with a single-int collective, and the other ranks never compute lm_head at all (it drops out of the lazy graph). Requests with `logprobs` automatically fall back to the legacy lockstep path so rank 0 keeps real logits.

2. **Bandwidth-aware layer allocation** — layers were split proportionally to available RAM, which overloads slow nodes in heterogeneous clusters (per-token decode latency is the *sum* of per-stage times, and stage time is bytes-read / memory-bandwidth). Nodes now report their GPU name (`nvidia-smi` on Linux, `system_profiler` on macOS), placement estimates per-chip memory bandwidth from a lookup table, and loads the fastest nodes to their memory caps first. Unrecognised hardware falls back to the existing RAM-proportional split, so behaviour is unchanged for clusters the table doesn't know.

3. **Link-speed-aware ring host selection** — Linux interfaces were all classified `"unknown"` (interface typing shelled out to macOS-only `networksetup`), so ring links between Linux nodes were chosen arbitrarily. Interfaces are now classified via sysfs with their negotiated link speed, and ring neighbours prefer the fastest measured link — e.g. a DGX Spark's 200GbE ConnectX port over its management ethernet. macOS behaviour (Thunderbolt first) is unchanged.

Also fixes a pipeline deadlock: shards of hybrid SSM/attention models (Qwen3-Next, Qwen3.5, Nemotron-H) can restore different KV prefix-cache lengths on different ranks — SSM shards need state snapshots, attention-only shards don't. Ranks then prefill different token counts and hang the ring's send/recv chain on the second request of a conversation. Ranks now gather their hit lengths and discard the hit everywhere when they disagree.

Adds per-token decode communication timing (recv / send / gather) logged at debug level every 64 tokens for future tuning.
## Results
Measured on a heterogeneous 4-node cluster (M3 Ultra Mac Studio 256GB + 2× DGX Spark GB10 + RTX 3090) and smaller mixes:
- Generation TPS: **+10% to +40%** depending on model and cluster composition
- Layer distribution / model load time: **over 2× faster**
- Multi-turn chat on hybrid SSM models no longer deadlocks on heterogeneous splits

## Test plan
- [x] `uv run pytest` — 448 passed, including new two-process distributed ring tests covering token relay (last rank samples, all ranks converge on its token, non-last ranks skip lm_head)
- [x] New unit tests for throughput-based allocation, bandwidth table, and link-speed ring preference
- [x] `uv run basedpyright` and `uv run ruff check` clean
- [x] Soak-tested on the 4-node heterogeneous cluster above (multi-turn chat + exo-bench, Qwen3.5-397B-A17B-8bit and Qwen3-Next-80B)
- [x] Linux/3090, 2x DGX Spark, MacStudio
