### PR TITLE
fix(mlx): validate vision prefix cache fail closed

### DIFF
--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -401,28 +401,57 @@ class KVPrefixCache:
         cached_regions: list["MediaRegion"],
         query_regions: list["MediaRegion"],
     ) -> int:
-        if not cached_regions:
-            return match_length
+        """Keep a media prefix only when both sides positively identify it.
 
-        query_by_start: dict[int, "MediaRegion"] = {
-            r.start_pos: r for r in query_regions
-        }
+        Empty region lists on both sides represent an ordinary text-only lookup.
+        If either side reports media inside the matched prefix, every region must
+        have exactly one positional twin with the same non-empty hash and span.
+        """
+        cached_by_start: dict[int, list["MediaRegion"]] = {}
+        query_by_start: dict[int, list["MediaRegion"]] = {}
+        for region in cached_regions:
+            cached_by_start.setdefault(region.start_pos, []).append(region)
+        for region in query_regions:
+            query_by_start.setdefault(region.start_pos, []).append(region)
 
-        for cached_r in cached_regions:
-            if cached_r.start_pos >= match_length:
+        region_starts = sorted(cached_by_start.keys() | query_by_start.keys())
+        for start_pos in region_starts:
+            if start_pos >= match_length:
                 break
-            query_r = query_by_start.get(cached_r.start_pos)
-            if query_r is None:
-                continue
-            if query_r.content_hash != cached_r.content_hash:
-                logger.info(
-                    f"Media region mismatch at pos {cached_r.start_pos}: "
-                    f"cached={cached_r.content_hash[:12]}... "
-                    f"query={query_r.content_hash[:12]}... — "
-                    f"truncating match from {match_length} to {cached_r.start_pos}"
+
+            cached_at_start = cached_by_start.get(start_pos, [])
+            query_at_start = query_by_start.get(start_pos, [])
+            if len(cached_at_start) != 1 or len(query_at_start) != 1:
+                reason = (
+                    f"region count mismatch (cached={len(cached_at_start)}, "
+                    f"query={len(query_at_start)})"
                 )
-                match_length = cached_r.start_pos
-                break
+            else:
+                cached_region = cached_at_start[0]
+                query_region = query_at_start[0]
+                if not cached_region.content_hash or not query_region.content_hash:
+                    reason = "empty content hash"
+                elif cached_region.end_pos != query_region.end_pos:
+                    reason = (
+                        f"span mismatch (cached_end={cached_region.end_pos}, "
+                        f"query_end={query_region.end_pos})"
+                    )
+                elif cached_region.content_hash != query_region.content_hash:
+                    reason = (
+                        "content hash mismatch "
+                        f"(cached={cached_region.content_hash[:12]}..., "
+                        f"query={query_region.content_hash[:12]}...)"
+                    )
+                else:
+                    continue
+
+            logger.info(
+                f"Media region could not be positively validated at pos {start_pos}: "
+                f"{reason} — "
+                f"truncating match from {match_length} to {start_pos}"
+            )
+            match_length = start_pos
+            break
 
         return match_length
 

--- a/src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py
@@ -20,6 +20,7 @@ from exo.worker.engines.mlx.cache import (
 from exo.worker.engines.mlx.generator.generate import mlx_generate, prefill
 from exo.worker.engines.mlx.types import Model
 from exo.worker.engines.mlx.utils_mlx import apply_chat_template
+from exo.worker.engines.mlx.vision import MediaRegion
 from exo.worker.tests.unittests.test_mlx.conftest import (
     DEFAULT_GPT_OSS_CONFIG,
     DEFAULT_GPT_OSS_MODEL_ID,
@@ -75,6 +76,158 @@ class TestGetPrefixLength:
         a = mx.array([]).astype(mx.int32)
         b = mx.array([]).astype(mx.int32)
         assert get_prefix_length(a, b) == 0
+
+
+class TestValidateMediaMatch:
+    validate = staticmethod(KVPrefixCache._validate_media_match)
+
+    def test_matching_region_preserves_prefix(self):
+        cached = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20)]
+        query = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20)]
+
+        assert self.validate(30, cached, query) == 30
+
+    def test_different_media_truncates_at_region_start(self):
+        cached = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20)]
+        query = [MediaRegion(content_hash="hash-b", start_pos=10, end_pos=20)]
+
+        assert self.validate(30, cached, query) == 10
+
+    def test_missing_query_region_fails_closed(self):
+        cached = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20)]
+
+        assert self.validate(30, cached, []) == 10
+
+    def test_missing_cached_metadata_fails_closed(self):
+        query = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20)]
+
+        assert self.validate(30, [], query) == 10
+
+    def test_shifted_query_region_fails_closed(self):
+        cached = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20)]
+        query = [MediaRegion(content_hash="hash-a", start_pos=11, end_pos=21)]
+
+        assert self.validate(30, cached, query) == 10
+
+    def test_different_region_span_fails_closed(self):
+        cached = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20)]
+        query = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=21)]
+
+        assert self.validate(30, cached, query) == 10
+
+    def test_empty_hash_fails_closed(self):
+        cached = [MediaRegion(content_hash="", start_pos=10, end_pos=20)]
+        query = [MediaRegion(content_hash="", start_pos=10, end_pos=20)]
+
+        assert self.validate(30, cached, query) == 10
+
+    def test_regions_after_prefix_do_not_truncate(self):
+        cached = [MediaRegion(content_hash="hash-a", start_pos=20, end_pos=30)]
+        query = [MediaRegion(content_hash="hash-b", start_pos=20, end_pos=30)]
+
+        assert self.validate(10, cached, query) == 10
+
+    def test_earliest_unvalidated_region_wins(self):
+        cached = [
+            MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20),
+            MediaRegion(content_hash="hash-b", start_pos=30, end_pos=40),
+        ]
+        query = [
+            MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20),
+            MediaRegion(content_hash="hash-c", start_pos=30, end_pos=40),
+        ]
+
+        assert self.validate(50, cached, query) == 30
+
+    def test_query_region_before_cached_region_truncates_at_query_start(self):
+        cached = [MediaRegion(content_hash="hash-a", start_pos=15, end_pos=25)]
+        query = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20)]
+
+        assert self.validate(30, cached, query) == 10
+
+    def test_region_at_exact_prefix_boundary_does_not_truncate(self):
+        cached = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20)]
+        query = [MediaRegion(content_hash="hash-b", start_pos=10, end_pos=20)]
+
+        assert self.validate(10, cached, query) == 10
+
+    def test_matching_region_straddling_prefix_preserves_prefix(self):
+        cached = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=50)]
+        query = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=50)]
+
+        assert self.validate(30, cached, query) == 30
+
+    def test_duplicate_region_start_fails_closed(self):
+        cached = [
+            MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20),
+            MediaRegion(content_hash="hash-b", start_pos=10, end_pos=20),
+        ]
+        query = [MediaRegion(content_hash="hash-a", start_pos=10, end_pos=20)]
+
+        assert self.validate(30, cached, query) == 10
+
+    def test_no_regions_is_text_only_and_preserves_prefix(self):
+        assert self.validate(30, [], []) == 30
+
+    def test_lookup_truncates_token_identical_prompt_for_different_media(self):
+        tokens = mx.arange(30)
+        layer_cache = KVCache()
+        layer_cache.update_and_fetch(
+            mx.zeros((1, 1, 30, 1)), mx.zeros((1, 1, 30, 1))
+        )
+        cached_region = MediaRegion(
+            content_hash="hash-a", start_pos=10, end_pos=20
+        )
+        query_region = MediaRegion(
+            content_hash="hash-b", start_pos=10, end_pos=20
+        )
+        prefix_cache = KVPrefixCache(None)
+        prefix_cache.add_kv_cache(
+            tokens,
+            [layer_cache],
+            media_regions=[cached_region],
+        )
+
+        restored, remaining, matched_index, is_exact = prefix_cache.get_kv_cache(
+            cast(Model, object()),
+            tokens,
+            media_regions=[query_region],
+        )
+
+        assert matched_index == 0
+        assert not is_exact
+        assert cache_length(restored) == 10
+        assert mx.array_equal(remaining, tokens[10:])
+
+    def test_update_replaces_media_metadata_after_truncated_match(self):
+        tokens = mx.arange(30)
+        layer_cache = KVCache()
+        layer_cache.update_and_fetch(
+            mx.zeros((1, 1, 30, 1)), mx.zeros((1, 1, 30, 1))
+        )
+        cached_region = MediaRegion(
+            content_hash="hash-a", start_pos=10, end_pos=20
+        )
+        query_region = MediaRegion(
+            content_hash="hash-b", start_pos=10, end_pos=20
+        )
+        prefix_cache = KVPrefixCache(None)
+        prefix_cache.add_kv_cache(
+            tokens,
+            [layer_cache],
+            media_regions=[cached_region],
+        )
+
+        prefix_cache.update_kv_cache(
+            0,
+            tokens,
+            [layer_cache],
+            snapshots=None,
+            restore_pos=10,
+            media_regions=[query_region],
+        )
+
+        assert prefix_cache._media_regions[0] == [query_region]
 
 
 class TestKVPrefix:


### PR DESCRIPTION
## Summary

- require positive media-region validation before reusing a vision KV prefix
- truncate the reusable prefix before the first unvalidated image region
- reject missing, shifted, duplicated, empty, or hash-mismatched media metadata instead of silently trusting it
- preserve normal text-only prefix-cache behavior

Fixes #2272.

## Why this approach

Image placeholder tokens can be identical even when the image bytes differ. A token-prefix match is therefore insufficient once it reaches a media region. The cache now fails closed unless the cached and incoming media spans have a one-to-one positional and hash match.

## Validation

- `uv run pytest -q src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py -m 'not slow'` — 28 passed
- `uv run pytest -q src/exo/worker/tests/unittests -m 'not slow'` — 161 passed, 184 deselected
- `uv run basedpyright src/exo/worker/engines/mlx/cache.py src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py`
- `uv run ruff check src/exo/worker/engines/mlx/cache.py src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py`

The regression tests cover different image hashes, missing metadata, positional shifts, duplicate spans, empty hashes, exact matches, and text-only prefixes.
