### PR TITLE
feat: support manual pipeline layer allocation

### DIFF
--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -432,6 +432,7 @@ class API:
             sharding=payload.sharding,
             instance_meta=payload.instance_meta,
             min_nodes=payload.min_nodes,
+            node_layers=payload.node_layers,
         )
         await self._send(command)
 

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -271,6 +271,7 @@ class PlaceInstanceParams(BaseModel):
     sharding: Sharding = Sharding.Pipeline
     instance_meta: InstanceMeta = InstanceMeta.MlxRing
     min_nodes: int = 1
+    node_layers: dict[NodeId, int] | None = None
 
 
 class CreateInstanceParams(BaseModel):

--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -122,7 +122,9 @@ def place_instance(
             raise ValueError("Manual layer allocation requires Pipeline sharding")
         requested_nodes = set(command.node_layers)
         candidate_cycles = [
-            cycle for cycle in candidate_cycles if set(cycle.node_ids) == requested_nodes
+            cycle
+            for cycle in candidate_cycles
+            if set(cycle.node_ids) == requested_nodes
         ]
         if not candidate_cycles:
             raise ValueError(

--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -117,6 +117,18 @@ def place_instance(
     cycles = topology.get_cycles()
     candidate_cycles = list(filter(lambda it: len(it) >= command.min_nodes, cycles))
 
+    if command.node_layers is not None:
+        if command.sharding != Sharding.Pipeline:
+            raise ValueError("Manual layer allocation requires Pipeline sharding")
+        requested_nodes = set(command.node_layers)
+        candidate_cycles = [
+            cycle for cycle in candidate_cycles if set(cycle.node_ids) == requested_nodes
+        ]
+        if not candidate_cycles:
+            raise ValueError(
+                "No connected cycle exactly matches the manual layer allocation nodes"
+            )
+
     # Filter to cycles containing all required nodes (subset matching)
     if required_nodes:
         candidate_cycles = [
@@ -252,7 +264,11 @@ def place_instance(
         )
 
     shard_assignments = get_shard_assignments(
-        command.model_card, selected_cycle, command.sharding, node_memory
+        command.model_card,
+        selected_cycle,
+        command.sharding,
+        node_memory,
+        command.node_layers,
     )
 
     cycle_digraph: Topology = topology.get_subgraph_from_nodes(selected_cycle.node_ids)

--- a/src/exo/master/placement_utils.py
+++ b/src/exo/master/placement_utils.py
@@ -122,19 +122,60 @@ def _allocate_and_validate_layers(
     return layer_allocations
 
 
+def _validate_manual_layer_allocations(
+    node_ids: list[NodeId],
+    node_memory: Mapping[NodeId, MemoryUsage],
+    model_card: ModelCard,
+    node_layers: Mapping[NodeId, int],
+) -> list[int]:
+    if set(node_layers) != set(node_ids):
+        raise ValueError(
+            "Manual layer allocation must specify exactly the selected pipeline nodes"
+        )
+    if any(layer_count < 1 for layer_count in node_layers.values()):
+        raise ValueError("Manual layer allocations must assign at least one layer per node")
+    if sum(node_layers.values()) != model_card.n_layers:
+        raise ValueError(
+            f"Manual layer allocations must sum to {model_card.n_layers} layers"
+        )
+
+    allocations = [node_layers[node_id] for node_id in node_ids]
+    for index, (node_id, layer_count) in enumerate(
+        zip(node_ids, allocations, strict=True)
+    ):
+        required_memory = (
+            model_card.storage_size * layer_count
+        ) // model_card.n_layers
+        available_memory = node_memory[node_id].ram_available
+        if required_memory > available_memory:
+            raise ValueError(
+                f"Node {index} ({node_id}) has insufficient memory: "
+                f"requires {required_memory.in_gb:.2f} GB for {layer_count} layers, "
+                f"but only has {available_memory.in_gb:.2f} GB available"
+            )
+    return allocations
+
+
 def get_shard_assignments_for_pipeline_parallel(
     model_card: ModelCard,
     cycle: Cycle,
     node_memory: Mapping[NodeId, MemoryUsage],
+    node_layers: Mapping[NodeId, int] | None = None,
 ) -> ShardAssignments:
     """Create shard assignments for pipeline parallel execution."""
     world_size = len(cycle)
     use_cfg_parallel = model_card.uses_cfg and world_size >= 2 and world_size % 2 == 0
 
     if use_cfg_parallel:
+        if node_layers is not None:
+            raise ValueError(
+                "Manual layer allocation is not supported for CFG-parallel models"
+            )
         return _get_shard_assignments_for_cfg_parallel(model_card, cycle, node_memory)
     else:
-        return _get_shard_assignments_for_pure_pipeline(model_card, cycle, node_memory)
+        return _get_shard_assignments_for_pure_pipeline(
+            model_card, cycle, node_memory, node_layers
+        )
 
 
 def _get_shard_assignments_for_cfg_parallel(
@@ -204,13 +245,20 @@ def _get_shard_assignments_for_pure_pipeline(
     model_card: ModelCard,
     cycle: Cycle,
     node_memory: Mapping[NodeId, MemoryUsage],
+    node_layers: Mapping[NodeId, int] | None = None,
 ) -> ShardAssignments:
     """Create shard assignments for pure pipeline execution."""
     _validate_cycle(cycle)
     total_memory = _compute_total_memory(cycle.node_ids, node_memory)
 
-    layer_allocations = _allocate_and_validate_layers(
-        cycle.node_ids, node_memory, total_memory, model_card
+    layer_allocations = (
+        _allocate_and_validate_layers(
+            cycle.node_ids, node_memory, total_memory, model_card
+        )
+        if node_layers is None
+        else _validate_manual_layer_allocations(
+            cycle.node_ids, node_memory, model_card, node_layers
+        )
     )
 
     runner_to_shard: dict[RunnerId, ShardMetadata] = {}
@@ -218,14 +266,14 @@ def _get_shard_assignments_for_pure_pipeline(
 
     for pipeline_rank, node_id in enumerate(cycle.node_ids):
         layers_before = sum(layer_allocations[:pipeline_rank])
-        node_layers = layer_allocations[pipeline_rank]
+        layer_count = layer_allocations[pipeline_rank]
 
         shard = PipelineShardMetadata(
             model_card=model_card,
             device_rank=pipeline_rank,
             world_size=len(cycle),
             start_layer=layers_before,
-            end_layer=layers_before + node_layers,
+            end_layer=layers_before + layer_count,
             n_layers=model_card.n_layers,
         )
 
@@ -278,6 +326,7 @@ def get_shard_assignments(
     cycle: Cycle,
     sharding: Sharding,
     node_memory: Mapping[NodeId, MemoryUsage],
+    node_layers: Mapping[NodeId, int] | None = None,
 ) -> ShardAssignments:
     match sharding:
         case Sharding.Pipeline:
@@ -285,6 +334,7 @@ def get_shard_assignments(
                 model_card=model_card,
                 cycle=cycle,
                 node_memory=node_memory,
+                node_layers=node_layers,
             )
         case Sharding.Tensor:
             return get_shard_assignments_for_tensor_parallel(

--- a/src/exo/master/placement_utils.py
+++ b/src/exo/master/placement_utils.py
@@ -133,7 +133,9 @@ def _validate_manual_layer_allocations(
             "Manual layer allocation must specify exactly the selected pipeline nodes"
         )
     if any(layer_count < 1 for layer_count in node_layers.values()):
-        raise ValueError("Manual layer allocations must assign at least one layer per node")
+        raise ValueError(
+            "Manual layer allocations must assign at least one layer per node"
+        )
     if sum(node_layers.values()) != model_card.n_layers:
         raise ValueError(
             f"Manual layer allocations must sum to {model_card.n_layers} layers"
@@ -143,9 +145,7 @@ def _validate_manual_layer_allocations(
     for index, (node_id, layer_count) in enumerate(
         zip(node_ids, allocations, strict=True)
     ):
-        required_memory = (
-            model_card.storage_size * layer_count
-        ) // model_card.n_layers
+        required_memory = (model_card.storage_size * layer_count) // model_card.n_layers
         available_memory = node_memory[node_id].ram_available
         if required_memory > available_memory:
             raise ValueError(

--- a/src/exo/master/tests/test_placement.py
+++ b/src/exo/master/tests/test_placement.py
@@ -193,6 +193,55 @@ def test_get_instance_placements_create_instance(
     assert shards_sorted[-1].end_layer == total_layers
 
 
+def test_pipeline_placement_uses_manual_per_node_layer_allocation(
+    model_card: ModelCard,
+) -> None:
+    node_a = NodeId()
+    node_b = NodeId()
+    topology = Topology()
+    topology.add_node(node_a)
+    topology.add_node(node_b)
+    topology.add_connection(
+        Connection(source=node_a, sink=node_b, edge=create_socket_connection(1))
+    )
+    topology.add_connection(
+        Connection(source=node_b, sink=node_a, edge=create_socket_connection(2))
+    )
+    node_memory = {
+        node_a: create_node_memory(300),
+        node_b: create_node_memory(900),
+    }
+    node_network = {
+        node_a: create_node_network(),
+        node_b: create_node_network(),
+    }
+    command = place_instance_command(
+        model_card.model_copy(update={"storage_size": Memory.from_bytes(1000)})
+    ).model_copy(
+        update={
+            "min_nodes": 2,
+            "node_layers": {node_a: 2, node_b: 8},
+        }
+    )
+
+    placements = place_instance(
+        command,
+        topology,
+        {},
+        node_memory,
+        node_network,
+        _metal_only(node_memory),
+    )
+
+    instance = next(iter(placements.values()))
+    runner_a = instance.shard_assignments.node_to_runner[node_a]
+    runner_b = instance.shard_assignments.node_to_runner[node_b]
+    shard_a = instance.shard_assignments.runner_to_shard[runner_a]
+    shard_b = instance.shard_assignments.runner_to_shard[runner_b]
+    assert shard_a.end_layer - shard_a.start_layer == 2
+    assert shard_b.end_layer - shard_b.start_layer == 8
+
+
 def test_get_instance_placements_one_node_exact_fit() -> None:
     topology = Topology()
     node_id = NodeId()

--- a/src/exo/master/tests/test_placement.py
+++ b/src/exo/master/tests/test_placement.py
@@ -193,9 +193,7 @@ def test_get_instance_placements_create_instance(
     assert shards_sorted[-1].end_layer == total_layers
 
 
-def test_pipeline_placement_uses_manual_per_node_layer_allocation(
-    model_card: ModelCard,
-) -> None:
+def _create_two_node_ring() -> tuple[Topology, NodeId, NodeId]:
     node_a = NodeId()
     node_b = NodeId()
     topology = Topology()
@@ -207,6 +205,13 @@ def test_pipeline_placement_uses_manual_per_node_layer_allocation(
     topology.add_connection(
         Connection(source=node_b, sink=node_a, edge=create_socket_connection(2))
     )
+    return topology, node_a, node_b
+
+
+def test_pipeline_placement_uses_manual_per_node_layer_allocation(
+    model_card: ModelCard,
+) -> None:
+    topology, node_a, node_b = _create_two_node_ring()
     node_memory = {
         node_a: create_node_memory(300),
         node_b: create_node_memory(900),
@@ -240,6 +245,120 @@ def test_pipeline_placement_uses_manual_per_node_layer_allocation(
     shard_b = instance.shard_assignments.runner_to_shard[runner_b]
     assert shard_a.end_layer - shard_a.start_layer == 2
     assert shard_b.end_layer - shard_b.start_layer == 8
+
+
+def test_manual_layer_allocation_rejects_non_pipeline_sharding(
+    model_card: ModelCard,
+) -> None:
+    topology, node_a, node_b = _create_two_node_ring()
+    node_memory = {
+        node_a: create_node_memory(500),
+        node_b: create_node_memory(500),
+    }
+    node_network = {
+        node_a: create_node_network(),
+        node_b: create_node_network(),
+    }
+    command = place_instance_command(
+        model_card.model_copy(update={"storage_size": Memory.from_bytes(1000)})
+    ).model_copy(
+        update={
+            "sharding": Sharding.Tensor,
+            "node_layers": {node_a: 5, node_b: 5},
+        }
+    )
+
+    with pytest.raises(ValueError, match="requires Pipeline sharding"):
+        place_instance(
+            command,
+            topology,
+            {},
+            node_memory,
+            node_network,
+            _metal_only(node_memory),
+        )
+
+
+def test_manual_layer_allocation_requires_matching_cycle(
+    model_card: ModelCard,
+) -> None:
+    topology, node_a, node_b = _create_two_node_ring()
+    node_memory = {
+        node_a: create_node_memory(500),
+        node_b: create_node_memory(500),
+    }
+    node_network = {
+        node_a: create_node_network(),
+        node_b: create_node_network(),
+    }
+    unknown_node = NodeId()
+    command = place_instance_command(
+        model_card.model_copy(update={"storage_size": Memory.from_bytes(1000)})
+    ).model_copy(update={"node_layers": {node_a: 5, unknown_node: 5}})
+
+    with pytest.raises(ValueError, match="No connected cycle exactly matches"):
+        place_instance(
+            command,
+            topology,
+            {},
+            node_memory,
+            node_network,
+            _metal_only(node_memory),
+        )
+
+
+def test_manual_layer_allocation_rejects_wrong_layer_sum(
+    model_card: ModelCard,
+) -> None:
+    topology, node_a, node_b = _create_two_node_ring()
+    node_memory = {
+        node_a: create_node_memory(500),
+        node_b: create_node_memory(500),
+    }
+    node_network = {
+        node_a: create_node_network(),
+        node_b: create_node_network(),
+    }
+    command = place_instance_command(
+        model_card.model_copy(update={"storage_size": Memory.from_bytes(1000)})
+    ).model_copy(update={"node_layers": {node_a: 3, node_b: 4}})
+
+    with pytest.raises(ValueError, match="must sum to 10 layers"):
+        place_instance(
+            command,
+            topology,
+            {},
+            node_memory,
+            node_network,
+            _metal_only(node_memory),
+        )
+
+
+def test_manual_layer_allocation_rejects_insufficient_memory(
+    model_card: ModelCard,
+) -> None:
+    topology, node_a, node_b = _create_two_node_ring()
+    node_memory = {
+        node_a: create_node_memory(300),
+        node_b: create_node_memory(900),
+    }
+    node_network = {
+        node_a: create_node_network(),
+        node_b: create_node_network(),
+    }
+    command = place_instance_command(
+        model_card.model_copy(update={"storage_size": Memory.from_bytes(1000)})
+    ).model_copy(update={"node_layers": {node_a: 8, node_b: 2}})
+
+    with pytest.raises(ValueError, match="insufficient memory"):
+        place_instance(
+            command,
+            topology,
+            {},
+            node_memory,
+            node_network,
+            _metal_only(node_memory),
+        )
 
 
 def test_get_instance_placements_one_node_exact_fit() -> None:

--- a/src/exo/shared/types/commands.py
+++ b/src/exo/shared/types/commands.py
@@ -39,6 +39,7 @@ class PlaceInstance(BaseCommand):
     sharding: Sharding
     instance_meta: InstanceMeta
     min_nodes: int
+    node_layers: dict[NodeId, int] | None = None
 
 
 class CreateInstance(BaseCommand):


### PR DESCRIPTION
## Motivation

Memory-proportional automatic allocation cannot express deliberate asymmetric load, such as assigning only a few layers to a laptop while a dedicated larger machine carries the rest.

## Changes

- add optional `node_layers` to the placement API and `PlaceInstance` command
- require the supplied nodes to exactly match a connected pipeline cycle
- validate positive counts, exact model-layer totals, and per-node memory capacity
- reject manual allocation for tensor and CFG-parallel modes where layer counts do not map one-to-one to physical nodes
- generate pipeline shard boundaries from the requested per-node counts
- preserve automatic proportional placement when `node_layers` is omitted

Example request field:

```json
{
  "node_layers": {
    "small-node-id": 2,
    "large-node-id": 38
  }
}
```

## Testing

- `uv run pytest src/exo/master/tests/test_placement.py src/exo/master/tests/test_placement_utils.py src/exo/api/tests -m "not slow"` (94 passed)
- repository-wide `uv run basedpyright`
- repository-wide `uv run ruff check`

Fixes #1720

---
*Refiled from #2214, which was closed unintentionally.*