### PR TITLE
fix: prefer accelerators in heterogeneous placement

### DIFF
--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -103,6 +103,23 @@ def _cycle_download_score(
     )
 
 
+def _cycle_accelerator_score(
+    cycle: Cycle,
+    node_backends: Mapping[NodeId, list[Backend]],
+    required_backends: set[Backend],
+) -> int:
+    """Count nodes that can run on an accelerator instead of CPU fallback."""
+    accelerator_backends = {Backend.MlxMetal, Backend.MlxCuda}
+    return sum(
+        bool(
+            set(node_backends.get(node_id, []))
+            & required_backends
+            & accelerator_backends
+        )
+        for node_id in cycle
+    )
+
+
 def place_instance(
     command: PlaceInstance,
     topology: Topology,
@@ -232,6 +249,7 @@ def place_instance(
     selected_cycle = max(
         candidate_cycles,
         key=lambda cycle: (
+            _cycle_accelerator_score(cycle, node_backends, required_backends),
             _cycle_download_score(
                 cycle, command.model_card.model_id, resolved_download_status
             ),

--- a/src/exo/master/tests/test_placement.py
+++ b/src/exo/master/tests/test_placement.py
@@ -981,6 +981,48 @@ def test_placement_rejects_when_model_backends_disjoint_from_engine(
         )
 
 
+def test_placement_prefers_accelerator_over_cpu_with_more_memory(
+    model_card: ModelCard,
+):
+    topology = Topology()
+    gpu_node = NodeId()
+    cpu_node = NodeId()
+    topology.add_node(gpu_node)
+    topology.add_node(cpu_node)
+    node_memory = {
+        gpu_node: create_node_memory(1000),
+        cpu_node: create_node_memory(2000),
+    }
+    node_network = {
+        gpu_node: create_node_network(),
+        cpu_node: create_node_network(),
+    }
+    node_backends = {
+        gpu_node: [Backend.MlxCuda],
+        cpu_node: [Backend.MlxCpu],
+    }
+    command = place_instance_command(
+        model_card.model_copy(
+            update={
+                "backends": [Backend.MlxCuda, Backend.MlxCpu],
+                "storage_size": Memory.from_bytes(500),
+            }
+        )
+    )
+
+    placements = place_instance(
+        command,
+        topology,
+        {},
+        node_memory,
+        node_network,
+        node_backends,
+    )
+
+    instance = next(iter(placements.values()))
+    assert set(instance.shard_assignments.node_to_runner) == {gpu_node}
+
+
 def test_placement_rejects_when_only_some_nodes_support_backend(
     model_card: ModelCard,
 ):


### PR DESCRIPTION
## Motivation

Backend compatibility alone can leave a CPU-only singleton tied with an accelerator singleton. The existing free-memory tiebreaker can then assign the full model to the CPU while CUDA sits idle.

## Changes

- score valid candidate cycles by accelerator-backed nodes
- rank Metal/CUDA capability ahead of download locality and free-memory tiebreakers
- preserve existing smallest-cycle, required-node, backend, and RDMA filtering
- add a regression test where a lower-memory CUDA node beats a higher-memory CPU node

## Testing

- `uv run pytest src/exo/master/tests/test_placement.py -k "accelerator or backend"`
- `uv run basedpyright src/exo/master/placement.py src/exo/master/tests/test_placement.py`
- `uv run ruff check src/exo/master/placement.py src/exo/master/tests/test_placement.py`

Fixes #2180

---
*Refiled from #2213, which was closed unintentionally.*