### PR TITLE
docs: request the mlx extra in the documented setup commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ To run EXO from source:
 git clone https://github.com/exo-explore/exo.git
 cd exo/dashboard
 npm install && npm run build && cd ..
+uv sync --extra mlx
 uv run exo
 ```
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Then restart the Nix daemon: `sudo launchctl kickstart -k system/org.nixos.nix-d
     --force
   ```
 
-Clone the repo, build the dashboard, and run exo:
+Clone the repo, build the dashboard, install the dependencies, and run exo:
 
 ```bash
 # Clone exo
@@ -126,6 +126,9 @@ git clone https://github.com/exo-explore/exo
 
 # Build dashboard
 cd exo/dashboard && npm install && npm run build && cd ..
+
+# Install Python dependencies, including the MLX backend
+uv sync --extra mlx
 
 # Run exo
 uv run exo
@@ -176,7 +179,7 @@ rustup toolchain install nightly
 
 **Note:** The `macmon` package is macOS-only and not required for Linux.
 
-Clone the repo, build the dashboard, and run exo:
+Clone the repo, build the dashboard, install the dependencies, and run exo:
 
 ```bash
 # Clone exo
@@ -184,6 +187,10 @@ git clone https://github.com/exo-explore/exo
 
 # Build dashboard
 cd exo/dashboard && npm install && npm run build && cd ..
+
+# Install Python dependencies with the MLX backend for your hardware
+# (NVIDIA: --extra mlx-cuda13 or --extra mlx-cuda12)
+uv sync --extra mlx-cpu
 
 # Run exo
 uv run exo

--- a/justfile
+++ b/justfile
@@ -16,10 +16,10 @@ check:
     uv run basedpyright --project pyproject.toml
 
 sync:
-    uv sync --all-packages
+    uv sync --all-packages --extra mlx
 
 sync-clean:
-    uv sync --all-packages --force-reinstall --no-cache
+    uv sync --all-packages --extra mlx --force-reinstall --no-cache
 
 rust-rebuild:
     PYO3_PYTHON="$(uv run python -c 'import sys; print(sys.executable)')" cargo run --bin stub_gen


### PR DESCRIPTION
Since #2087 moved mlx, mlx-lm, mlx-vlm and mflux out of `dependencies` into the `mlx` extra, the documented setup path never installs them, and `[tool.uv]` sets no default extras. `uv run exo` starts the API, then every runner crashes with `ModuleNotFoundError: No module named 'mlx'` (#2156).

Adds the extra to the commands documented as the way to set up:

- README macOS: `uv sync --extra mlx`
- README Linux: `uv sync --extra mlx-cpu`, with the mlx-cuda12 / mlx-cuda13 alternatives
- CONTRIBUTING.md quick start
- `just sync` / `just sync-clean`, which `just build-app` runs before pyinstaller — the spec aborts when the mlx Metal libraries are missing

Docs plus two justfile recipes; no dependency or lock changes. Backend choice stays explicit, since mlx-cpu / mlx-cuda12 / mlx-cuda13 / mlx-none are declared as conflicting extras.

#2234 overlaps on the macOS README block only, via a setup script that runs `uv sync --extra mlx`; the Linux block, CONTRIBUTING.md and the justfile are not covered there.
