### PR TITLE
fix: skip None entries when applying per-request logits processors

### DIFF
--- a/src/exo/worker/engines/mlx/patches/opt_batch_gen.py
+++ b/src/exo/worker/engines/mlx/patches/opt_batch_gen.py
@@ -71,7 +71,7 @@ def _patched_step(self: GenerationBatch) -> tuple[list[int], list[mx.array]]:
         processed_logits: list[mx.array] = []
         for e in range(len(self.uids)):
             sample_logits = logits[e : e + 1]
-            for processor in self.logits_processors[e]:
+            for processor in self.logits_processors[e] or []:
                 sample_logits = processor(mx.array(self.tokens[e]), sample_logits)
             processed_logits.append(sample_logits)
         logits = mx.concatenate(processed_logits, axis=0)

--- a/src/exo/worker/engines/mlx/patches/opt_batch_gen.py
+++ b/src/exo/worker/engines/mlx/patches/opt_batch_gen.py
@@ -71,7 +71,7 @@ def _patched_step(self: GenerationBatch) -> tuple[list[int], list[mx.array]]:
         processed_logits: list[mx.array] = []
         for e in range(len(self.uids)):
             sample_logits = logits[e : e + 1]
-            for processor in self.logits_processors[e] or []:
+            for processor in self.logits_processors[e] or ():
                 sample_logits = processor(mx.array(self.tokens[e]), sample_logits)
             processed_logits.append(sample_logits)
         logits = mx.concatenate(processed_logits, axis=0)

--- a/src/exo/worker/engines/mlx/tests/test_opt_batch_gen.py
+++ b/src/exo/worker/engines/mlx/tests/test_opt_batch_gen.py
@@ -1,0 +1,58 @@
+# type: ignore
+"""Per-entry logits processors in the patched batch step.
+
+``GenerationBatch`` normalizes the processor list to ``[None] * len(uids)`` when a
+merged-in batch brings none of its own, so a batch that mixes a request with
+penalties and one without holds ``None`` next to a real processor list.
+"""
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from exo.worker.engines.mlx.patches.opt_batch_gen import _patched_step
+
+VOCAB = 8
+
+
+def _boost(token_id: int):
+    """Logits processor that makes ``token_id`` the argmax for its row."""
+
+    def processor(tokens: mx.array, logits: mx.array) -> mx.array:
+        bias = mx.zeros(logits.shape)
+        bias[:, token_id] = 1.0
+        return logits + bias
+
+    return processor
+
+
+def _batch(logits_processors) -> SimpleNamespace:
+    """Two-request batch over flat logits, so the argmax is entirely processor-driven."""
+    logits = mx.zeros((2, 1, VOCAB))
+    return SimpleNamespace(
+        model=lambda inputs, cache=None: logits,
+        prompt_cache=None,
+        uids=[0, 1],
+        tokens=[[1, 2], [3, 4]],
+        logits_processors=logits_processors,
+        samplers=None,
+        fallback_sampler=lambda logprobs: mx.argmax(logprobs, axis=-1),
+        _next_tokens=mx.array([1, 3]),
+        _next_logprobs=[],
+    )
+
+
+def test_step_skips_none_entries_and_applies_the_rest() -> None:
+    batch = _batch([None, [_boost(5)]])
+
+    _patched_step(batch)
+
+    assert batch._next_tokens.tolist() == [0, 5]
+
+
+def test_step_handles_an_all_none_processor_list() -> None:
+    batch = _batch([None, None])
+
+    _patched_step(batch)
+
+    assert batch._next_tokens.tolist() == [0, 0]


### PR DESCRIPTION
`_patched_step` raises `TypeError: 'NoneType' object is not iterable` when a decode batch mixes a request that sets sampling penalties with one that sets none.

`GenerationBatch` normalizes its processor list to `[None] * len(uids)` when a merged-in batch brings none of its own, so the list can hold `None` next to a real processor list. The guard is `any(self.logits_processors)`, which passes on the populated entry, and the loop then iterates every entry including the `None` ones.

The exception escapes into the runner process, so it takes down every request in flight rather than just the one that hit it. Those streams close with no tokens and no usage, which reaches callers as an empty completion instead of an error, and it only shows up under concurrency, which makes it look intermittent.

`self.samplers[e] or self.fallback_sampler` a few lines below already handles the same shape. This does the same for processors.

The added test reproduces the TypeError on current main and checks that the surviving processor still applies to the right row.