### PR TITLE
fix(mlx): let sharded models re-derive layer indices after pipeline split

### DIFF
--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -388,6 +388,20 @@ def pipeline_auto_parallel(
 
     _set_layers(model, layers)
 
+    # Pipeline sharding swaps in a slice of the layer stack after the model was
+    # already constructed. Any index a model derived from the *full* stack in
+    # __init__ -- which cache entry holds the first full-attention layer, which
+    # holds the first recurrent layer -- now addresses the wrong entry, so the
+    # model builds its masks from the wrong cache. Nothing raises: generation
+    # keeps running and quietly produces wrong output.
+    #
+    # The isinstance branches above repair this for four model types by name.
+    # Any other hybrid stack silently keeps its stale indices, so give models a
+    # supported way to re-derive their own state from the sharded layer list.
+    resync = getattr(inner_model_instance, "resync_sharded_layers", None)
+    if callable(resync):
+        resync()
+
     assert isinstance(layers, list), (
         "Expected a list of layers after auto-parallel initialisation"
     )

--- a/src/exo/worker/engines/mlx/tests/test_pipeline_layer_resync.py
+++ b/src/exo/worker/engines/mlx/tests/test_pipeline_layer_resync.py
@@ -1,0 +1,106 @@
+# type: ignore
+"""Pipeline sharding must let a model re-derive state from its sharded layers.
+
+A hybrid stack (linear-attention layers interleaved with full-attention ones)
+records which cache entry holds the first layer of each kind. Those indices are
+derived from the *full* stack at construction time, but pipeline sharding
+replaces the layer list afterwards, so on every shard but the first they point
+at the wrong entry -- and the model then builds its masks from the wrong cache
+without raising.
+"""
+
+import mlx.nn as nn
+
+from exo.shared.types.worker.shards import PipelineShardMetadata
+from exo.worker.engines.mlx.auto_parallel import pipeline_auto_parallel
+
+
+class _Layer(nn.Module):
+    def __init__(self, is_linear: bool):
+        super().__init__()
+        self.is_linear = is_linear
+
+    def __call__(self, x, *args, **kwargs):
+        return x
+
+
+class _Inner(nn.Module):
+    """Caches layer indices in __init__, the way hybrid stacks do."""
+
+    def __init__(self, kinds: list[bool]):
+        super().__init__()
+        self.layers = [_Layer(k) for k in kinds]
+        self._recompute()
+        self.resynced = False
+
+    def _recompute(self) -> None:
+        self.ssm_idx = next(
+            (i for i, layer in enumerate(self.layers) if layer.is_linear), None
+        )
+        self.fa_idx = next(
+            (i for i, layer in enumerate(self.layers) if not layer.is_linear),
+            None,
+        )
+
+    def resync_sharded_layers(self) -> None:
+        self.resynced = True
+        self._recompute()
+
+
+class _Model(nn.Module):
+    def __init__(self, kinds: list[bool]):
+        super().__init__()
+        self.model = _Inner(kinds)
+
+    def __call__(self, x, cache=None):
+        return x
+
+
+def _shard(model, start, end, rank, world):
+    meta = PipelineShardMetadata.model_construct(
+        start_layer=start, end_layer=end, device_rank=rank, world_size=world
+    )
+    gen = pipeline_auto_parallel(model, group=None, model_shard_meta=meta)
+    try:
+        while True:
+            next(gen)
+    except StopIteration:
+        pass
+
+
+# layer_types repeating [linear, linear, linear, full]
+KINDS = [(i % 4) != 3 for i in range(12)]
+
+
+def test_resync_hook_runs_and_fixes_indices() -> None:
+    model = _Model(KINDS)
+    # Before sharding, indices describe the full stack.
+    assert (model.model.ssm_idx, model.model.fa_idx) == (0, 3)
+
+    # Shard 3 holds global layers 9..12 -> [linear, linear, full] locally,
+    # so the first full-attention layer is now at local index 2, not 3.
+    _shard(model, 9, 12, rank=2, world=3)
+
+    assert model.model.resynced, "resync_sharded_layers was never called"
+    assert model.model.fa_idx == 2
+    assert model.model.ssm_idx == 0
+
+
+class _InnerNoHook(_Inner):
+    resync_sharded_layers = None  # model opts out; sharding must still work
+
+
+class _ModelNoHook(nn.Module):
+    def __init__(self, kinds: list[bool]):
+        super().__init__()
+        self.model = _InnerNoHook(kinds)
+
+    def __call__(self, x, cache=None):
+        return x
+
+
+def test_model_without_hook_is_untouched() -> None:
+    """A model that does not define the hook shards exactly as before."""
+    model = _ModelNoHook(KINDS)
+    _shard(model, 0, 4, rank=0, world=3)  # must not raise
+    assert len(model.model.layers) == 4


### PR DESCRIPTION
## The bug

`pipeline_auto_parallel()` replaces the model's layer stack with a slice **after** the model has been constructed:

```python
layers = layers[start_layer:end_layer]
...
_set_layers(model, layers)
```

Any index a model derived from the *full* stack in `__init__` — which cache entry holds the first full-attention layer, which holds the first recurrent layer — now addresses the wrong entry on every shard but the first. The model then builds its attention and SSM masks from the wrong cache.

**Nothing raises.** Generation runs at full speed and returns fluent-looking tokens with no semantics. That failure mode is expensive to track down: activations stay finite and well-scaled all the way through, so every obvious diagnostic looks healthy.

## Why a general hook

`auto_parallel` already repairs exactly this, by name, for four model types:

```python
if isinstance(inner_model_instance, GptOssMoeModel): ...
if isinstance(inner_model_instance, Step35InnerModel): ...
if isinstance(inner_model_instance, (Qwen3_5TextModelInner, Qwen3NextInnerModel)): ...
if isinstance(inner_model_instance, NemotronHInnerModel): ...
```

That list has grown once per hybrid model added. The problem is not that the list is incomplete — it is that a stack which is *not* on it fails **silently** instead of loudly, including any model loaded from outside the tree.

This adds a small opt-in hook after `_set_layers()` so a model can re-derive its own state from the sharded layer list. Models that do not define `resync_sharded_layers` are completely unaffected — no behaviour change for anything in-tree today.

## How it was found

Running **GLM-5.3-Flash** (`glm5_next`: 34 gated-delta linear-attention layers interleaved with 11 DeepSeek-sparse-attention layers, hyper-connections, 288-expert MoE) across a 4-node Mac Studio pipeline over Thunderbolt/RDMA.

The inner model caches:

```python
self.ssm_idx = next((i for i, l in enumerate(self.layers) if l.is_linear), 0)
self.fa_idx  = next((i for i, l in enumerate(self.layers) if not l.is_linear), 0)
```

On the full 45-layer stack that gives `ssm_idx=0, fa_idx=3`. The shard holding global layers 27–44 needs `fa_idx=0, ssm_idx=1`. With the stale values, `create_ssm_mask()` receives a full-attention `CacheList` and the attention path receives the recurrent cache.

Note the `, 0)` default is a second trap: a shard containing no layer of one kind silently gets index `0` — a valid index into the wrong entry — rather than `None`.

## Testing

`src/exo/worker/engines/mlx/tests/test_pipeline_layer_resync.py` covers both that the hook fires and corrects indices on a non-first shard, and that a model without the hook shards exactly as before.

```
uv run pytest src/exo/worker/engines/mlx/tests/  ->  8 passed
uv run ruff check                                ->  All checks passed
uv run ruff format --check                       ->  already formatted
uv run basedpyright <changed files>              ->  0 errors, 0 warnings
```

Draft: happy to fold the four existing `isinstance` special-cases onto this hook if you'd prefer that shape, but left them untouched here to keep the change additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)