### PR TITLE
fix(mlx sharding): bypass deadlocking pipeline prefill + chunk stream_generate + CPU all_gather (#2108)

### DIFF
--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -186,9 +186,27 @@ class PipelineLastLayer(CustomMlxLayer):
                 mx.eval(_cache.keys)  # type: ignore
 
         if not self.is_prefill:
-            output = mx.distributed.all_gather(output, group=self.group)[
-                -output.shape[0] :
-            ]
+            # FIX (exo Issue #2108): run the decode all_gather on the CPU stream, NOT
+            # the current (thread-local generation) GPU stream. Two reasons:
+            #   1. mlx's AllGather has NO GPU implementation
+            #      ("[AllGather::eval_gpu] has no GPU implementation") — it MUST run
+            #      on CPU. On the GPU generation_stream it silently never executes,
+            #      so the original code hung (the eval never completed).
+            #   2. mlx_lm's stream_generate wraps the forward in
+            #      `with mx.stream(generation_stream)` where
+            #      `generation_stream = mx.new_thread_local_stream(...)`. Even if
+            #      all_gather had a GPU impl, collectives on the thread-local stream
+            #      do not block for the delayed peer — the leading rank races ahead
+            #      with stale data while the trailing rank deadlocks.
+            # The CPU stream's collectives DO block (matching mx_barrier in
+            # utils_mlx.py, which uses `stream=mx.default_stream(mx.Device(mx.cpu))`
+            # for the same reason). The `mx.eval(output)` above materializes the send
+            # result so mlx can move it to CPU for the gather.
+            output = mx.distributed.all_gather(
+                output,
+                group=self.group,
+                stream=mx.default_stream(mx.Device(mx.cpu)),
+            )[-output.shape[0] :]
             mx.eval(output)
 
         return output

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -331,7 +331,15 @@ def prefill(
 
     is_pipeline = _has_pipeline_communication_layer(model)
 
-    prefill_step_size = 4096
+    # WORKAROUND (exo Issue #2108): pipeline_parallel_prefill deadlocks for large
+    # contexts (>=4096) on multi-machine sharded models — the chunked ring send/recv
+    # in the pipeline loop desyncs even with queue_sends=False + the distributed
+    # callback skipped. The single-pass stream_generate path (below) does NOT
+    # deadlock (its decode all_gather is fixed to run on the CPU stream — see
+    # PipelineLastLayer in auto_parallel.py). Setting the threshold to 100000 means
+    # num_tokens >= prefill_step_size is effectively never true, so all prompts use
+    # stream_generate. This matches the verified-working 8K/16K/32K results.
+    prefill_step_size = 100000
 
     try:
         if is_pipeline and num_tokens >= prefill_step_size:
@@ -363,7 +371,17 @@ def prefill(
             )
         else:
             # Use max_tokens=1 because max_tokens=0 does not work.
-            # We just throw away the generated token - we only care about filling the cache
+            # We just throw away the generated token - we only care about filling the cache.
+            #
+            # WORKAROUND (exo Issue #2108): chunk the stream_generate prefill at 2048
+            # tokens (NOT the bypass threshold of 100000) so the peer's GPU doesn't OOM
+            # on large prompts. With prefill_step_size=100000 the entire prompt is
+            # processed in a single forward pass, which exhausts the 24GB peer's Metal
+            # memory at ~6K+ tokens ("kIOGPUCommandBufferCallbackErrorOutOfMemory").
+            # Chunking at 2048 processes the prompt in multiple smaller forward passes,
+            # each holding only 2048 tokens of activations. Each pass is an independent
+            # send/recv pair (unlike the broken pipeline_parallel_prefill loop, which
+            # deadlocks on the chunked ring send/recv).
             for _ in stream_generate(
                 model=model,
                 tokenizer=tokenizer,
@@ -371,7 +389,7 @@ def prefill(
                 max_tokens=1,
                 sampler=sampler,
                 prompt_cache=cache,
-                prefill_step_size=prefill_step_size,
+                prefill_step_size=2048,
                 kv_group_size=KV_GROUP_SIZE,
                 kv_bits=KV_BITS,
                 prompt_progress_callback=combined_progress_callback,

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -335,7 +335,13 @@ def prefill(
 
     try:
         if is_pipeline and num_tokens >= prefill_step_size:
-            set_pipeline_queue_sends(model, queue_sends=True)
+            # FIX (exo Issue #2108): queue_sends=False. With queue_sends=True the
+            # send is appended to _pending_prefill_sends and submitted later via
+            # flush_prefill_sends (mx.async_eval), but the async send is never forced
+            # by any eval, so it is never actually submitted and the receiver's recv
+            # deadlocks. Submitting immediately (queue_sends=False) in the
+            # PipelineLastLayer (like the warmup path) makes the send/recv pair.
+            set_pipeline_queue_sends(model, queue_sends=False)
             assert group is not None, "Pipeline prefill requires a distributed group"
             pipeline_parallel_prefill(
                 model=model,
@@ -345,7 +351,14 @@ def prefill(
                 kv_group_size=KV_GROUP_SIZE,
                 kv_bits=KV_BITS,
                 prompt_progress_callback=progress_callback,
-                distributed_prompt_progress_callback=distributed_prompt_progress_callback,
+                # FIX (exo Issue #2108): skip the distributed callback during pipeline
+                # prefill. The callback's mx_any (all_sum) + mx_all_gather_tasks
+                # (all_gather) are collective ops that don't block for the delayed peer
+                # (the rank doing the real forward is ~8s behind the leading-dummy rank),
+                # so the leading rank's recv returns stale/garbage data and the forward
+                # rank's all_sum deadlocks. For single-request prefill (no cancellations,
+                # no new tasks) the callback is a no-op anyway (all counts are 0).
+                distributed_prompt_progress_callback=None,
                 group=group,
             )
         else:

--- a/src/exo/worker/runner/supervisor.py
+++ b/src/exo/worker/runner/supervisor.py
@@ -68,6 +68,14 @@ class RunnerStdioHandler:
     diagnostics: RunnerDiagnosticCollector = field(
         default_factory=RunnerDiagnosticCollector
     )
+    # FIX (exo Issue #2108): when a fatal runner diagnostic is detected on stderr
+    # (e.g. the mlx ring transport aborting after too many send/recv errors), this
+    # callback is invoked so the supervisor can kill the runner process and let exo
+    # re-place the instance (re-initializing the distributed group / ring). Without
+    # this the runner hangs forever — the ring is dead but the process stays alive,
+    # so the diagnostics are never acted upon (only surfaced on runner termination).
+    on_fatal_diagnostic: Callable[[str], Awaitable[None]] | None = None
+    _fatal_triggered: bool = field(default=False, init=False)
 
     _tg: TaskGroup = field(default_factory=TaskGroup, init=False)
 
@@ -275,10 +283,19 @@ class RunnerSupervisor:
         Aborting...`` but does not crash the process — the in-flight collective
         hangs forever. Stopping the runner here lets the supervisor surface the
         failure + exo re-place the instance (re-initializing the ring).
+
+        We also clear the collected diagnostics before stopping, because the
+        ErrorChunk's ``diagnostics: list[KnownRunnerDiagnostic]`` field fails
+        pydantic validation for ``RunnerRingTransportError`` (the ``message`` field
+        is rejected as ``extra_forbidden`` on the receiving side — a pre-existing
+        TaggedModel serialization bug). Sending an empty diagnostics list avoids
+        the validation flood that would otherwise wedge the supervisor.
         """
         logger.error(
             f"Killing runner process due to fatal diagnostic: {line.strip()}"
         )
+        # Avoid the pydantic validation flood in ErrorChunk sending.
+        self._runner_stdio_handler.diagnostics._diagnostics.clear()
         with anyio.CancelScope(shield=True):
             await self.runner_process.stop()
 

--- a/src/exo/worker/runner/supervisor.py
+++ b/src/exo/worker/runner/supervisor.py
@@ -3,7 +3,7 @@ import contextlib
 import signal
 from dataclasses import dataclass, field
 from os import PathLike
-from typing import Callable, Self
+from typing import Awaitable, Callable, Self
 
 import anyio
 from anyio import (
@@ -52,6 +52,7 @@ from exo.worker.runner.bootstrap import RunnerTerminationError, entrypoint
 from exo.worker.runner.diagnostics import (
     RunnerDiagnosticCollector,
     RunnerUnknown,
+    _RING_TRANSPORT_ABORT_RE,
 )
 
 PREFILL_TIMEOUT_SECONDS = 60
@@ -144,6 +145,26 @@ class RunnerStdioHandler:
             # Send to logger & error recovery task
             log_line(line)
             record_diagnostic_line(line)
+
+            # FIX (exo Issue #2108): detect a fatal ring-transport abort on the
+            # runner's stderr and trigger the supervisor's fatal-diagnostic callback
+            # (which kills the runner process so exo re-places the instance +
+            # re-initializes the ring). The mlx ring prints
+            #   "[ring] Too many send/recv errors. Aborting..."
+            # but does NOT crash the process — the collective call hangs forever,
+            # leaving the runner alive but unresponsive. Guard with _fatal_triggered
+            # so we only fire once (the abort line can repeat).
+            if (
+                not self._fatal_triggered
+                and self.on_fatal_diagnostic is not None
+                and _RING_TRANSPORT_ABORT_RE.match(line)
+            ):
+                self._fatal_triggered = True
+                logger.error(
+                    f"Fatal ring transport abort detected on runner stderr — "
+                    f"triggering runner restart to re-init the distributed group: {line}"
+                )
+                await self.on_fatal_diagnostic(line)
 
         async def handle_text(text: str):
             nonlocal pending_line
@@ -240,7 +261,26 @@ class RunnerSupervisor:
             _event_sender=event_sender,
         )
 
+        # FIX (exo Issue #2108): wire the fatal-diagnostic callback so a ring
+        # transport abort kills this runner process → the supervisor marks it
+        # RunnerFailed → exo re-places the instance with a fresh distributed group.
+        runner_stdio_handler.on_fatal_diagnostic = self._on_fatal_diagnostic
+
         return self
+
+    async def _on_fatal_diagnostic(self, line: str) -> None:
+        """Kill the runner process when a fatal stderr diagnostic is detected.
+
+        The mlx ring transport prints ``[ring] Too many send/recv errors.
+        Aborting...`` but does not crash the process — the in-flight collective
+        hangs forever. Stopping the runner here lets the supervisor surface the
+        failure + exo re-place the instance (re-initializing the ring).
+        """
+        logger.error(
+            f"Killing runner process due to fatal diagnostic: {line.strip()}"
+        )
+        with anyio.CancelScope(shield=True):
+            await self.runner_process.stop()
 
     async def run(self):
         try:


### PR DESCRIPTION
## Fixes #2108 — multi-machine sharded inference deadlocks/hangs

Four changes that make multi-machine sharded inference (27B across 2 Macs over Thunderbolt 5) work for **all prompt sizes** + auto-recover from ring transport failures.

### 1. Bypass the deadlocking pipeline prefill (`generate.py`)
`prefill_step_size = 100000` so `pipeline_parallel_prefill` is never taken — that path has a deeper chunked-ring send/recv deadlock that `queue_sends=False` + skipping the distributed callback do NOT resolve. All prompts use `stream_generate`.

### 2. Chunk stream_generate to avoid OOM (`generate.py`)
Pass `prefill_step_size=2048` to `stream_generate(...)` (NOT the 100000 threshold). Without this the entire prompt is one forward pass → OOMs the 24GB peer Metal memory at ~6K+ tokens (`kIOGPUCommandBufferCallbackErrorOutOfMemory`).

### 3. Decode all_gather on the CPU stream (`auto_parallel.py`)
`PipelineLastLayer` decode: `mx.distributed.all_gather(..., stream=mx.default_stream(mx.Device(mx.cpu)))`. mlx `AllGather` has **no GPU implementation** — on the GPU `generation_stream` it silently never executes → eval hangs. CPU stream collectives DO block (matching `mx_barrier` in `utils_mlx.py`).

### 4. Crash-on-ring-abort auto-recovery (`supervisor.py`)
The mlx ring transport prints `[ring] Too many send/recv errors. Aborting...` to stderr under sustained load (an `errno 14` EFAULT on recv — a buffer-lifetime bug in the mlx C++ ring code) but does NOT crash the process — the in-flight collective hangs forever, leaving the runner alive but unresponsive. exo diagnostics were only acted upon on runner termination, so the hung runner was never recovered.

This wires a fatal-diagnostic callback: when the ring abort is detected on stderr, the supervisor clears the collected diagnostics (avoids a pre-existing pydantic validation flood in `ErrorChunk` sending — `RunnerRingTransportError.message` is rejected as `extra_forbidden` by the receiver) + kills the runner process → `RunnerFailed` → exo re-places the instance with a fresh distributed group (re-initialized ring) → the 27B recovers.

### Verification (27B: M4 Max 36GB + M5 Pro 24GB)
- Warmup: both ranks ready ✅
- 10 tokens: 1-8s ✅ | 6373 tokens: 34s ✅ | 9382 tokens: 47s ✅
- Agent (pi -p, ~18K context): 144s, correct TDD implementation ✅
- **Sustained load (120 calls, 5K-prompt): 118 OK, 2 ring breaks → both auto-recovered, exo API stayed up, 111 consecutive OK after warmup** ✅

### What does NOT work (and why)
- `pipeline_parallel_prefill` (bypassed) — the chunked ring send/recv deadlocks even with the `queue_sends`/callback fixes.
- The mlx ring `errno 14` EFAULT is an underlying C++ buffer-lifetime bug that cannot be fixed in Python — the crash-on-ring-abort fix makes the system resilient (auto-restart) rather than fixing the ring itself.
- The pre-existing pydantic `TaggedModel` serialization bug (`RunnerRingTransportError.message` rejected as `extra_forbidden`) is worked around by clearing diagnostics; the real fix would be in the schema.