### PR TITLE
fix: eos token ids for Qwen3.8/Kimi-Linear + auto trust_remote_code

### DIFF
--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -309,7 +309,7 @@ def get_eos_token_ids_for_model(model_id: ModelId) -> list[int] | None:
         List of EOS token IDs, or None if the model uses standard tokenizer config
     """
     model_id_lower = model_id.lower()
-    if "kimi-k2" in model_id_lower:
+    if "kimi-k2" in model_id_lower or "kimi-linear" in model_id_lower:
         return [163586]
     elif "glm-5" in model_id_lower:
         # 154820: <|endoftext|>, 154827: <|user|>, 154829: <|observation|>
@@ -324,6 +324,8 @@ def get_eos_token_ids_for_model(model_id: ModelId) -> list[int] | None:
         or "qwen-3.5" in model_id_lower
         or "qwen3.6" in model_id_lower
         or "qwen-3.6" in model_id_lower
+        or "qwen3.8" in model_id_lower
+        or "qwen-3.8" in model_id_lower
     ):
         # For Qwen3.5 / Qwen3.6: 248046 (<|im_end|>), 248044 (<|endoftext|>)
         return [248046, 248044]
@@ -350,6 +352,14 @@ def load_tokenizer_for_model_id(
     """
     model_id_lower = model_id.lower()
     eos_token_ids = get_eos_token_ids_for_model(model_id)
+
+    # Models that ship custom code (e.g. modeling_*.py for kimi_linear) require
+    # trust_remote_code regardless of what the generated model card says.
+    if not trust_remote_code and any(model_path.glob("modeling_*.py")):
+        trust_remote_code = True
+        logger.info(
+            f"{model_id}: custom modeling code detected, enabling trust_remote_code"
+        )
 
     # Kimi uses a custom TikTokenTokenizer that transformers 5.x can't load via AutoTokenizer
     if "kimi-k2" in model_id_lower:


### PR DESCRIPTION
Three model-loading fixes in utils_mlx.py:

1. Add Qwen3.8 to the eos token branch ([248046, 248044]) — without this, <|im_end|> leaked into generated content on all Qwen3.8 quants.

2. Add kimi-linear to the kimi-k2 eos branch ([163586]) — the auto-resolved eos (163585) was off-by-one, causing stop-token failures.

3. Auto-enable trust_remote_code when a model directory ships modeling_*.py custom code (e.g. kimi_linear). Without this, such models fail to load with "custom code which must be executed" errors.

## Motivation

<!-- Why is this change needed? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

## Changes

<!-- Describe what you changed in detail -->

## Why It Works

<!-- Explain why your approach solves the problem -->

## Test Plan

### Manual Testing
<!-- Hardware: (e.g., MacBook Pro M1 Max 32GB, Mac Mini M2 16GB, connected via Thunderbolt 4) -->
<!-- What you did: -->
<!-- - -->

### Automated Testing
<!-- Describe changes to automated tests, or how existing tests cover this change -->
<!-- - -->
