### PR TITLE
feat: measure link latency and prefer low-latency paths for ring hosts

### DIFF
--- a/src/exo/master/placement_utils.py
+++ b/src/exo/master/placement_utils.py
@@ -329,11 +329,11 @@ def _find_connection_ip(
     node_i: NodeId,
     node_j: NodeId,
     cycle_digraph: Topology,
-) -> Generator[str, None, None]:
-    """Find all IP addresses that connect node i to node j."""
+) -> Generator[SocketConnection, None, None]:
+    """Find all socket connections from node i to node j."""
     for connection in cycle_digraph.get_all_connections_between(node_i, node_j):
         if isinstance(connection, SocketConnection):
-            yield connection.sink_multiaddr.ip_address
+            yield connection
 
 
 def find_ip_prioritised(
@@ -345,18 +345,29 @@ def find_ip_prioritised(
 ) -> str | None:
     """Find an IP address between nodes with prioritization.
 
-    Priority: ethernet > wifi > unknown > thunderbolt
+    Ring connections prefer the lowest measured probe latency, falling back to
+    interface type (thunderbolt first) when latency is unmeasured. RDMA
+    coordinator selection prefers ethernet.
     """
-    ips = list(_find_connection_ip(node_id, other_node_id, cycle_digraph))
-    if not ips:
+    connections = list(_find_connection_ip(node_id, other_node_id, cycle_digraph))
+    if not connections:
         return None
+    latency_by_ip: dict[str, float] = {}
+    for connection in connections:
+        ip_address = connection.sink_multiaddr.ip_address
+        if connection.latency_ms is None:
+            continue
+        known = latency_by_ip.get(ip_address)
+        if known is None or connection.latency_ms < known:
+            latency_by_ip[ip_address] = connection.latency_ms
+
     other_network = node_network.get(other_node_id, NodeNetworkInfo())
     ip_to_type = {
         iface.ip_address: iface.interface_type for iface in other_network.interfaces
     }
 
-    # Ring should prioritise fastest connection. As a best-effort, we prioritise TB.
-    # TODO: Profile and get actual connection speeds.
+    # Ring should prioritise the fastest connection: measured latency first,
+    # then interface type as a tie-break / fallback for unmeasured links.
     if ring:
         priority = {
             "thunderbolt": 0,
@@ -365,17 +376,26 @@ def find_ip_prioritised(
             "wifi": 3,
             "unknown": 4,
         }
+        return min(
+            {connection.sink_multiaddr.ip_address for connection in connections},
+            key=lambda ip: (
+                latency_by_ip.get(ip, float("inf")),
+                priority.get(ip_to_type.get(ip, "unknown"), 2),
+            ),
+        )
 
     # RDMA prefers ethernet coordinator
-    else:
-        priority = {
-            "ethernet": 0,
-            "wifi": 1,
-            "unknown": 2,
-            "maybe_ethernet": 3,
-            "thunderbolt": 4,
-        }
-    return min(ips, key=lambda ip: priority.get(ip_to_type.get(ip, "unknown"), 2))
+    priority = {
+        "ethernet": 0,
+        "wifi": 1,
+        "unknown": 2,
+        "maybe_ethernet": 3,
+        "thunderbolt": 4,
+    }
+    return min(
+        {connection.sink_multiaddr.ip_address for connection in connections},
+        key=lambda ip: priority.get(ip_to_type.get(ip, "unknown"), 2),
+    )
 
 
 def get_mlx_ring_hosts_by_node(

--- a/src/exo/master/placement_utils.py
+++ b/src/exo/master/placement_utils.py
@@ -329,11 +329,11 @@ def _find_connection_ip(
     node_i: NodeId,
     node_j: NodeId,
     cycle_digraph: Topology,
-) -> Generator[str, None, None]:
-    """Find all IP addresses that connect node i to node j."""
+) -> Generator[SocketConnection, None, None]:
+    """Find all socket connections from node i to node j."""
     for connection in cycle_digraph.get_all_connections_between(node_i, node_j):
         if isinstance(connection, SocketConnection):
-            yield connection.sink_multiaddr.ip_address
+            yield connection
 
 
 def find_ip_prioritised(
@@ -345,18 +345,37 @@ def find_ip_prioritised(
 ) -> str | None:
     """Find an IP address between nodes with prioritization.
 
-    Priority: ethernet > wifi > unknown > thunderbolt
+    Ring connections prefer the lowest measured probe latency, falling back to
+    interface type (thunderbolt first) when latency is unmeasured. RDMA
+    coordinator selection prefers ethernet.
     """
-    ips = list(_find_connection_ip(node_id, other_node_id, cycle_digraph))
-    if not ips:
+    connections = list(_find_connection_ip(node_id, other_node_id, cycle_digraph))
+    if not connections:
         return None
+    # Deduplicate in first-seen order: `min` breaks ties on iteration order, and
+    # unmeasured links all tie at infinity, so a set here would make the choice
+    # vary with hash seed between master restarts.
+    candidate_ips = list(
+        dict.fromkeys(
+            connection.sink_multiaddr.ip_address for connection in connections
+        )
+    )
+    latency_by_ip: dict[str, float] = {}
+    for connection in connections:
+        ip_address = connection.sink_multiaddr.ip_address
+        if connection.latency_ms is None:
+            continue
+        known = latency_by_ip.get(ip_address)
+        if known is None or connection.latency_ms < known:
+            latency_by_ip[ip_address] = connection.latency_ms
+
     other_network = node_network.get(other_node_id, NodeNetworkInfo())
     ip_to_type = {
         iface.ip_address: iface.interface_type for iface in other_network.interfaces
     }
 
-    # Ring should prioritise fastest connection. As a best-effort, we prioritise TB.
-    # TODO: Profile and get actual connection speeds.
+    # Ring should prioritise the fastest connection: measured latency first,
+    # then interface type as a tie-break / fallback for unmeasured links.
     if ring:
         priority = {
             "thunderbolt": 0,
@@ -365,17 +384,26 @@ def find_ip_prioritised(
             "wifi": 3,
             "unknown": 4,
         }
+        return min(
+            candidate_ips,
+            key=lambda ip: (
+                latency_by_ip.get(ip, float("inf")),
+                priority.get(ip_to_type.get(ip, "unknown"), 2),
+            ),
+        )
 
     # RDMA prefers ethernet coordinator
-    else:
-        priority = {
-            "ethernet": 0,
-            "wifi": 1,
-            "unknown": 2,
-            "maybe_ethernet": 3,
-            "thunderbolt": 4,
-        }
-    return min(ips, key=lambda ip: priority.get(ip_to_type.get(ip, "unknown"), 2))
+    priority = {
+        "ethernet": 0,
+        "wifi": 1,
+        "unknown": 2,
+        "maybe_ethernet": 3,
+        "thunderbolt": 4,
+    }
+    return min(
+        candidate_ips,
+        key=lambda ip: priority.get(ip_to_type.get(ip, "unknown"), 2),
+    )
 
 
 def get_mlx_ring_hosts_by_node(

--- a/src/exo/master/tests/test_placement_utils.py
+++ b/src/exo/master/tests/test_placement_utils.py
@@ -3,6 +3,7 @@ import pytest
 from exo.master.placement_utils import (
     allocate_layers_proportionally,
     filter_cycles_by_memory,
+    find_ip_prioritised,
     get_mlx_jaccl_coordinators,
     get_shard_assignments,
     get_shard_assignments_for_pipeline_parallel,
@@ -17,6 +18,7 @@ from exo.shared.topology import Topology
 from exo.shared.types.backends import Backend
 from exo.shared.types.common import NodeId
 from exo.shared.types.memory import Memory
+from exo.shared.types.multiaddr import Multiaddr
 from exo.shared.types.profiling import (
     NetworkInterfaceInfo,
     NodeNetworkInfo,
@@ -689,3 +691,135 @@ class TestCfgParallelPlacement:
         # First shard starts at 0, last shard ends at 57
         assert layer_ranges[0][0] == 0
         assert layer_ranges[-1][1] == 57
+
+
+def _socket_edge(ip_address: str, latency_ms: float | None = None) -> SocketConnection:
+    return SocketConnection(
+        sink_multiaddr=Multiaddr(address=f"/ip4/{ip_address}/tcp/1234"),
+        latency_ms=latency_ms,
+    )
+
+
+def _two_node_topology_with_edges(
+    node_a: NodeId, node_b: NodeId, edges: list[SocketConnection]
+) -> Topology:
+    topology = Topology()
+    topology.add_node(node_a)
+    topology.add_node(node_b)
+    for edge in edges:
+        topology.add_connection(Connection(source=node_a, sink=node_b, edge=edge))
+    return topology
+
+
+def test_find_ip_prioritised_ring_prefers_measured_low_latency():
+    """A link with low measured latency wins even over a thunderbolt-labelled one."""
+    node_a = NodeId()
+    node_b = NodeId()
+    topology = _two_node_topology_with_edges(
+        node_a,
+        node_b,
+        [
+            _socket_edge("100.64.0.2", latency_ms=55.0),
+            _socket_edge("192.168.4.2", latency_ms=0.8),
+        ],
+    )
+    node_network = {
+        node_b: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="utun3", ip_address="100.64.0.2", interface_type="unknown"
+                ),
+                NetworkInterfaceInfo(
+                    name="bridge0",
+                    ip_address="192.168.4.2",
+                    interface_type="thunderbolt",
+                ),
+            ]
+        )
+    }
+
+    ip = find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+
+    assert ip == "192.168.4.2"
+
+
+def test_find_ip_prioritised_ring_latency_beats_interface_label():
+    """Measured latency outranks the interface-type heuristic entirely."""
+    node_a = NodeId()
+    node_b = NodeId()
+    topology = _two_node_topology_with_edges(
+        node_a,
+        node_b,
+        [
+            _socket_edge("192.168.4.2", latency_ms=55.0),
+            _socket_edge("10.0.0.2", latency_ms=1.2),
+        ],
+    )
+    node_network = {
+        node_b: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="bridge0",
+                    ip_address="192.168.4.2",
+                    interface_type="thunderbolt",
+                ),
+                NetworkInterfaceInfo(
+                    name="en0", ip_address="10.0.0.2", interface_type="wifi"
+                ),
+            ]
+        )
+    }
+
+    ip = find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+
+    assert ip == "10.0.0.2"
+
+
+def test_find_ip_prioritised_ring_falls_back_to_interface_type():
+    """Without measurements, thunderbolt-labelled links keep their priority."""
+    node_a = NodeId()
+    node_b = NodeId()
+    topology = _two_node_topology_with_edges(
+        node_a,
+        node_b,
+        [
+            _socket_edge("10.0.0.2"),
+            _socket_edge("192.168.4.2"),
+        ],
+    )
+    node_network = {
+        node_b: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="en0", ip_address="10.0.0.2", interface_type="wifi"
+                ),
+                NetworkInterfaceInfo(
+                    name="bridge0",
+                    ip_address="192.168.4.2",
+                    interface_type="thunderbolt",
+                ),
+            ]
+        )
+    }
+
+    ip = find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+
+    assert ip == "192.168.4.2"
+
+
+def test_find_ip_prioritised_measured_link_beats_unmeasured():
+    node_a = NodeId()
+    node_b = NodeId()
+    topology = _two_node_topology_with_edges(
+        node_a,
+        node_b,
+        [
+            _socket_edge("10.0.0.2", latency_ms=40.0),
+            _socket_edge("192.168.4.2"),
+        ],
+    )
+    node_network = {node_b: NodeNetworkInfo()}
+
+    ip = find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+
+    assert ip == "10.0.0.2"

--- a/src/exo/shared/types/topology.py
+++ b/src/exo/shared/types/topology.py
@@ -24,6 +24,17 @@ class RDMAConnection(FrozenModel):
 
 class SocketConnection(FrozenModel):
     sink_multiaddr: Multiaddr
+    # Most recent reachability-probe round-trip time. Excluded from identity so
+    # jitter does not make otherwise-identical edges unequal.
+    latency_ms: float | None = None
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SocketConnection):
+            return NotImplemented
+        return (
+            self.sink_multiaddr.ip_address == other.sink_multiaddr.ip_address
+            and self.sink_multiaddr.port == other.sink_multiaddr.port
+        )
 
     def __hash__(self):
         return hash(self.sink_multiaddr.ip_address)

--- a/src/exo/utils/info_gatherer/net_profile.py
+++ b/src/exo/utils/info_gatherer/net_profile.py
@@ -1,3 +1,4 @@
+import time
 from collections import defaultdict
 from collections.abc import AsyncGenerator, Mapping
 
@@ -13,6 +14,26 @@ from exo.utils.channels import Sender, channel
 
 REACHABILITY_ATTEMPTS = 3
 
+# Thresholds below which a latency change is treated as measurement noise
+LATENCY_NOISE_FLOOR_MS = 2.0
+LATENCY_CHANGE_FACTOR = 2.0
+
+
+def latency_changed_materially(old_ms: float | None, new_ms: float) -> bool:
+    """Whether a new latency measurement differs enough to be worth republishing.
+
+    Requires both an absolute change above the noise floor and a factor-of-two
+    change, so probe jitter on fast links never churns the topology.
+    """
+    if old_ms is None:
+        return True
+    if abs(new_ms - old_ms) <= LATENCY_NOISE_FLOOR_MS:
+        return False
+    return (
+        new_ms < old_ms / LATENCY_CHANGE_FACTOR
+        or new_ms > old_ms * LATENCY_CHANGE_FACTOR
+    )
+
 
 async def check_reachability(
     target_ip: str,
@@ -20,8 +41,12 @@ async def check_reachability(
     out: dict[NodeId, set[str]],
     client: httpx.AsyncClient,
     api_port: int,
-) -> None:
-    """Check if a node is reachable at the given IP and verify its identity."""
+) -> float | None:
+    """Check if a node is reachable at the given IP and verify its identity.
+
+    Returns the round-trip time of the successful probe in milliseconds, or
+    None if the node was not reachable at this IP.
+    """
     if ":" in target_ip:
         # TODO: use real IpAddress types
         url = f"http://[{target_ip}]:{api_port}/node_id"
@@ -30,10 +55,13 @@ async def check_reachability(
 
     remote_node_id = None
     last_error = None
+    latency_ms = None
 
     for _ in range(REACHABILITY_ATTEMPTS):
         try:
+            probe_start = time.perf_counter()
             r = await client.get(url)
+            probe_elapsed_ms = (time.perf_counter() - probe_start) * 1000
             if r.status_code != 200:
                 await anyio.sleep(1)
                 continue
@@ -44,6 +72,7 @@ async def check_reachability(
                 continue
 
             remote_node_id = NodeId(body)
+            latency_ms = probe_elapsed_ms
             break
 
         # expected failure cases
@@ -64,7 +93,7 @@ async def check_reachability(
         )
 
     if remote_node_id is None:
-        return
+        return None
 
     if remote_node_id != expected_node_id:
         logger.debug(
@@ -72,11 +101,12 @@ async def check_reachability(
             f"ip={target_ip}, expected_node_id={expected_node_id}, "
             f"remote_node_id={remote_node_id}"
         )
-        return
+        return None
 
     if remote_node_id not in out:
         out[remote_node_id] = set()
     out[remote_node_id].add(target_ip)
+    return latency_ms
 
 
 async def check_reachable(
@@ -84,10 +114,10 @@ async def check_reachable(
     self_node_id: NodeId,
     node_network: Mapping[NodeId, NodeNetworkInfo],
     api_port: int,
-) -> AsyncGenerator[tuple[str, NodeId], None]:
-    """Yield (ip, node_id) pairs as reachability probes complete."""
+) -> AsyncGenerator[tuple[str, NodeId, float], None]:
+    """Yield (ip, node_id, latency_ms) tuples as reachability probes complete."""
 
-    send, recv = channel[tuple[str, NodeId]]()
+    send, recv = channel[tuple[str, NodeId, float]]()
 
     # these are intentionally httpx's defaults so we can tune them later
     timeout = httpx.Timeout(timeout=5.0)
@@ -101,13 +131,15 @@ async def check_reachable(
         target_ip: str,
         expected_node_id: NodeId,
         client: httpx.AsyncClient,
-        send: Sender[tuple[str, NodeId]],
+        send: Sender[tuple[str, NodeId, float]],
     ) -> None:
         async with send:
             out: defaultdict[NodeId, set[str]] = defaultdict(set)
-            await check_reachability(target_ip, expected_node_id, out, client, api_port)
-            if expected_node_id in out:
-                await send.send((target_ip, expected_node_id))
+            latency_ms = await check_reachability(
+                target_ip, expected_node_id, out, client, api_port
+            )
+            if expected_node_id in out and latency_ms is not None:
+                await send.send((target_ip, expected_node_id, latency_ms))
 
     async with (
         httpx.AsyncClient(timeout=timeout, limits=limits, verify=False) as client,

--- a/src/exo/utils/info_gatherer/tests/test_net_profile.py
+++ b/src/exo/utils/info_gatherer/tests/test_net_profile.py
@@ -1,0 +1,22 @@
+from exo.utils.info_gatherer.net_profile import latency_changed_materially
+
+
+def test_first_measurement_is_material():
+    assert latency_changed_materially(None, 0.5)
+
+
+def test_small_absolute_jitter_is_ignored():
+    # sub-noise-floor changes never republish, even when the factor is large
+    assert not latency_changed_materially(0.4, 1.9)
+    assert not latency_changed_materially(1.9, 0.4)
+
+
+def test_small_relative_change_is_ignored():
+    assert not latency_changed_materially(40.0, 55.0)
+    assert not latency_changed_materially(55.0, 40.0)
+
+
+def test_large_change_is_material():
+    # e.g. traffic silently rerouted from thunderbolt to a WAN path
+    assert latency_changed_materially(0.8, 45.0)
+    assert latency_changed_materially(45.0, 0.8)

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -55,7 +55,10 @@ from exo.shared.types.worker.instances import InstanceId
 from exo.shared.types.worker.runners import RunnerId
 from exo.utils.channels import Receiver, Sender, channel
 from exo.utils.info_gatherer.info_gatherer import GatheredInfo, InfoGatherer
-from exo.utils.info_gatherer.net_profile import check_reachable
+from exo.utils.info_gatherer.net_profile import (
+    check_reachable,
+    latency_changed_materially,
+)
 from exo.utils.keyed_backoff import KeyedBackoff
 from exo.utils.task_group import TaskGroup
 from exo.worker.plan import plan
@@ -388,11 +391,13 @@ class Worker:
 
     async def _poll_connection_updates(self):
         while True:
-            edges = set(
-                conn.edge for conn in self.state.topology.out_edges(self.node_id)
-            )
+            existing_edges: dict[SocketConnection, Connection] = {
+                conn.edge: conn
+                for conn in self.state.topology.out_edges(self.node_id)
+                if isinstance(conn.edge, SocketConnection)
+            }
             conns: defaultdict[NodeId, set[str]] = defaultdict(set)
-            async for ip, nid in check_reachable(
+            async for ip, nid, latency_ms in check_reachable(
                 self.state.topology,
                 self.node_id,
                 self.state.node_network,
@@ -407,9 +412,23 @@ class Worker:
                     if "." in ip
                     # nonsense multiaddr
                     else Multiaddr(address=f"/ip6/{ip}/tcp/{self.api_port}"),
+                    latency_ms=latency_ms,
                 )
-                if edge not in edges:
+                old_conn = existing_edges.get(edge)
+                if old_conn is None:
                     logger.debug(f"ping discovered {edge=}")
+                    await self.event_sender.send(
+                        TopologyEdgeCreated(
+                            conn=Connection(source=self.node_id, sink=nid, edge=edge)
+                        )
+                    )
+                elif isinstance(
+                    old_conn.edge, SocketConnection
+                ) and latency_changed_materially(old_conn.edge.latency_ms, latency_ms):
+                    logger.debug(
+                        f"latency changed {old_conn.edge.latency_ms}ms -> {latency_ms}ms for {edge=}"
+                    )
+                    await self.event_sender.send(TopologyEdgeDeleted(conn=old_conn))
                     await self.event_sender.send(
                         TopologyEdgeCreated(
                             conn=Connection(source=self.node_id, sink=nid, edge=edge)


### PR DESCRIPTION
Addresses the link-preference half of #1723 (P2P mesh falling back to a slow path after crash/restart).

## Problem

MLX ring host selection (`find_ip_prioritised`) chooses between candidate IPs purely by interface-type label, with a `TODO: Profile and get actual connection speeds`. After the crash/restart scenario in #1723, inference traffic can land on a 40–70 ms path (Tailscale/WAN) even when a sub-millisecond Thunderbolt link is available — the label heuristic has no way to notice, and VPN interfaces classify as `unknown`.

## Changes

- **Measure RTT in the existing probe.** `check_reachability` already makes an HTTP request to each peer interface every 10s; it now records the round-trip time of the successful request instead of discarding it.
- **Carry latency on topology edges.** `SocketConnection` gains `latency_ms`. Identity is explicitly IP+port (matching the existing IP-based `__hash__`), so measurement jitter does not make otherwise-identical edges unequal. The worker republishes an edge (delete + create) only when latency changes materially — both >2 ms absolute and a factor-of-two — so fast-link jitter never churns the topology.
- **Prefer measured latency for ring hosts.** `find_ip_prioritised(ring=True)` now sorts by measured latency first, using the interface-type priority (thunderbolt first) only as tie-break/fallback for unmeasured links. The RDMA coordinator path (`ring=False`) is unchanged. This resolves the TODO and fixes the stale docstring (which described the coordinator priority, not the ring one).
- **Keep selection deterministic.** Candidate IPs are deduplicated in first-seen order rather than collected into a set — see below.

With this, after a restart where the Thunderbolt bridge comes back late: the periodic probe measures both paths, the topology reflects real latencies within ~10s, and the next placement picks the fast link by measurement rather than by label.

## Note on tie-breaking

Deduplicating candidates is necessary here (the same IP can appear on several connections), but doing it with a set introduces a subtle bug worth naming, since it is easy to reintroduce.

`min()` resolves ties by iteration order. Iteration order of a `set` of strings depends on PYTHONHASHSEED, which is randomised per process. And ties are not an edge case: on a cluster that has not yet completed a probe round, *every* candidate has `latency_ms is None` and sorts at `inf`, so the entire selection is decided by the tie-break. The chosen ring IP would then vary between master restarts for an unchanged topology — a regression against the pre-existing list-based `min`, which was deterministic.

```
$ for i in 1 2 3 4 5; do python3 -c "
  ips={'10.0.0.5','10.0.0.9','192.168.1.4'}
  print(min(ips, key=lambda ip:(float('inf'),2)))"; done
192.168.1.4
10.0.0.5
10.0.0.9
192.168.1.4
10.0.0.9
```

`dict.fromkeys(...)` deduplicates while preserving first-seen order, so ties resolve to topology order exactly as before.

## Not in scope

- Re-evaluating hosts of an **already-running** instance when a better link appears (needs a design decision about instance migration/renegotiation).
- The SIGABRT itself — the crash traces in #1723 are from the libp2p-era `exo_pyo3_bindings`; that code was replaced by the zenoh stack in #2132.

## Tests

- `find_ip_prioritised`: measured low latency beats a thunderbolt-labelled slow link; latency outranks labels; unmeasured links fall back to label priority; measured links beat unmeasured ones.
- `latency_changed_materially`: first measurement, sub-noise-floor jitter, sub-factor-two changes, and genuine degradation (0.8 ms → 45 ms).

basedpyright, ruff, and the master/shared/utils/worker-unit test suites pass locally.

---
*Refiled from #2215, which was closed unintentionally.*

## Related work

Issue #2295 independently reports MlxRing selecting a high-latency LAN path over Thunderbolt. Its exact missing or mismatched topology state is still being investigated, so this PR is related rather than claimed as a complete fix.

The measured per-link latency added here also provides the `L_i` input used by the bandwidth-and-latency placement work in #2297, which fixes #957.

