### PR TITLE
mlx tensor-parallel: replicate vector-quantized codebooks

### DIFF
--- a/resources/inference_model_cards/TheDrainFlorist--Qwen3.5-397B-A17B-VQ-2.2bpw.toml
+++ b/resources/inference_model_cards/TheDrainFlorist--Qwen3.5-397B-A17B-VQ-2.2bpw.toml
@@ -1,0 +1,26 @@
+model_id = "TheDrainFlorist/Qwen3.5-397B-A17B-VQ-2.2bpw"
+n_layers = 60
+hidden_size = 4096
+num_key_value_heads = 2
+supports_tensor = true
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "vq-2.2bpw"
+base_model = "Qwen3.5 397B A17B"
+capabilities = ["text", "thinking", "thinking_toggle", "vision"]
+reasoning_dialect = "post_last_user"
+context_length = 262144
+backends = ["MlxMetal"]
+[storage_size]
+in_bytes = 108372357800
+
+# Vector-quantized MoE experts. Loads on stock mlx-lm via the bundled
+# model.py (config.json model_file). Includes the vision tower.
+
+[sampling_defaults]
+temperature = 0.6
+top_p = 0.95
+top_k = 20
+min_p = 0.0
+repetition_penalty = 1.0
+presence_penalty = 0.0

--- a/resources/inference_model_cards/TheDrainFlorist--Qwen3.5-397B-A17B-VQ-2.4bpw.toml
+++ b/resources/inference_model_cards/TheDrainFlorist--Qwen3.5-397B-A17B-VQ-2.4bpw.toml
@@ -1,0 +1,26 @@
+model_id = "TheDrainFlorist/Qwen3.5-397B-A17B-VQ-2.4bpw"
+n_layers = 60
+hidden_size = 4096
+num_key_value_heads = 2
+supports_tensor = true
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "vq-2.4bpw"
+base_model = "Qwen3.5 397B A17B"
+capabilities = ["text", "thinking", "thinking_toggle", "vision"]
+reasoning_dialect = "post_last_user"
+context_length = 262144
+backends = ["MlxMetal"]
+[storage_size]
+in_bytes = 119848147188
+
+# Vector-quantized MoE experts. Loads on stock mlx-lm via the bundled
+# model.py (config.json model_file). Includes the vision tower.
+
+[sampling_defaults]
+temperature = 0.6
+top_p = 0.95
+top_k = 20
+min_p = 0.0
+repetition_penalty = 1.0
+presence_penalty = 0.0

--- a/resources/inference_model_cards/TheDrainFlorist--Qwen3.5-397B-A17B-VQ-3.1bpw.toml
+++ b/resources/inference_model_cards/TheDrainFlorist--Qwen3.5-397B-A17B-VQ-3.1bpw.toml
@@ -1,0 +1,26 @@
+model_id = "TheDrainFlorist/Qwen3.5-397B-A17B-VQ-3.1bpw"
+n_layers = 60
+hidden_size = 4096
+num_key_value_heads = 2
+supports_tensor = true
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "vq-3.1bpw"
+base_model = "Qwen3.5 397B A17B"
+capabilities = ["text", "thinking", "thinking_toggle", "vision"]
+reasoning_dialect = "post_last_user"
+context_length = 262144
+backends = ["MlxMetal"]
+[storage_size]
+in_bytes = 154277447647
+
+# Vector-quantized MoE experts. Loads on stock mlx-lm via the bundled
+# model.py (config.json model_file). Includes the vision tower.
+
+[sampling_defaults]
+temperature = 0.6
+top_p = 0.95
+top_k = 20
+min_p = 0.0
+repetition_penalty = 1.0
+presence_penalty = 0.0

--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -471,6 +471,11 @@ def tensor_auto_parallel(
     segments: int = 1
 
     def _all_to_sharded(path: str, weight: mx.array):
+        if path.endswith("codebook"):
+            # Vector-quantized experts: the [K, d] codebook is a shared
+            # lookup table, not a weight slice — replicate it. The codes and
+            # scales alongside it shard fine on the default axes.
+            return None
         if path.endswith("bias"):
             logger.info(f"Sharding bias for {path} - all to sharded")
             return weight.ndim - 1, segments
@@ -485,6 +490,9 @@ def tensor_auto_parallel(
     n = group.size()
 
     def _sharded_to_all(path: str, weight: mx.array):
+        if path.endswith("codebook"):
+            # Replicate the lookup table (see _all_to_sharded).
+            return None
         if path.endswith("bias"):
             logger.info(f"Sharding bias for {path} - sharded to all")
             weight /= n


### PR DESCRIPTION
## What

Vector-quantized (VQ) models store each expert weight as `codes` + `scales` + a `[K, d]` `codebook`. Under tensor-parallel sharding, `codes` and `vq_scales` shard correctly on the default axes, but the codebook is a shared lookup table indexed by the codes — slicing it across ranks leaves every rank decoding against a fraction of the table, producing garbage output. This adds a guard to both sharding closures in `auto_parallel.py` so any parameter path ending in `codebook` is replicated instead of sliced.

The guard can't misfire on existing models: no parameter anywhere in current mlx-lm is named `codebook`.

Also adds model cards for the three VQ builds this was found on — [Qwen3.5-397B-A17B-VQ-2.2bpw / 2.4bpw / 3.1bpw](https://huggingface.co/TheDrainFlorist) — which load on **stock mlx-lm** via the bundled `model.py` (`config.json` `model_file`), so no engine changes are needed beyond this one.

## Why

I built these quants to make this model more accessible to the community. The 2.2bpw **and** 2.4bpw builds each run on a **single 128 GB Mac** (~101 / ~112 GiB on disk); the 3.1bpw quality build is what tensor-parallel across two Macs is for — which is where this guard matters. Verified serving across a 2-node ring: output identical to the single-box run.

The artifacts also ship the model's full vision tower at source precision as a top-level indexed shard, and the cards declare the `vision` capability — `mlx-lm` is text-only for this architecture, but exo's vision path loads the tower from the folder directly. Verified: an image query through `/v1/chat/completions` against the 2.4bpw build on a live 2-node tensor instance returns a correct description.

## Testing

- Card TOMLs validate against `ModelCard.load_from_path` (existing card tests pass).
- Live 2-node tensor-parallel serving of the VQ builds: coherent generation, output matching the unsharded run.
- Without the guard: garbage output (the failure this fixes).
- Vision: image round-trip through the API on a live tensor instance, correct description returned.


