### PR TITLE
fix(utils): stop retrying SIGKILL forever on an unkillable child process

### DIFF
--- a/src/exo/utils/async_process.py
+++ b/src/exo/utils/async_process.py
@@ -34,6 +34,10 @@ _TERMINATE_GRACE_SECONDS = 5.0
 _TERMINATE_RETRY_GRACE_SECONDS = 2.0
 _TERMINATE_ATTEMPTS = 10
 _KILL_GRACE_SECONDS = 2.0
+# A child stuck in an uninterruptible kernel wait ignores SIGKILL until the wait
+# returns, which may be never. Give up after this many attempts rather than
+# holding the owner's shutdown open indefinitely.
+_KILL_ATTEMPTS = 5
 
 
 @final
@@ -232,15 +236,23 @@ class AsyncProcess:
                     return
 
             logger.critical("Child process didn't respond to SIGTERM, killing")
-            j = 0
-            while True:
+            for attempt in range(1, _KILL_ATTEMPTS + 1):
                 process.kill()
                 with move_on_after(_KILL_GRACE_SECONDS):
                     await self.wait()
-                j += 1
                 if self.exitcode is not None or not process.is_alive():
-                    break
-            logger.warning(f"That took {j} attempts :(")
+                    logger.warning(f"That took {attempt} attempts :(")
+                    return
+
+            # SIGKILL cannot be delivered to a process blocked in an
+            # uninterruptible kernel wait (ps state "U"); looping forever here
+            # kept the owner's shutdown -- and everything awaiting it -- stuck
+            # until the daemon was restarted by hand. Leave the child to the
+            # kernel and let the owner carry on.
+            logger.critical(
+                f"Child process {self._pid} ignored SIGKILL {_KILL_ATTEMPTS} times "
+                "(uninterruptible wait); giving up and leaving it orphaned"
+            )
 
 
 # Spawn-mode multiprocessing requires a module-level target that can be pickled.

--- a/src/exo/utils/tests/test_unkillable_child.py
+++ b/src/exo/utils/tests/test_unkillable_child.py
@@ -1,0 +1,58 @@
+from multiprocessing.process import BaseProcess
+from typing import cast
+
+import pytest
+from anyio import fail_after
+
+from exo.utils import async_process
+from exo.utils.async_process import AsyncProcess
+
+
+class _UnkillableChild:
+    """Stands in for a process blocked in an uninterruptible kernel wait."""
+
+    def __init__(self) -> None:
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.exitcode = None
+        self.pid = 4242
+
+    def is_alive(self) -> bool:
+        return True
+
+    def join(self, timeout: float | None = None) -> None:
+        return None
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+
+    def close(self) -> None:
+        raise ValueError("cannot close a running process")
+
+
+async def test_terminate_gives_up_on_unkillable_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Shrink every grace period so the escalation runs in well under a second.
+    for name in (
+        "_JOIN_GRACE_SECONDS",
+        "_TERMINATE_GRACE_SECONDS",
+        "_TERMINATE_RETRY_GRACE_SECONDS",
+        "_KILL_GRACE_SECONDS",
+    ):
+        monkeypatch.setattr(async_process, name, 0.01)
+
+    child = _UnkillableChild()
+    process = AsyncProcess()
+    process._process = cast(BaseProcess, cast(object, child))  # pyright: ignore[reportPrivateUsage]
+    process._pid = child.pid  # pyright: ignore[reportPrivateUsage]
+    process._started.set()  # pyright: ignore[reportPrivateUsage]
+
+    with fail_after(10):
+        await process._terminate_if_still_alive()  # pyright: ignore[reportPrivateUsage]
+
+    assert child.kill_calls == async_process._KILL_ATTEMPTS  # pyright: ignore[reportPrivateUsage]
+    assert child.terminate_calls == async_process._TERMINATE_ATTEMPTS  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
## Bug

`AsyncProcess._terminate_if_still_alive()` escalates join → SIGTERM ×10 → SIGKILL, and the SIGKILL phase is an unbounded loop:

```python
while True:
    process.kill()
    with move_on_after(_KILL_GRACE_SECONDS):
        await self.wait()
    if self.exitcode is not None or not process.is_alive():
        break
```

A child blocked in an uninterruptible kernel wait (`ps` state `U`) does not receive SIGKILL until that wait returns — which may be never. `is_alive()` then stays true and the loop has no exit, so whatever awaits the owner's shutdown never completes.

## How it was hit

On a 4-node pipeline deployment (v1.0.71), deleting two `MlxJaccl` instances of the same model back-to-back left every node's runner in state `U`. The supervisor logged

```
Runner process didn't respond to SIGTERM, killing
That took 1 attempts :( … That took 26 attempts :(     (one line every 5 s, indefinitely)
```

and because that loop ran inside the worker's `Shutdown` plan, the node's event loop stalled and the HTTP API stopped accepting connections until the daemons were restarted by hand. The equivalent code on `main` is async (the API would survive) but still never returns, so the owner's shutdown never finishes.

## Fix

Bound the SIGKILL phase to `_KILL_ATTEMPTS = 5`; on success log as before, otherwise log `CRITICAL` with the pid and return, leaving the child to the kernel. `run()` already wraps `process.close()` in `suppress(ValueError)`, so a still-alive child is tolerated on the way out.

## Test

`test_unkillable_child.py` drives the full escalation against a fake child that ignores every signal, with the grace periods shortened via `monkeypatch`, and asserts the call returns after exactly `_TERMINATE_ATTEMPTS` terminates and `_KILL_ATTEMPTS` kills. Existing `test_async_process.py` unchanged and passing; `ruff`, `ruff format --check`, `basedpyright` clean.

## Not addressed here

Why the runners became unkillable (most likely two JACCL/RDMA groups tearing down on the same devices at once) — I could not reproduce that on demand, only the supervisor's behaviour once it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)