### PR TITLE
fix: API stream cleanup on reset + runner preservation across elections

### DIFF
--- a/src/exo/api/adapters/chat_completions.py
+++ b/src/exo/api/adapters/chat_completions.py
@@ -175,6 +175,7 @@ async def chat_request_to_text_generation(
         presence_penalty=request.presence_penalty,
         frequency_penalty=request.frequency_penalty,
         images=images,
+        use_prefix_cache=request.use_prefix_cache,
     )
 
 

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -297,6 +297,21 @@ class API:
 
     def reset(self, result_clock: int, event_receiver: Receiver[IndexedEvent]):
         logger.info("Resetting API State")
+        # Close active generation streams gracefully instead of orphaning them.
+        # Without this, clients hang on keep-alives forever — the sender objects
+        # remain alive (referenced by active async generators) but are unreachable
+        # from the new empty dict, so receivers never get an end-of-stream signal.
+        # Uses the same sender.close() pattern as _close_streams_for_instance.
+        for sender in self._text_generation_queues.values():
+            try:
+                sender.close()
+            except Exception:
+                pass
+        for sender in self._image_generation_queues.values():
+            try:
+                sender.close()
+            except Exception:
+                pass
         self._event_log.close()
         self._event_log = DiskEventLog(_API_EVENT_LOG_DIR)
         self.state = State()

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -247,6 +247,7 @@ class ChatCompletionRequest(BaseModel):
     tool_choice: str | dict[str, Any] | None = None
     parallel_tool_calls: bool | None = None
     user: str | None = None
+    use_prefix_cache: bool = False
 
 
 class BenchChatCompletionRequest(ChatCompletionRequest):

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -255,6 +255,25 @@ class Node:
                         self._tg.start_soon(self.download_coordinator.run)
                     if self.worker:
                         await self.worker.shutdown()
+                        # PATCH: preserve loaded model runners across the election
+                        # transition. The old code started a fresh Worker with no
+                        # runners, which evicted every loaded model on both nodes
+                        # whenever the master changed (startup elections made
+                        # 2-node placement effectively impossible).
+                        preserved_runners = getattr(
+                            self.worker, "runners", None
+                        ) or {}
+                        # Only preserve runners whose instance still exists in the
+                        # worker's last-known state — runners for deleted instances
+                        # were (or will be) shut down and must not be resurrected.
+                        old_instances = getattr(self.worker, "state", None)
+                        if old_instances is not None and preserved_runners:
+                            preserved_runners = {
+                                rid: sup
+                                for rid, sup in preserved_runners.items()
+                                if sup.bound_instance.instance.instance_id
+                                in old_instances.instances
+                            }
                         # TODO: add profiling etc to resource monitor
                         self.worker = Worker(
                             self.node_id,
@@ -266,6 +285,15 @@ class Node:
                             ),
                             api_port=self._api_port,
                         )
+                        if preserved_runners:
+                            self.worker.runners = preserved_runners
+                            new_sender = self.event_router.sender()
+                            for supervisor in preserved_runners.values():
+                                supervisor.rewire_event_sender(new_sender.clone())
+                            logger.info(
+                                f"Preserved {len(preserved_runners)} runner(s) "
+                                "across master transition"
+                            )
                         self._tg.start_soon(self.worker.run)
                     if self.api:
                         self.api.reset(result.won_clock, self.event_router.receiver())

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -105,6 +105,7 @@ class Worker:
         info_send, info_recv = channel[GatheredInfo]()
         info_gatherer: InfoGatherer = InfoGatherer(info_send)
 
+        router_died = False
         try:
             async with self._tg as tg:
                 tg.start_soon(info_gatherer.run)
@@ -114,16 +115,21 @@ class Worker:
                 tg.start_soon(self._poll_connection_updates)
                 tg.start_soon(self._reconcile_custom_cards)
         except* (EventRouterBrokenResourceError, EventRouterClosedResourceError):
-            # Event router has been closed (try-star syntax handles error groups)
-            pass
+            # Event router has been closed (try-star syntax handles error groups).
+            # This happens on every new-master election transition (the router is
+            # recreated with a new session). Model runner processes are independent
+            # of the session — keep them alive so loaded models survive elections.
+            # The caller (main.py) restarts this worker and transfers self.runners.
+            router_died = True
         finally:
             # Actual shutdown code - waits for all tasks to complete before executing.
             logger.info("Stopping Worker")
             self.event_sender.close()
             self.command_sender.close()
             self.download_command_sender.close()
-            for runner in self.runners.values():
-                runner.shutdown()
+            if not router_died:
+                for runner in self.runners.values():
+                    runner.shutdown()
             self._stopped.set()
 
     async def _forward_info(self, recv: Receiver[GatheredInfo]):

--- a/src/exo/worker/runner/supervisor.py
+++ b/src/exo/worker/runner/supervisor.py
@@ -199,6 +199,15 @@ class RunnerSupervisor:
         default_factory=anyio.CancelScope, init=False
     )
 
+    def rewire_event_sender(self, event_sender: Sender[Event]) -> None:
+        """Replace the event sender after event-router recreation (new master session).
+
+        Keeps loaded model runner processes alive across election transitions:
+        the runner's mp pipes are session-independent, only this event sender
+        pointed at the old (now closed) event router.
+        """
+        self._event_sender = event_sender
+
     @classmethod
     async def create(
         cls,


### PR DESCRIPTION
Cluster stability fixes:

1. api/main.py: reset() now closes active stream senders before clearing state. Without this, clients on keep-alive connections hang indefinitely when a runner dies (the "Reset API State" wedge).

2. api/types/api.py + adapters/chat_completions.py: expose use_prefix_cache through the regular chat completions API (was bench-endpoint only).

3. worker/main.py + supervisor.py + main.py: model runners survive router-death (election transitions) via a router_died flag; the new worker inherits preserved runners and rewires their event senders. Filter preserved runners to those whose instances still exist in state (unfiltered version resurrected stale runners for deleted instances).

## Motivation

<!-- Why is this change needed? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

## Changes

<!-- Describe what you changed in detail -->

## Why It Works

<!-- Explain why your approach solves the problem -->

## Test Plan

### Manual Testing
<!-- Hardware: (e.g., MacBook Pro M1 Max 32GB, Mac Mini M2 16GB, connected via Thunderbolt 4) -->
<!-- What you did: -->
<!-- - -->

### Automated Testing
<!-- Describe changes to automated tests, or how existing tests cover this change -->
<!-- - -->
