### PR TITLE
fix: repair the test suite on main

### DIFF
--- a/rust/exo_rs/tests/test_python.py
+++ b/rust/exo_rs/tests/test_python.py
@@ -13,7 +13,7 @@ from exo_rs import (
 @pytest.mark.asyncio
 async def test_sleep_on_multiple_items() -> None:
     print("PYTHON: starting handle")
-    h = NetworkingHandle.new(os.urandom(16).hex().lstrip("0"), 52414, 52413)
+    h = NetworkingHandle.new(os.urandom(16).hex().lstrip("0"), "exo-test", 52414, 52413)
     print("PYTHON: handle started")
 
     rt = asyncio.create_task(_await_recv(h))

--- a/src/exo/download/__init__.py
+++ b/src/exo/download/__init__.py
@@ -1,0 +1,1 @@
+"""Model download orchestration and storage helpers."""


### PR DESCRIPTION
## Problem

`uv run pytest` — the command in `CLAUDE.md`'s pre-commit checklist — does not currently run on `main`. It aborts during collection:

```
ERROR src/exo/download/tests/test_cancel_download.py
... 8 errors during collection ...
190 deselected, 8 errors in 2.60s
```

Two independent causes:

**1. `src/exo/download/` has no `__init__.py`.** Every other test package in the tree has one. Without it, pytest walks up only as far as `src/exo/download/` when deriving a module name, so the eight files under `src/exo/download/tests/` are imported as `tests.test_*`. With `pythonpath = "."`, the repo's top-level `tests/` package wins that name and the imports fail:

```
ModuleNotFoundError: No module named 'tests.test_safetensors_index'
```

The failure only appears in a full-suite run — `pytest src/exo/download/tests` alone passes, which is likely why it went unnoticed.

**2. `rust/exo_rs/tests/test_python.py` calls `NetworkingHandle.new()` with three arguments.** The zenoh migration (#2132) added a `namespace` parameter:

```rust
pub fn new(
    identity: &str,
    namespace: &str,
    listen_port: u16,
    discovery_service_port: u16,
) -> PyResult<PyNetworkingHandle> {
```

so the test raises `TypeError: NetworkingHandle.new() missing 1 required positional argument: 'discovery_service_port'`.

## Fix

Add the missing `__init__.py`, and pass a namespace in the test.

## Result

| | before | after |
|---|---|---|
| `uv run pytest` | 8 collection errors, aborts | **471 passed**, 3 skipped |

The 68 tests under `src/exo/download/tests/` had not been running as part of a full-suite invocation.
