### PR TITLE
fix(mlx): reject image input when the runner has no vision processor

### DIFF
--- a/src/exo/api/adapters/chat_completions.py
+++ b/src/exo/api/adapters/chat_completions.py
@@ -353,7 +353,17 @@ async def collect_chat_response(
                 finish_reason = chunk.finish_reason
 
     if error_message is not None:
-        raise ValueError(error_message)
+        # The endpoint wraps this generator in a StreamingResponse, so the 200
+        # status is already on the wire; raising here only truncates the body
+        # to nothing. Emit the same error object the SSE path sends instead.
+        yield ErrorResponse(
+            error=ErrorInfo(
+                message=error_message,
+                type="InternalServerError",
+                code=500,
+            )
+        ).model_dump_json(exclude_none=True)
+        return
 
     combined_text = "".join(text_parts)
     combined_thinking = "".join(thinking_parts) if thinking_parts else None

--- a/src/exo/api/tests/test_collect_chat_response_error.py
+++ b/src/exo/api/tests/test_collect_chat_response_error.py
@@ -1,7 +1,7 @@
-import json
 from collections.abc import AsyncGenerator
 
 from exo.api.adapters.chat_completions import collect_chat_response
+from exo.api.types import ErrorResponse
 from exo.shared.types.chunks import (
     ErrorChunk,
     PrefillProgressChunk,
@@ -35,6 +35,6 @@ async def test_error_chunk_yields_error_body_instead_of_raising() -> None:
         item async for item in collect_chat_response(CommandId("cmd"), _stream(error))
     ]
     assert len(items) == 1
-    body = json.loads(items[0])
-    assert body["error"]["message"] == "image input is not supported here"
-    assert body["error"]["code"] == 500
+    body = ErrorResponse.model_validate_json(items[0])
+    assert body.error.message == "image input is not supported here"
+    assert body.error.code == 500

--- a/src/exo/api/tests/test_collect_chat_response_error.py
+++ b/src/exo/api/tests/test_collect_chat_response_error.py
@@ -1,0 +1,40 @@
+import json
+from collections.abc import AsyncGenerator
+
+from exo.api.adapters.chat_completions import collect_chat_response
+from exo.shared.types.chunks import (
+    ErrorChunk,
+    PrefillProgressChunk,
+    TokenChunk,
+    ToolCallChunk,
+)
+from exo.shared.types.common import CommandId, ModelId
+
+
+async def _stream(
+    *chunks: ErrorChunk | ToolCallChunk | TokenChunk | PrefillProgressChunk,
+) -> AsyncGenerator[
+    ErrorChunk | ToolCallChunk | TokenChunk | PrefillProgressChunk, None
+]:
+    for chunk in chunks:
+        yield chunk
+
+
+async def test_error_chunk_yields_error_body_instead_of_raising() -> None:
+    """A request rejected before the first token must still produce a body.
+
+    The non-streaming endpoint wraps this generator in a StreamingResponse, so
+    an exception here would leave the client with an empty HTTP 200.
+    """
+    error = ErrorChunk(
+        model=ModelId("test/model"),
+        finish_reason="error",
+        error_message="image input is not supported here",
+    )
+    items = [
+        item async for item in collect_chat_response(CommandId("cmd"), _stream(error))
+    ]
+    assert len(items) == 1
+    body = json.loads(items[0])
+    assert body["error"]["message"] == "image input is not supported here"
+    assert body["error"]["code"] == 500

--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -90,6 +90,34 @@ class _EngineTask:
     last_gen_token_time: float | None = None
 
 
+class UnsupportedRequestError(ValueError):
+    """The request asks for something this runner cannot serve.
+
+    Raised for request-level problems, such as image input on an instance that
+    has no vision processor. Only this request fails; the runner stays up and
+    the client gets an error instead of a silently wrong answer.
+    """
+
+
+def check_vision_support(
+    task_params: TextGenerationTaskParams,
+    vision_processor: VisionProcessor | None,
+) -> None:
+    """Refuse image input when nothing can process it.
+
+    The vision processor is None when the model has none, or when loading it
+    failed and load_mlx_items disabled vision for this runner. Dropping the
+    images would leave a bare image placeholder in the prompt, and the model
+    would answer confidently about an image it never saw.
+    """
+    if task_params.images and vision_processor is None:
+        raise UnsupportedRequestError(
+            f"{len(task_params.images)} image(s) were provided, but this model "
+            "instance has no vision processor loaded; image input is not "
+            "supported here."
+        )
+
+
 @dataclass(eq=False)
 class ExoBatchGenerator:
     model: Model
@@ -134,6 +162,8 @@ class ExoBatchGenerator:
         vision: VisionResult | None = None
         media_regions: list[MediaRegion] = []
 
+        check_vision_support(task_params, self.vision_processor)
+
         if self.vision_processor is not None:
             try:
                 vision = prepare_vision(
@@ -145,7 +175,13 @@ class ExoBatchGenerator:
                     model_id=task_params.model,
                     task_params=task_params,
                 )
-            except Exception:
+            except Exception as e:
+                if task_params.images:
+                    # The user sent images; answering without them is wrong,
+                    # not a fallback.
+                    raise UnsupportedRequestError(
+                        f"Vision processing failed for this request: {e}"
+                    ) from e
                 logger.opt(exception=True).warning(
                     "Vision processing failed, falling back to text-only"
                 )

--- a/src/exo/worker/engines/mlx/tests/test_vision_gate.py
+++ b/src/exo/worker/engines/mlx/tests/test_vision_gate.py
@@ -1,0 +1,37 @@
+from exo.shared.types.common import ModelId
+from exo.shared.types.text_generation import (
+    Base64Image,
+    InputMessage,
+    InputMessageContent,
+    TextGenerationTaskParams,
+)
+from exo.worker.engines.mlx.generator.batch_generate import (
+    UnsupportedRequestError,
+    check_vision_support,
+)
+
+
+def _params(images: list[Base64Image]) -> TextGenerationTaskParams:
+    return TextGenerationTaskParams(
+        model=ModelId("test/model"),
+        input=[InputMessage(role="user", content=InputMessageContent("hi"))],
+        images=images,
+    )
+
+
+def test_images_without_vision_processor_are_rejected() -> None:
+    try:
+        check_vision_support(_params([Base64Image("data:image/png;base64,AAAA")]), None)
+    except UnsupportedRequestError as e:
+        assert "vision processor" in str(e)
+    else:
+        raise AssertionError("expected UnsupportedRequestError")
+
+
+def test_text_only_request_passes_without_vision_processor() -> None:
+    check_vision_support(_params([]), None)
+
+
+def test_unsupported_request_error_is_a_value_error() -> None:
+    # Callers that already handle ValueError keep working.
+    assert issubclass(UnsupportedRequestError, ValueError)

--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -30,7 +30,10 @@ from exo.worker.engines.base import Engine
 from exo.worker.engines.mlx.cache import KVPrefixCache
 from exo.worker.engines.mlx.disaggregated.adapter import write_cache_to_wire
 from exo.worker.engines.mlx.disaggregated.serve import run_prefill_for_request
-from exo.worker.engines.mlx.generator.batch_generate import ExoBatchGenerator
+from exo.worker.engines.mlx.generator.batch_generate import (
+    ExoBatchGenerator,
+    UnsupportedRequestError,
+)
 from exo.worker.engines.mlx.generator.generate import (
     PrefillCancelled,
     mlx_generate,
@@ -411,6 +414,12 @@ class BatchGenerator(Engine):
             try:
                 uid = self._start_task(task)
             except PrefillCancelled:
+                continue
+            except UnsupportedRequestError as e:
+                # A request this runner cannot serve (e.g. images without a
+                # vision processor). Tell the client and move on; the runner
+                # itself is healthy.
+                self._send_error(task, e)
                 continue
             except Exception as e:
                 self._send_error(task, e)

--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -409,6 +409,7 @@ class BatchGenerator(Engine):
             self.agree_on_tasks()
 
         # Submit any queued tasks to the engine
+        rejected: list[tuple[TaskId, FinishedResponse]] = []
         while self._queue and len(self._active_tasks) < EXO_MAX_CONCURRENT_REQUESTS:
             task = self._queue.popleft()
             try:
@@ -417,9 +418,11 @@ class BatchGenerator(Engine):
                 continue
             except UnsupportedRequestError as e:
                 # A request this runner cannot serve (e.g. images without a
-                # vision processor). Tell the client and move on; the runner
-                # itself is healthy.
+                # vision processor). Tell the client, then retire the task so
+                # the runner returns to idle -- without a terminal result the
+                # task would stay in active_tasks and step() would spin.
                 self._send_error(task, e)
+                rejected.append((task.task_id, FinishedResponse()))
                 continue
             except Exception as e:
                 self._send_error(task, e)
@@ -443,7 +446,7 @@ class BatchGenerator(Engine):
             self._active_tasks[uid] = (task, queue, output_generator)
 
         if not self._gen.has_work:
-            return self._apply_cancellations()
+            return itertools.chain(rejected, self._apply_cancellations())
 
         results = self._gen.step()
 
@@ -471,7 +474,7 @@ class BatchGenerator(Engine):
             lambda chunk: (
                 not isinstance(chunk[1], GenerationChunk) or self.device_rank == 0
             ),
-            itertools.chain(output, self._apply_cancellations()),
+            itertools.chain(rejected, output, self._apply_cancellations()),
         )
 
     def _apply_cancellations(


### PR DESCRIPTION
## Bug

A chat request with an image against a runner whose vision processor is `None` succeeds silently and returns a hallucinated answer.

Reproduced with a solid **red** 8×8 PNG on a 4-node pipeline deployment: `HTTP 200`, content `"Black"`. The runner log shows the prompt it actually ran ended in `<|begin_of_image|><|image|><|end_of_image|>` — one bare placeholder token, no vision embeddings.

Three things line up to make it silent:

1. `utils_mlx.load_mlx_items` catches any vision-processor load failure, logs it, and sets `vision_processor = None` (`utils_mlx.py:221-227`).
2. `ExoBatchGenerator.submit` only prepares images `if self.vision_processor is not None`; otherwise they are dropped (`batch_generate.py:137`), and a `prepare_vision` exception also "falls back to text-only".
3. The chat template still renders the image placeholder, so the model sees an image token with nothing behind it.

Nothing in the API gates on a vision capability, so the client has no way to know.

## Fix

- `check_vision_support()` raises a request-level `UnsupportedRequestError(ValueError)` when `task_params.images` is non-empty and there is no processor; `submit()` calls it first, and a `prepare_vision` failure on a request *with* images now raises the same error instead of silently degrading. The text-only fallback is kept for requests without images.
- `BatchGenerator.step()` catches `UnsupportedRequestError` next to `PrefillCancelled`: `_send_error` to the client, then **emit a terminal `FinishedResponse` for the task** on both return paths of `step()`. The runner registers a task in `active_tasks` before `step()` runs, so without that terminal result the rejected task would stay active with no generator behind it and the runner loop would spin (I hit exactly that with a first version: four runners stuck in `RunnerRunning` at ~85% CPU with nothing in flight). The generic `except Exception` still re-raises, so runner-fatal errors behave as before.

- `collect_chat_response()` (non-streaming) now **yields the same `{"error": …}` JSON object** the SSE path emits instead of raising. The endpoint wraps it in a `StreamingResponse` whose 200 status is already committed, so the old `raise ValueError` left non-streaming clients with an empty body for any `ErrorChunk` that arrived before the first token — a pre-existing gap this bug made visible. Covered by `test_collect_chat_response_error.py`; the existing `test_chat_completions_stream.py` still passes.

The condition is identical on every rank (same images, same `None`), so all pipeline ranks reject and retire the task together and none is left waiting in a collective.

## Tests

`test_vision_gate.py` — three pure tests, no model download: images + no processor raises with a clear message; text-only passes; the error is a `ValueError` so existing handlers keep working. `ruff check`, `ruff format --check`, `basedpyright` clean on the changed files.

## Scope

Covers the default `BatchGenerator` path. `SequentialGenerator` builds its generator separately (`batch_generator.py:300`) and is not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
