### PR TITLE
fix: auto-detect CUDA_HOME from bundled nvidia headers on Linux

### DIFF
--- a/src/exo/worker/runner/bootstrap.py
+++ b/src/exo/worker/runner/bootstrap.py
@@ -1,7 +1,10 @@
+import importlib.util
 import os
 import resource
+import sys
 import traceback
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Self, cast
 
 import loguru
@@ -37,6 +40,30 @@ class RunnerTerminationError:
         return f"{self.exception_type}: {self.exception_message}\n{self.traceback}"
 
 
+def _ensure_cuda_home() -> None:
+    """Point MLX's CUDA backend at bundled CUDA headers when none are configured.
+
+    MLX on CUDA JIT-compiles kernels with NVRTC at runtime (the first
+    distributed send/recv triggers this) and fails with "Can not find
+    locations of CUDA headers" unless CUDA_HOME or CUDA_PATH is set. The pip
+    `nvidia-cuda-runtime` package ships the headers but nothing exports their
+    location, so resolve them from the `nvidia` namespace package.
+    """
+    if sys.platform != "linux":
+        return
+    if os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH"):
+        return
+    specification = importlib.util.find_spec("nvidia")
+    if specification is None or not specification.submodule_search_locations:
+        return
+    for location in specification.submodule_search_locations:
+        candidate = Path(location) / "cuda_runtime"
+        if (candidate / "include").is_dir():
+            os.environ["CUDA_HOME"] = str(candidate)
+            logger.info(f"CUDA_HOME unset; using bundled CUDA headers at {candidate}")
+            return
+
+
 def entrypoint(
     bound_instance: BoundInstance,
     event_sender: MpSender[Event | RunnerTerminationError],
@@ -46,6 +73,8 @@ def entrypoint(
 ) -> None:
     global logger
     logger = _logger
+
+    _ensure_cuda_home()
 
     soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
     resource.setrlimit(resource.RLIMIT_NOFILE, (min(max(soft, 2048), hard), hard))

--- a/src/exo/worker/tests/unittests/test_runner/test_cuda_home.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_cuda_home.py
@@ -1,0 +1,66 @@
+import importlib.machinery
+from pathlib import Path
+
+import pytest
+
+import exo.worker.runner.bootstrap as bootstrap
+from exo.worker.runner.bootstrap import (
+    _ensure_cuda_home,  # pyright: ignore[reportPrivateUsage]
+)
+
+
+@pytest.fixture
+def cuda_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)
+
+
+def _fake_nvidia_spec(base: Path) -> importlib.machinery.ModuleSpec:
+    spec = importlib.machinery.ModuleSpec("nvidia", None, is_package=True)
+    spec.submodule_search_locations = [str(base)]
+    return spec
+
+
+def test_noop_off_linux(
+    cuda_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(bootstrap.sys, "platform", "darwin")
+    _ensure_cuda_home()
+    assert "CUDA_HOME" not in bootstrap.os.environ
+
+
+def test_respects_existing_configuration(
+    cuda_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(bootstrap.sys, "platform", "linux")
+    monkeypatch.setenv("CUDA_PATH", "/opt/cuda")
+    _ensure_cuda_home()
+    assert "CUDA_HOME" not in bootstrap.os.environ
+
+
+def test_sets_cuda_home_from_nvidia_package(
+    cuda_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    include_dir = tmp_path / "cuda_runtime" / "include"
+    include_dir.mkdir(parents=True)
+
+    def fake_find_spec(name: str) -> importlib.machinery.ModuleSpec | None:
+        return _fake_nvidia_spec(tmp_path) if name == "nvidia" else None
+
+    monkeypatch.setattr(bootstrap.sys, "platform", "linux")
+    monkeypatch.setattr(bootstrap.importlib.util, "find_spec", fake_find_spec)
+    _ensure_cuda_home()
+    assert bootstrap.os.environ["CUDA_HOME"] == str(tmp_path / "cuda_runtime")
+    monkeypatch.delenv("CUDA_HOME")
+
+
+def test_noop_without_headers(
+    cuda_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_find_spec(name: str) -> importlib.machinery.ModuleSpec | None:
+        return _fake_nvidia_spec(tmp_path) if name == "nvidia" else None
+
+    monkeypatch.setattr(bootstrap.sys, "platform", "linux")
+    monkeypatch.setattr(bootstrap.importlib.util, "find_spec", fake_find_spec)
+    _ensure_cuda_home()
+    assert "CUDA_HOME" not in bootstrap.os.environ


### PR DESCRIPTION
## Problem

MLX's CUDA backend JIT-compiles kernels with NVRTC at runtime, and NVRTC needs the CUDA headers. If neither `CUDA_HOME` nor `CUDA_PATH` is set, compilation fails with:

```
Can not find locations of CUDA headers
```

On a pip-installed Linux CUDA setup the headers *are* present — `nvidia-cuda-runtime` ships them under the `nvidia` namespace package — but nothing exports their location, so MLX can't find them.

The failure is badly timed: it doesn't happen at model load, but at the first NVRTC-compiled kernel. In my case that was the distributed send in ring prefill, so a node came up healthy, loaded weights, and only died once inference actually started.

## Fix

In the runner bootstrap, when neither variable is set and we're on Linux, resolve the bundled headers from the `nvidia` namespace package and set `CUDA_HOME`.

```python
specification = importlib.util.find_spec("nvidia")
...
candidate = Path(location) / "cuda_runtime"
if (candidate / "include").is_dir():
    os.environ["CUDA_HOME"] = str(candidate)
```

Deliberately conservative:

- **No-op unless Linux.** Returns immediately on darwin.
- **Never overrides an existing setting.** A system CUDA install or an explicit `CUDA_HOME`/`CUDA_PATH` wins.
- **Never guesses.** Only sets the variable if the `include/` directory actually exists.

So a machine with a working CUDA toolchain is unaffected; this only fills in the gap for pip-provided CUDA.

## Tests

`src/exo/worker/tests/unittests/test_runner/test_cuda_home.py` covers the detection, the non-Linux skip, the existing-value skip, and the missing-headers case.

## Note on overlap

#2103 and #2129 also touch `bootstrap.py`, but only the `MLX_METAL_FAST_SYNCH` block — neither sets `CUDA_HOME`. Different hunk, no functional overlap; happy to rebase behind either if they land first.
