### PR TITLE
fix: disable loguru variable inspection so runner exceptions surface

### DIFF
--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -56,6 +56,10 @@ def logger_setup(log_file: Path | None, verbosity: int = 0):
     # replace all stdlib loggers with _InterceptHandlers that log to loguru
     logging.basicConfig(handlers=[_InterceptHandler()], level=0)
 
+    # diagnose=False everywhere: loguru's variable inspection calls repr() on
+    # every local in the traceback, and repr of MLX device objects can crash
+    # the process mid-log (observed as an opaque SIGSEGV replacing the actual
+    # runner exception on the CUDA backend).
     if verbosity == 0:
         logger.add(
             sys.__stderr__,  # type: ignore
@@ -63,6 +67,7 @@ def logger_setup(log_file: Path | None, verbosity: int = 0):
             level="INFO",
             colorize=True,
             enqueue=True,
+            diagnose=False,
         )
     else:
         logger.add(
@@ -71,6 +76,7 @@ def logger_setup(log_file: Path | None, verbosity: int = 0):
             level="DEBUG",
             colorize=True,
             enqueue=True,
+            diagnose=False,
         )
     if log_file:
         rotate_once = _once_then_never()
@@ -80,6 +86,7 @@ def logger_setup(log_file: Path | None, verbosity: int = 0):
             level="DEBUG" if verbosity > 0 else "INFO",
             colorize=False,
             enqueue=True,
+            diagnose=False,
             rotation=lambda _, __: next(rotate_once),
             retention=_MAX_LOG_ARCHIVES,
             compression=_zstd_compress,


### PR DESCRIPTION
## Problem

loguru's `diagnose=True` (the default) annotates tracebacks by calling `repr()` on every local variable in every frame. On the MLX CUDA backend, `repr()` of some device objects can segfault the interpreter *while the exception is being logged*.

The result is that the real error never reaches the log — the runner dies with an opaque `signal 11` instead. I hit this while validating a heterogeneous Metal + CUDA cluster: a straightforward missing-`CUDA_HOME` error surfaced as an unexplained SIGSEGV, and the actual message was only recoverable by disabling diagnose.

This is a diagnosability trap: it corrupts exactly the information you need at exactly the moment you need it, and the more unusual the failure, the more likely the locals are to be unreprable.

## Fix

Pass `diagnose=False` on all three sinks in `logger_setup`.

Variable inspection is a debugging nicety; tracebacks (`backtrace=True`) are unaffected and still show the full call chain. Nothing else changes.
