### PR TITLE
feat: place pipeline shards by measured bandwidth and latency

### DIFF
--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -378,6 +378,7 @@ class Master:
                                 self.state.node_backends,
                                 download_status=self.state.downloads,
                                 node_rdma_ctl=self.state.node_rdma_ctl,
+                                node_bandwidth=self.state.node_bandwidth,
                             )
                             transition_events = get_transition_events(
                                 self.state.instances, placement, self.state.tasks

--- a/src/exo/master/placement.py
+++ b/src/exo/master/placement.py
@@ -4,6 +4,7 @@ from typing import Sequence
 
 from exo.master.placement_utils import (
     Cycle,
+    estimate_token_seconds,
     filter_cycles_by_memory,
     get_mlx_jaccl_coordinators,
     get_mlx_jaccl_devices_matrix,
@@ -29,7 +30,12 @@ from exo.shared.types.events import (
     TaskStatusUpdated,
 )
 from exo.shared.types.memory import Memory
-from exo.shared.types.profiling import MemoryUsage, NodeNetworkInfo, NodeRdmaCtlStatus
+from exo.shared.types.profiling import (
+    MemoryUsage,
+    NodeBandwidth,
+    NodeNetworkInfo,
+    NodeRdmaCtlStatus,
+)
 from exo.shared.types.tasks import Task, TaskId, TaskStatus
 from exo.shared.types.worker.downloads import (
     DownloadCompleted,
@@ -45,6 +51,7 @@ from exo.shared.types.worker.instances import (
     MlxJacclInstance,
     MlxRingInstance,
 )
+from exo.shared.types.worker.runners import ShardAssignments
 from exo.shared.types.worker.shards import Sharding
 from exo.utils.ports import random_ephemeral_port
 
@@ -103,77 +110,65 @@ def _cycle_download_score(
     )
 
 
-def place_instance(
+def _filter_cycles_for_sharding(
     command: PlaceInstance,
-    topology: Topology,
-    current_instances: Mapping[InstanceId, Instance],
-    node_memory: Mapping[NodeId, MemoryUsage],
-    node_network: Mapping[NodeId, NodeNetworkInfo],
-    node_backends: Mapping[NodeId, list[Backend]],
-    required_nodes: set[NodeId] | None = None,
-    download_status: Mapping[NodeId, Sequence[DownloadProgress]] | None = None,
-    node_rdma_ctl: Mapping[NodeId, NodeRdmaCtlStatus] | None = None,
-) -> dict[InstanceId, Instance]:
-    cycles = topology.get_cycles()
-    candidate_cycles = list(filter(lambda it: len(it) >= command.min_nodes, cycles))
+    cycles: list[Cycle],
+) -> list[Cycle]:
+    """Keep cycles whose width is compatible with the requested sharding.
 
-    # Filter to cycles containing all required nodes (subset matching)
-    if required_nodes:
-        candidate_cycles = [
-            cycle
-            for cycle in candidate_cycles
-            if required_nodes.issubset(cycle.node_ids)
-        ]
-    cycles_with_sufficient_memory = filter_cycles_by_memory(
-        candidate_cycles, node_memory, command.model_card.storage_size
-    )
-    if len(cycles_with_sufficient_memory) == 0:
-        raise ValueError("No cycles found with sufficient memory")
+    Raises if the model cannot be sharded this way at all, or if no candidate
+    cycle has a compatible width.
+    """
+    model_card = command.model_card
 
     if command.sharding == Sharding.Tensor:
-        if not command.model_card.supports_tensor:
+        if not model_card.supports_tensor:
             raise ValueError(
-                f"Requested Tensor sharding but this model does not support tensor parallelism: {command.model_card.model_id}"
+                f"Requested Tensor sharding but this model does not support tensor parallelism: {model_card.model_id}"
             )
         # TODO: the condition here for tensor parallel is not correct, but it works good enough for now.
         # DeepSeek V4 is MQA (num_key_value_heads=1) but its sharding strategy
         # head-parallelises wq_b/wo_a and shards MoE experts instead of splitting
         # KV heads, so the kv-head divisibility check doesn't apply.
-        is_deepseek_v4 = command.model_card.base_model.startswith("DeepSeek V4")
-        kv_heads = command.model_card.num_key_value_heads
-        cycles_with_sufficient_memory = [
+        is_deepseek_v4 = model_card.base_model.startswith("DeepSeek V4")
+        kv_heads = model_card.num_key_value_heads
+        compatible_cycles = [
             cycle
-            for cycle in cycles_with_sufficient_memory
-            if command.model_card.hidden_size % len(cycle) == 0
+            for cycle in cycles
+            if model_card.hidden_size % len(cycle) == 0
             and (is_deepseek_v4 or kv_heads is None or kv_heads % len(cycle) == 0)
         ]
-        if not cycles_with_sufficient_memory:
+        if not compatible_cycles:
             raise ValueError(
                 f"No tensor sharding found for model with "
-                f"hidden_size={command.model_card.hidden_size}"
+                f"hidden_size={model_card.hidden_size}"
                 f"{f', num_key_value_heads={kv_heads}' if kv_heads is not None else ''}"
                 f" across candidate cycles"
             )
-    if command.sharding == Sharding.Pipeline and command.model_card.model_id == ModelId(
-        "mlx-community/DeepSeek-V3.1-8bit"
-    ):
-        raise ValueError(
-            "Pipeline parallelism is not supported for DeepSeek V3.1 (8-bit)"
-        )
-    if (
-        command.sharding == Sharding.Pipeline
-        and command.model_card.base_model.startswith("Gemma 4")
-    ):
-        cycles_with_sufficient_memory = [
-            cycle for cycle in cycles_with_sufficient_memory if len(cycle) == 1
-        ]
-        if not cycles_with_sufficient_memory:
+        return compatible_cycles
+
+    if command.sharding == Sharding.Pipeline:
+        if model_card.model_id == ModelId("mlx-community/DeepSeek-V3.1-8bit"):
             raise ValueError(
-                "Pipeline parallelism is not supported for Gemma 4; use tensor parallelism instead."
+                "Pipeline parallelism is not supported for DeepSeek V3.1 (8-bit)"
             )
+        if model_card.base_model.startswith("Gemma 4"):
+            single_node_cycles = [cycle for cycle in cycles if len(cycle) == 1]
+            if not single_node_cycles:
+                raise ValueError(
+                    "Pipeline parallelism is not supported for Gemma 4; use tensor parallelism instead."
+                )
+            return single_node_cycles
 
-    smallest_cycles = get_smallest_cycles(cycles_with_sufficient_memory)
+    return cycles
 
+
+def _filter_cycles_by_backends(
+    command: PlaceInstance,
+    cycles: list[Cycle],
+    node_backends: Mapping[NodeId, list[Backend]],
+) -> list[Cycle]:
+    """Keep cycles where every node supports a backend the engine and model share."""
     required_backends = set(INSTANCE_META_BACKENDS[command.instance_meta]) & set(
         command.model_card.backends
     )
@@ -184,82 +179,139 @@ def place_instance(
             f"{command.instance_meta.value} which requires "
             f"{sorted(b.value for b in INSTANCE_META_BACKENDS[command.instance_meta])}"
         )
-    smallest_cycles = [
+
+    supported_cycles = [
         cycle
-        for cycle in smallest_cycles
+        for cycle in cycles
         if all(
             set(node_backends.get(node_id, [])) & required_backends for node_id in cycle
         )
     ]
-    if not smallest_cycles:
+    if not supported_cycles:
         raise ValueError(
             f"No cycle where every node supports a backend in "
             f"{sorted(b.value for b in required_backends)} for {command.model_card.model_id}"
         )
+    return supported_cycles
 
-    rdma_ctl_status = node_rdma_ctl or {}
 
-    def _all_rdma_ctl_enabled(cycle: Cycle) -> bool:
+def _filter_cycles_by_rdma(
+    cycles: list[Cycle],
+    topology: Topology,
+    node_rdma_ctl: Mapping[NodeId, NodeRdmaCtlStatus],
+) -> list[Cycle]:
+    """Keep cycles that are fully RDMA-connected and have rdma_ctl enabled everywhere."""
+
+    def all_rdma_ctl_enabled(cycle: Cycle) -> bool:
         return all(
-            ((status := rdma_ctl_status.get(node_id)) is not None and status.enabled)
+            ((status := node_rdma_ctl.get(node_id)) is not None and status.enabled)
             for node_id in cycle
         )
 
-    smallest_rdma_cycles = [
+    rdma_cycles = [
         cycle
-        for cycle in smallest_cycles
-        if topology.is_rdma_cycle(cycle) and _all_rdma_ctl_enabled(cycle)
+        for cycle in cycles
+        if topology.is_rdma_cycle(cycle) and all_rdma_ctl_enabled(cycle)
     ]
+    if not rdma_cycles:
+        raise ValueError(
+            "Requested RDMA (MlxJaccl) but no RDMA-connected cycles available"
+        )
+    return rdma_cycles
 
-    if command.instance_meta == InstanceMeta.MlxJaccl:
-        if not smallest_rdma_cycles:
-            raise ValueError(
-                "Requested RDMA (MlxJaccl) but no RDMA-connected cycles available"
+
+def _select_cycle(
+    command: PlaceInstance,
+    cycles: list[Cycle],
+    topology: Topology,
+    node_memory: Mapping[NodeId, MemoryUsage],
+    node_network: Mapping[NodeId, NodeNetworkInfo],
+    node_bandwidth: Mapping[NodeId, int],
+    download_status: Mapping[NodeId, Sequence[DownloadProgress]],
+) -> Cycle:
+    """Choose which of the remaining candidate cycles to place the instance on.
+
+    Fully profiled MLX ring pipeline cycles are ranked by estimated steady-state
+    token time. Operational preferences only break ties. Before profiling has
+    produced a complete candidate, retain the existing smallest-cycle behavior.
+    """
+    profiled_cycles = (
+        [
+            cycle
+            for cycle in cycles
+            if all(node_bandwidth.get(node_id, 0) > 0 for node_id in cycle)
+        ]
+        if command.sharding == Sharding.Pipeline
+        and command.instance_meta == InstanceMeta.MlxRing
+        and not command.model_card.uses_cfg
+        else []
+    )
+    cycle_estimates: list[tuple[Cycle, float]] = []
+    for cycle in profiled_cycles:
+        try:
+            estimate = estimate_token_seconds(
+                cycle,
+                command.model_card,
+                topology,
+                node_memory,
+                node_network,
+                node_bandwidth,
             )
-        smallest_cycles = smallest_rdma_cycles
+        except ValueError:
+            # Total RAM can be sufficient while an individual node cannot hold
+            # the mandatory one-layer minimum. Such a cycle is not placeable.
+            continue
+        cycle_estimates.append((cycle, estimate))
 
-    cycles_with_leaf_nodes: list[Cycle] = [
+    if cycle_estimates:
+
+        def performance_score(
+            cycle_and_estimate: tuple[Cycle, float],
+        ) -> tuple[float, bool, float, Memory]:
+            cycle, estimate = cycle_and_estimate
+            return (
+                -estimate,
+                any(topology.node_is_leaf(node_id) for node_id in cycle),
+                _cycle_download_score(
+                    cycle, command.model_card.model_id, download_status
+                ),
+                sum(
+                    (node_memory[node_id].ram_available for node_id in cycle),
+                    start=Memory(),
+                ),
+            )
+
+        return max(cycle_estimates, key=performance_score)[0]
+
+    cycles = get_smallest_cycles(cycles)
+    cycles_with_leaf_nodes = [
         cycle
-        for cycle in smallest_cycles
+        for cycle in cycles
         if any(topology.node_is_leaf(node_id) for node_id in cycle)
     ]
+    candidate_cycles = cycles_with_leaf_nodes or cycles
 
-    resolved_download_status = download_status or {}
-    candidate_cycles = (
-        cycles_with_leaf_nodes if cycles_with_leaf_nodes != [] else smallest_cycles
-    )
-
-    selected_cycle = max(
-        candidate_cycles,
-        key=lambda cycle: (
-            _cycle_download_score(
-                cycle, command.model_card.model_id, resolved_download_status
-            ),
+    def cycle_score(cycle: Cycle) -> tuple[float, Memory]:
+        return (
+            _cycle_download_score(cycle, command.model_card.model_id, download_status),
             sum(
                 (node_memory[node_id].ram_available for node_id in cycle),
                 start=Memory(),
             ),
-        ),
-    )
-
-    # Single-node: force Pipeline/Ring (Tensor and Jaccl require multi-node)
-    if len(selected_cycle) == 1:
-        command = command.model_copy(
-            update={
-                "instance_meta": InstanceMeta.MlxRing,
-                "sharding": Sharding.Pipeline,
-            }
         )
 
-    shard_assignments = get_shard_assignments(
-        command.model_card, selected_cycle, command.sharding, node_memory
-    )
+    return max(candidate_cycles, key=cycle_score)
 
-    cycle_digraph: Topology = topology.get_subgraph_from_nodes(selected_cycle.node_ids)
 
-    instance_id = InstanceId()
-    target_instances = dict(deepcopy(current_instances))
-
+def _build_instance(
+    command: PlaceInstance,
+    instance_id: InstanceId,
+    selected_cycle: Cycle,
+    cycle_digraph: Topology,
+    shard_assignments: ShardAssignments,
+    node_network: Mapping[NodeId, NodeNetworkInfo],
+) -> Instance:
+    """Construct the engine-specific instance for an already-selected cycle."""
     match command.instance_meta:
         case InstanceMeta.MlxJaccl:
             # TODO(evan): shard assignments should contain information about ranks, this is ugly
@@ -287,7 +339,7 @@ def place_instance(
                 cycle_digraph=cycle_digraph,
                 node_network=node_network,
             )
-            target_instances[instance_id] = MlxJacclInstance(
+            return MlxJacclInstance(
                 instance_id=instance_id,
                 shard_assignments=shard_assignments,
                 jaccl_devices=mlx_jaccl_devices,
@@ -301,12 +353,91 @@ def place_instance(
                 ephemeral_port=ephemeral_port,
                 node_network=node_network,
             )
-            target_instances[instance_id] = MlxRingInstance(
+            return MlxRingInstance(
                 instance_id=instance_id,
                 shard_assignments=shard_assignments,
                 hosts_by_node=hosts_by_node,
                 ephemeral_port=ephemeral_port,
             )
+
+
+def place_instance(
+    command: PlaceInstance,
+    topology: Topology,
+    current_instances: Mapping[InstanceId, Instance],
+    node_memory: Mapping[NodeId, MemoryUsage],
+    node_network: Mapping[NodeId, NodeNetworkInfo],
+    node_backends: Mapping[NodeId, list[Backend]],
+    required_nodes: set[NodeId] | None = None,
+    download_status: Mapping[NodeId, Sequence[DownloadProgress]] | None = None,
+    node_rdma_ctl: Mapping[NodeId, NodeRdmaCtlStatus] | None = None,
+    node_bandwidth: Mapping[NodeId, NodeBandwidth] | None = None,
+) -> dict[InstanceId, Instance]:
+    cycles = [
+        cycle for cycle in topology.get_cycles() if len(cycle) >= command.min_nodes
+    ]
+
+    # Filter to cycles containing all required nodes (subset matching)
+    if required_nodes:
+        cycles = [cycle for cycle in cycles if required_nodes.issubset(cycle.node_ids)]
+
+    cycles = filter_cycles_by_memory(
+        cycles, node_memory, command.model_card.storage_size
+    )
+    if not cycles:
+        raise ValueError("No cycles found with sufficient memory")
+
+    cycles = _filter_cycles_for_sharding(command, cycles)
+    cycles = _filter_cycles_by_backends(command, cycles, node_backends)
+
+    if command.instance_meta == InstanceMeta.MlxJaccl:
+        cycles = _filter_cycles_by_rdma(cycles, topology, node_rdma_ctl or {})
+
+    memory_bandwidth_by_node = (
+        {
+            node_id: bandwidth.memory_bandwidth
+            for node_id, bandwidth in node_bandwidth.items()
+        }
+        if node_bandwidth
+        else {}
+    )
+    selected_cycle = _select_cycle(
+        command,
+        cycles,
+        topology,
+        node_memory,
+        node_network,
+        memory_bandwidth_by_node,
+        download_status or {},
+    )
+
+    # Single-node: force Pipeline/Ring (Tensor and Jaccl require multi-node)
+    if len(selected_cycle) == 1:
+        command = command.model_copy(
+            update={
+                "instance_meta": InstanceMeta.MlxRing,
+                "sharding": Sharding.Pipeline,
+            }
+        )
+
+    shard_assignments = get_shard_assignments(
+        command.model_card,
+        selected_cycle,
+        command.sharding,
+        node_memory,
+        memory_bandwidth_by_node or None,
+    )
+
+    instance_id = InstanceId()
+    target_instances = dict(deepcopy(current_instances))
+    target_instances[instance_id] = _build_instance(
+        command,
+        instance_id,
+        selected_cycle,
+        topology.get_subgraph_from_nodes(selected_cycle.node_ids),
+        shard_assignments,
+        node_network,
+    )
 
     return target_instances
 

--- a/src/exo/master/placement_utils.py
+++ b/src/exo/master/placement_utils.py
@@ -6,7 +6,7 @@ from exo.shared.models.model_cards import ModelCard
 from exo.shared.topology import Topology
 from exo.shared.types.common import Host, NodeId
 from exo.shared.types.memory import Memory
-from exo.shared.types.profiling import MemoryUsage, NodeNetworkInfo
+from exo.shared.types.profiling import InterfaceType, MemoryUsage, NodeNetworkInfo
 from exo.shared.types.topology import Cycle, RDMAConnection, SocketConnection
 from exo.shared.types.worker.runners import RunnerId, ShardAssignments
 from exo.shared.types.worker.shards import (
@@ -93,19 +93,13 @@ def _compute_total_memory(
     return total_memory
 
 
-def _allocate_and_validate_layers(
+def _validate_layer_allocations(
     node_ids: list[NodeId],
     node_memory: Mapping[NodeId, MemoryUsage],
-    total_memory: Memory,
+    layer_allocations: list[int],
     model_card: ModelCard,
-) -> list[int]:
-    layer_allocations = allocate_layers_proportionally(
-        total_layers=model_card.n_layers,
-        memory_fractions=[
-            node_memory[node_id].ram_available / total_memory for node_id in node_ids
-        ],
-    )
-
+) -> None:
+    """Reject an allocation that does not fit in a node's available memory."""
     total_storage = model_card.storage_size
     total_layers = model_card.n_layers
     for i, node_id in enumerate(node_ids):
@@ -119,28 +113,142 @@ def _allocate_and_validate_layers(
                 f"but only has {available_memory.in_gb:.2f} GB available"
             )
 
+
+def _allocate_layers(
+    node_ids: list[NodeId],
+    node_memory: Mapping[NodeId, MemoryUsage],
+    model_card: ModelCard,
+    node_bandwidth: Mapping[NodeId, int] | None,
+) -> list[int]:
+    """Split the model's layers across nodes, by bandwidth where it is known.
+
+    Falls back to RAM-proportional allocation when any node is missing bandwidth
+    data, so a cluster that has not finished profiling still places instances.
+    Both paths are validated against the same memory constraint.
+    """
+    if node_bandwidth is not None and all(
+        node_id in node_bandwidth for node_id in node_ids
+    ):
+        logger.info("Using bandwidth-aware shard assignment")
+        layer_allocations = allocate_layers_by_bandwidth(
+            total_layers=model_card.n_layers,
+            bandwidths=[float(node_bandwidth[node_id]) for node_id in node_ids],
+            layer_capacities=_layer_capacities(node_ids, node_memory, model_card),
+        )
+    else:
+        if node_bandwidth:
+            logger.info(
+                "Bandwidth data missing for some nodes, "
+                "falling back to RAM-proportional assignment"
+            )
+        total_memory = _compute_total_memory(node_ids, node_memory)
+        layer_allocations = allocate_layers_proportionally(
+            total_layers=model_card.n_layers,
+            memory_fractions=[
+                node_memory[node_id].ram_available / total_memory
+                for node_id in node_ids
+            ],
+        )
+
+    _validate_layer_allocations(node_ids, node_memory, layer_allocations, model_card)
     return layer_allocations
+
+
+def _layer_capacities(
+    node_ids: list[NodeId],
+    node_memory: Mapping[NodeId, MemoryUsage],
+    model_card: ModelCard,
+) -> list[int]:
+    """Maximum layers each node can hold, using the same arithmetic as validation.
+
+    ``_validate_layer_allocations`` rejects a node when
+    ``storage_size * layers // n_layers > ram_available``, so the capacity is the
+    largest layer count that keeps that expression within budget. Deriving both
+    from the same equation means an allocation that respects these capacities
+    always passes validation.
+    """
+    storage_bytes = model_card.storage_size.in_bytes
+    if storage_bytes <= 0:
+        return [model_card.n_layers for _ in node_ids]
+
+    return [
+        (node_memory[node_id].ram_available.in_bytes * model_card.n_layers)
+        // storage_bytes
+        for node_id in node_ids
+    ]
+
+
+def allocate_layers_by_bandwidth(
+    total_layers: int,
+    bandwidths: list[float],
+    layer_capacities: list[int],
+) -> list[int]:
+    """Distribute layers proportionally to memory bandwidth, capped by capacity.
+
+    Layers are handed out one at a time to whichever node is furthest below its
+    bandwidth-proportional target and still has room, so a node that runs out of
+    memory spills onto the next-fastest node instead of stalling the allocation.
+
+    Every node receives at least one layer: a node in the cycle with no layers
+    would still sit in the ring and pay the hop cost without doing any work.
+    """
+    n = len(bandwidths)
+    if n == 0:
+        raise ValueError("Cannot allocate layers to an empty node list")
+    if total_layers < n:
+        raise ValueError(
+            f"Cannot distribute {total_layers} layers across {n} nodes "
+            "(need at least 1 layer per node)"
+        )
+
+    total_bandwidth = sum(bandwidths)
+    if total_bandwidth <= 0:
+        raise ValueError("Cannot allocate layers: total memory bandwidth is 0")
+
+    targets = [total_layers * bandwidth / total_bandwidth for bandwidth in bandwidths]
+
+    # One layer per node up front, then the rest by largest shortfall against target.
+    result = [1] * n
+    for _ in range(total_layers - n):
+        candidates = [i for i in range(n) if result[i] < layer_capacities[i]]
+        if not candidates:
+            raise ValueError(
+                f"Cannot allocate {total_layers} layers across {n} nodes: "
+                "every node is at its memory capacity"
+            )
+        # Highest bandwidth wins ties so the faster node absorbs the odd layer.
+        result[
+            max(candidates, key=lambda i: (targets[i] - result[i], bandwidths[i]))
+        ] += 1
+
+    return result
 
 
 def get_shard_assignments_for_pipeline_parallel(
     model_card: ModelCard,
     cycle: Cycle,
     node_memory: Mapping[NodeId, MemoryUsage],
+    node_bandwidth: Mapping[NodeId, int] | None = None,
 ) -> ShardAssignments:
     """Create shard assignments for pipeline parallel execution."""
     world_size = len(cycle)
     use_cfg_parallel = model_card.uses_cfg and world_size >= 2 and world_size % 2 == 0
 
     if use_cfg_parallel:
-        return _get_shard_assignments_for_cfg_parallel(model_card, cycle, node_memory)
+        return _get_shard_assignments_for_cfg_parallel(
+            model_card, cycle, node_memory, node_bandwidth
+        )
     else:
-        return _get_shard_assignments_for_pure_pipeline(model_card, cycle, node_memory)
+        return _get_shard_assignments_for_pure_pipeline(
+            model_card, cycle, node_memory, node_bandwidth
+        )
 
 
 def _get_shard_assignments_for_cfg_parallel(
     model_card: ModelCard,
     cycle: Cycle,
     node_memory: Mapping[NodeId, MemoryUsage],
+    node_bandwidth: Mapping[NodeId, int] | None = None,
 ) -> ShardAssignments:
     """Create shard assignments for CFG parallel execution.
 
@@ -157,9 +265,8 @@ def _get_shard_assignments_for_cfg_parallel(
 
     # Allocate layers for one pipeline group (both groups run the same layers)
     pipeline_node_ids = cycle.node_ids[:pipeline_world_size]
-    pipeline_memory = _compute_total_memory(pipeline_node_ids, node_memory)
-    layer_allocations = _allocate_and_validate_layers(
-        pipeline_node_ids, node_memory, pipeline_memory, model_card
+    layer_allocations = _allocate_layers(
+        pipeline_node_ids, node_memory, model_card, node_bandwidth
     )
 
     # Ring topology: group 0 ascending [0,1,2,...], group 1 descending [...,2,1,0]
@@ -204,13 +311,12 @@ def _get_shard_assignments_for_pure_pipeline(
     model_card: ModelCard,
     cycle: Cycle,
     node_memory: Mapping[NodeId, MemoryUsage],
+    node_bandwidth: Mapping[NodeId, int] | None = None,
 ) -> ShardAssignments:
     """Create shard assignments for pure pipeline execution."""
     _validate_cycle(cycle)
-    total_memory = _compute_total_memory(cycle.node_ids, node_memory)
-
-    layer_allocations = _allocate_and_validate_layers(
-        cycle.node_ids, node_memory, total_memory, model_card
+    layer_allocations = _allocate_layers(
+        cycle.node_ids, node_memory, model_card, node_bandwidth
     )
 
     runner_to_shard: dict[RunnerId, ShardMetadata] = {}
@@ -278,6 +384,7 @@ def get_shard_assignments(
     cycle: Cycle,
     sharding: Sharding,
     node_memory: Mapping[NodeId, MemoryUsage],
+    node_bandwidth: Mapping[NodeId, int] | None = None,
 ) -> ShardAssignments:
     match sharding:
         case Sharding.Pipeline:
@@ -285,6 +392,7 @@ def get_shard_assignments(
                 model_card=model_card,
                 cycle=cycle,
                 node_memory=node_memory,
+                node_bandwidth=node_bandwidth,
             )
         case Sharding.Tensor:
             return get_shard_assignments_for_tensor_parallel(
@@ -404,6 +512,97 @@ def find_ip_prioritised(
         candidate_ips,
         key=lambda ip: priority.get(ip_to_type.get(ip, "unknown"), 2),
     )
+
+
+# Fallback per-hop cost when a reachability probe has not measured the selected
+# link yet. The ordering mirrors the ring priority in find_ip_prioritised.
+LINK_SECONDS_BY_INTERFACE: dict[InterfaceType, float] = {
+    "thunderbolt": 0.0005,
+    "maybe_ethernet": 0.0010,
+    "ethernet": 0.0015,
+    "wifi": 0.0050,
+    "unknown": 0.0080,
+}
+
+
+def _hop_seconds(
+    node_id: NodeId,
+    other_node_id: NodeId,
+    topology: Topology,
+    node_network: Mapping[NodeId, NodeNetworkInfo],
+) -> float:
+    """Measured RTT for the selected ring link, or its interface fallback."""
+    ip = find_ip_prioritised(node_id, other_node_id, topology, node_network, ring=True)
+    if ip is None:
+        return LINK_SECONDS_BY_INTERFACE["unknown"]
+
+    measured_latency_ms = [
+        connection.latency_ms
+        for connection in _find_connection_ip(node_id, other_node_id, topology)
+        if connection.sink_multiaddr.ip_address == ip
+        and connection.latency_ms is not None
+    ]
+    if measured_latency_ms:
+        return min(measured_latency_ms) / 1000
+
+    other_network = node_network.get(other_node_id, NodeNetworkInfo())
+    for interface in other_network.interfaces:
+        if interface.ip_address == ip:
+            return LINK_SECONDS_BY_INTERFACE[interface.interface_type]
+    return LINK_SECONDS_BY_INTERFACE["unknown"]
+
+
+def estimate_token_seconds(
+    cycle: Cycle,
+    model_card: ModelCard,
+    topology: Topology,
+    node_memory: Mapping[NodeId, MemoryUsage],
+    node_network: Mapping[NodeId, NodeNetworkInfo],
+    node_bandwidth: Mapping[NodeId, int],
+) -> float:
+    """Estimate the time to produce one token on this cycle.
+
+    This is the objective from issue #957: the time for one token is the sum over
+    devices of the compute time ``C_i = M * (N_i / N) / B_i`` plus the latency
+    ``L_i`` of the hop to the next device.
+
+    The compute term uses the capacity-aware layer allocation that will actually
+    be assigned. This matters when a fast node cannot hold its proportional
+    share and layers spill onto slower nodes.
+
+    Hop latency uses the reachability probe's measured RTT when available and
+    falls back to the selected interface type while measurements are pending.
+    The caller only compares cycles with bandwidth measurements for every node.
+    ``M`` is taken as the model's storage size, which overstates bytes read per
+    token for MoE models by a constant factor that does not affect the ranking.
+    """
+    node_ids = cycle.node_ids
+
+    layer_allocations = _allocate_layers(
+        node_ids, node_memory, model_card, node_bandwidth
+    )
+    compute_seconds = sum(
+        model_card.storage_size.in_bytes
+        * layer_count
+        / model_card.n_layers
+        / node_bandwidth[node_id]
+        for node_id, layer_count in zip(node_ids, layer_allocations, strict=True)
+    )
+
+    # A single node still runs the ring backend, but talks to nobody.
+    hop_seconds = 0.0
+    if len(node_ids) > 1:
+        hop_seconds = sum(
+            _hop_seconds(
+                node_id,
+                node_ids[(rank + 1) % len(node_ids)],
+                topology,
+                node_network,
+            )
+            for rank, node_id in enumerate(node_ids)
+        )
+
+    return compute_seconds + hop_seconds
 
 
 def get_mlx_ring_hosts_by_node(

--- a/src/exo/master/placement_utils.py
+++ b/src/exo/master/placement_utils.py
@@ -329,11 +329,11 @@ def _find_connection_ip(
     node_i: NodeId,
     node_j: NodeId,
     cycle_digraph: Topology,
-) -> Generator[str, None, None]:
-    """Find all IP addresses that connect node i to node j."""
+) -> Generator[SocketConnection, None, None]:
+    """Find all socket connections from node i to node j."""
     for connection in cycle_digraph.get_all_connections_between(node_i, node_j):
         if isinstance(connection, SocketConnection):
-            yield connection.sink_multiaddr.ip_address
+            yield connection
 
 
 def find_ip_prioritised(
@@ -345,18 +345,37 @@ def find_ip_prioritised(
 ) -> str | None:
     """Find an IP address between nodes with prioritization.
 
-    Priority: ethernet > wifi > unknown > thunderbolt
+    Ring connections prefer the lowest measured probe latency, falling back to
+    interface type (thunderbolt first) when latency is unmeasured. RDMA
+    coordinator selection prefers ethernet.
     """
-    ips = list(_find_connection_ip(node_id, other_node_id, cycle_digraph))
-    if not ips:
+    connections = list(_find_connection_ip(node_id, other_node_id, cycle_digraph))
+    if not connections:
         return None
+    # Deduplicate in first-seen order: `min` breaks ties on iteration order, and
+    # unmeasured links all tie at infinity, so a set here would make the choice
+    # vary with hash seed between master restarts.
+    candidate_ips = list(
+        dict.fromkeys(
+            connection.sink_multiaddr.ip_address for connection in connections
+        )
+    )
+    latency_by_ip: dict[str, float] = {}
+    for connection in connections:
+        ip_address = connection.sink_multiaddr.ip_address
+        if connection.latency_ms is None:
+            continue
+        known = latency_by_ip.get(ip_address)
+        if known is None or connection.latency_ms < known:
+            latency_by_ip[ip_address] = connection.latency_ms
+
     other_network = node_network.get(other_node_id, NodeNetworkInfo())
     ip_to_type = {
         iface.ip_address: iface.interface_type for iface in other_network.interfaces
     }
 
-    # Ring should prioritise fastest connection. As a best-effort, we prioritise TB.
-    # TODO: Profile and get actual connection speeds.
+    # Ring should prioritise the fastest connection: measured latency first,
+    # then interface type as a tie-break / fallback for unmeasured links.
     if ring:
         priority = {
             "thunderbolt": 0,
@@ -365,17 +384,26 @@ def find_ip_prioritised(
             "wifi": 3,
             "unknown": 4,
         }
+        return min(
+            candidate_ips,
+            key=lambda ip: (
+                latency_by_ip.get(ip, float("inf")),
+                priority.get(ip_to_type.get(ip, "unknown"), 2),
+            ),
+        )
 
     # RDMA prefers ethernet coordinator
-    else:
-        priority = {
-            "ethernet": 0,
-            "wifi": 1,
-            "unknown": 2,
-            "maybe_ethernet": 3,
-            "thunderbolt": 4,
-        }
-    return min(ips, key=lambda ip: priority.get(ip_to_type.get(ip, "unknown"), 2))
+    priority = {
+        "ethernet": 0,
+        "wifi": 1,
+        "unknown": 2,
+        "maybe_ethernet": 3,
+        "thunderbolt": 4,
+    }
+    return min(
+        candidate_ips,
+        key=lambda ip: priority.get(ip_to_type.get(ip, "unknown"), 2),
+    )
 
 
 def get_mlx_ring_hosts_by_node(

--- a/src/exo/master/tests/test_placement.py
+++ b/src/exo/master/tests/test_placement.py
@@ -26,6 +26,7 @@ from exo.shared.types.memory import Memory
 from exo.shared.types.multiaddr import Multiaddr
 from exo.shared.types.profiling import (
     NetworkInterfaceInfo,
+    NodeBandwidth,
     NodeNetworkInfo,
     NodeRdmaCtlStatus,
 )
@@ -960,6 +961,245 @@ def test_placement_does_not_prefer_cycle_with_failed_download(
     assigned_nodes = set(instance.shard_assignments.node_to_runner.keys())
     # node_a should win on RAM tiebreaker since failed download scores 0.0
     assert assigned_nodes == {node_a}
+
+
+def test_placement_prefers_cycle_with_lower_measured_ring_latency(
+    model_card: ModelCard,
+) -> None:
+    topology = Topology()
+    fast_a, fast_b, slow_a, slow_b = (NodeId() for _ in range(4))
+
+    connections = [
+        (fast_a, fast_b, 1, 0.5),
+        (fast_b, fast_a, 2, 0.5),
+        (slow_a, slow_b, 3, 50.0),
+        (slow_b, slow_a, 4, 50.0),
+    ]
+    for source, sink, ip_suffix, latency_ms in connections:
+        topology.add_connection(
+            Connection(
+                source=source,
+                sink=sink,
+                edge=create_socket_connection(ip_suffix).model_copy(
+                    update={"latency_ms": latency_ms}
+                ),
+            )
+        )
+
+    node_memory = {
+        node_id: create_node_memory(1000)
+        for node_id in (fast_a, fast_b, slow_a, slow_b)
+    }
+    node_network = {
+        fast_a: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="bridge0",
+                    ip_address="169.254.0.2",
+                    interface_type="wifi",
+                )
+            ]
+        ),
+        fast_b: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="bridge0",
+                    ip_address="169.254.0.1",
+                    interface_type="wifi",
+                )
+            ]
+        ),
+        slow_a: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="en0",
+                    ip_address="169.254.0.4",
+                    interface_type="thunderbolt",
+                )
+            ]
+        ),
+        slow_b: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="en0",
+                    ip_address="169.254.0.3",
+                    interface_type="thunderbolt",
+                )
+            ]
+        ),
+    }
+    node_bandwidth = {
+        node_id: NodeBandwidth(memory_bandwidth=1000) for node_id in node_memory
+    }
+
+    placements = place_instance(
+        place_instance_command(
+            model_card.model_copy(update={"storage_size": Memory.from_bytes(1000)})
+        ).model_copy(update={"min_nodes": 2}),
+        topology,
+        {},
+        node_memory,
+        node_network,
+        _metal_only(node_memory),
+        node_bandwidth=node_bandwidth,
+    )
+
+    instance = next(iter(placements.values()))
+    assert set(instance.shard_assignments.node_to_runner) == {fast_a, fast_b}
+
+
+def test_placement_prefers_cycle_with_more_memory_bandwidth_than_download_progress(
+    model_card: ModelCard,
+) -> None:
+    topology = Topology()
+    slow_node = NodeId()
+    fast_node = NodeId()
+    topology.add_node(slow_node)
+    topology.add_node(fast_node)
+
+    node_memory = {
+        slow_node: create_node_memory(1000),
+        fast_node: create_node_memory(1000),
+    }
+    node_network = {
+        slow_node: create_node_network(),
+        fast_node: create_node_network(),
+    }
+    model_card = model_card.model_copy(update={"storage_size": Memory.from_bytes(500)})
+    download_status = {
+        slow_node: [
+            DownloadCompleted(
+                node_id=slow_node,
+                shard_metadata=_make_shard_metadata(model_card),
+                total=model_card.storage_size,
+            )
+        ]
+    }
+
+    placements = place_instance(
+        place_instance_command(model_card),
+        topology,
+        {},
+        node_memory,
+        node_network,
+        _metal_only(node_memory),
+        download_status=download_status,
+        node_bandwidth={
+            slow_node: NodeBandwidth(memory_bandwidth=1000),
+            fast_node: NodeBandwidth(memory_bandwidth=2000),
+        },
+    )
+
+    instance = next(iter(placements.values()))
+    assert set(instance.shard_assignments.node_to_runner) == {fast_node}
+
+
+def test_placement_compares_profiled_cycles_with_different_node_counts(
+    model_card: ModelCard,
+) -> None:
+    topology = Topology()
+    node_a, node_b, fast_low_memory_node = (NodeId() for _ in range(3))
+
+    for source, sink, ip_suffix in [
+        (node_a, node_b, 1),
+        (node_b, node_a, 2),
+        (node_b, fast_low_memory_node, 3),
+        (fast_low_memory_node, node_a, 4),
+        (fast_low_memory_node, node_b, 5),
+        (node_a, fast_low_memory_node, 6),
+    ]:
+        topology.add_connection(
+            Connection(
+                source=source,
+                sink=sink,
+                edge=create_socket_connection(ip_suffix).model_copy(
+                    update={"latency_ms": 0.1}
+                ),
+            )
+        )
+
+    node_memory = {
+        node_a: create_node_memory(500),
+        node_b: create_node_memory(500),
+        fast_low_memory_node: create_node_memory(200),
+    }
+    node_bandwidth = {
+        node_a: NodeBandwidth(memory_bandwidth=100),
+        node_b: NodeBandwidth(memory_bandwidth=100),
+        fast_low_memory_node: NodeBandwidth(memory_bandwidth=10_000),
+    }
+
+    placements = place_instance(
+        place_instance_command(
+            model_card.model_copy(
+                update={"n_layers": 10, "storage_size": Memory.from_bytes(1000)}
+            )
+        ).model_copy(update={"min_nodes": 2}),
+        topology,
+        {},
+        node_memory,
+        {node_id: create_node_network() for node_id in node_memory},
+        _metal_only(node_memory),
+        node_bandwidth=node_bandwidth,
+    )
+
+    instance = next(iter(placements.values()))
+    assert set(instance.shard_assignments.node_to_runner) == set(node_memory)
+
+
+def test_placement_scores_capacity_adjusted_layer_allocation(
+    model_card: ModelCard,
+) -> None:
+    topology = Topology()
+    constrained_fast, constrained_slow, balanced_a, balanced_b = (
+        NodeId() for _ in range(4)
+    )
+
+    for source, sink, ip_suffix in [
+        (constrained_fast, constrained_slow, 1),
+        (constrained_slow, constrained_fast, 2),
+        (balanced_a, balanced_b, 3),
+        (balanced_b, balanced_a, 4),
+    ]:
+        topology.add_connection(
+            Connection(
+                source=source,
+                sink=sink,
+                edge=create_socket_connection(ip_suffix).model_copy(
+                    update={"latency_ms": 0.1}
+                ),
+            )
+        )
+
+    node_memory = {
+        constrained_fast: create_node_memory(100),
+        constrained_slow: create_node_memory(900),
+        balanced_a: create_node_memory(500),
+        balanced_b: create_node_memory(500),
+    }
+    node_bandwidth = {
+        constrained_fast: NodeBandwidth(memory_bandwidth=10_000),
+        constrained_slow: NodeBandwidth(memory_bandwidth=100),
+        balanced_a: NodeBandwidth(memory_bandwidth=150),
+        balanced_b: NodeBandwidth(memory_bandwidth=150),
+    }
+
+    placements = place_instance(
+        place_instance_command(
+            model_card.model_copy(
+                update={"n_layers": 10, "storage_size": Memory.from_bytes(1000)}
+            )
+        ).model_copy(update={"min_nodes": 2}),
+        topology,
+        {},
+        node_memory,
+        {node_id: create_node_network() for node_id in node_memory},
+        _metal_only(node_memory),
+        node_bandwidth=node_bandwidth,
+    )
+
+    instance = next(iter(placements.values()))
+    assert set(instance.shard_assignments.node_to_runner) == {balanced_a, balanced_b}
 
 
 def test_placement_rejects_when_model_backends_disjoint_from_engine(

--- a/src/exo/master/tests/test_placement_utils.py
+++ b/src/exo/master/tests/test_placement_utils.py
@@ -3,6 +3,7 @@ import pytest
 from exo.master.placement_utils import (
     allocate_layers_proportionally,
     filter_cycles_by_memory,
+    find_ip_prioritised,
     get_mlx_jaccl_coordinators,
     get_shard_assignments,
     get_shard_assignments_for_pipeline_parallel,
@@ -17,6 +18,7 @@ from exo.shared.topology import Topology
 from exo.shared.types.backends import Backend
 from exo.shared.types.common import NodeId
 from exo.shared.types.memory import Memory
+from exo.shared.types.multiaddr import Multiaddr
 from exo.shared.types.profiling import (
     NetworkInterfaceInfo,
     NodeNetworkInfo,
@@ -689,3 +691,135 @@ class TestCfgParallelPlacement:
         # First shard starts at 0, last shard ends at 57
         assert layer_ranges[0][0] == 0
         assert layer_ranges[-1][1] == 57
+
+
+def _socket_edge(ip_address: str, latency_ms: float | None = None) -> SocketConnection:
+    return SocketConnection(
+        sink_multiaddr=Multiaddr(address=f"/ip4/{ip_address}/tcp/1234"),
+        latency_ms=latency_ms,
+    )
+
+
+def _two_node_topology_with_edges(
+    node_a: NodeId, node_b: NodeId, edges: list[SocketConnection]
+) -> Topology:
+    topology = Topology()
+    topology.add_node(node_a)
+    topology.add_node(node_b)
+    for edge in edges:
+        topology.add_connection(Connection(source=node_a, sink=node_b, edge=edge))
+    return topology
+
+
+def test_find_ip_prioritised_ring_prefers_measured_low_latency():
+    """A link with low measured latency wins even over a thunderbolt-labelled one."""
+    node_a = NodeId()
+    node_b = NodeId()
+    topology = _two_node_topology_with_edges(
+        node_a,
+        node_b,
+        [
+            _socket_edge("100.64.0.2", latency_ms=55.0),
+            _socket_edge("192.168.4.2", latency_ms=0.8),
+        ],
+    )
+    node_network = {
+        node_b: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="utun3", ip_address="100.64.0.2", interface_type="unknown"
+                ),
+                NetworkInterfaceInfo(
+                    name="bridge0",
+                    ip_address="192.168.4.2",
+                    interface_type="thunderbolt",
+                ),
+            ]
+        )
+    }
+
+    ip = find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+
+    assert ip == "192.168.4.2"
+
+
+def test_find_ip_prioritised_ring_latency_beats_interface_label():
+    """Measured latency outranks the interface-type heuristic entirely."""
+    node_a = NodeId()
+    node_b = NodeId()
+    topology = _two_node_topology_with_edges(
+        node_a,
+        node_b,
+        [
+            _socket_edge("192.168.4.2", latency_ms=55.0),
+            _socket_edge("10.0.0.2", latency_ms=1.2),
+        ],
+    )
+    node_network = {
+        node_b: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="bridge0",
+                    ip_address="192.168.4.2",
+                    interface_type="thunderbolt",
+                ),
+                NetworkInterfaceInfo(
+                    name="en0", ip_address="10.0.0.2", interface_type="wifi"
+                ),
+            ]
+        )
+    }
+
+    ip = find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+
+    assert ip == "10.0.0.2"
+
+
+def test_find_ip_prioritised_ring_falls_back_to_interface_type():
+    """Without measurements, thunderbolt-labelled links keep their priority."""
+    node_a = NodeId()
+    node_b = NodeId()
+    topology = _two_node_topology_with_edges(
+        node_a,
+        node_b,
+        [
+            _socket_edge("10.0.0.2"),
+            _socket_edge("192.168.4.2"),
+        ],
+    )
+    node_network = {
+        node_b: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="en0", ip_address="10.0.0.2", interface_type="wifi"
+                ),
+                NetworkInterfaceInfo(
+                    name="bridge0",
+                    ip_address="192.168.4.2",
+                    interface_type="thunderbolt",
+                ),
+            ]
+        )
+    }
+
+    ip = find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+
+    assert ip == "192.168.4.2"
+
+
+def test_find_ip_prioritised_measured_link_beats_unmeasured():
+    node_a = NodeId()
+    node_b = NodeId()
+    topology = _two_node_topology_with_edges(
+        node_a,
+        node_b,
+        [
+            _socket_edge("10.0.0.2", latency_ms=40.0),
+            _socket_edge("192.168.4.2"),
+        ],
+    )
+    node_network = {node_b: NodeNetworkInfo()}
+
+    ip = find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+
+    assert ip == "10.0.0.2"

--- a/src/exo/master/tests/test_placement_utils.py
+++ b/src/exo/master/tests/test_placement_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from exo.master.placement_utils import (
+    allocate_layers_by_bandwidth,
     allocate_layers_proportionally,
     filter_cycles_by_memory,
     find_ip_prioritised,
@@ -691,6 +692,287 @@ class TestCfgParallelPlacement:
         # First shard starts at 0, last shard ends at 57
         assert layer_ranges[0][0] == 0
         assert layer_ranges[-1][1] == 57
+
+
+def test_get_shard_assignments_bandwidth_aware():
+    """Test bandwidth-aware shard assignment gives more layers to faster nodes."""
+    # arrange
+    node_a_id = NodeId()
+    node_b_id = NodeId()
+    node_c_id = NodeId()
+
+    # Nodes with plenty of RAM (no memory constraint)
+    node_a_mem = create_node_memory(1024 * 1024 * 1024)
+    node_b_mem = create_node_memory(1024 * 1024 * 1024)
+    node_c_mem = create_node_memory(1024 * 1024 * 1024)
+
+    node_memory = {
+        node_a_id: node_a_mem,
+        node_b_id: node_b_mem,
+        node_c_id: node_c_mem,
+    }
+
+    # Bandwidths: A=400 GB/s (fastest), B=200 GB/s, C=100 GB/s (slowest)
+    node_bandwidth = {
+        node_a_id: 400_000_000_000,
+        node_b_id: 200_000_000_000,
+        node_c_id: 100_000_000_000,
+    }
+
+    topology = Topology()
+    topology.add_node(node_a_id)
+    topology.add_node(node_b_id)
+    topology.add_node(node_c_id)
+
+    topology.add_connection(
+        Connection(source=node_a_id, sink=node_b_id, edge=create_socket_connection(1))
+    )
+    topology.add_connection(
+        Connection(source=node_b_id, sink=node_c_id, edge=create_socket_connection(2))
+    )
+    topology.add_connection(
+        Connection(source=node_c_id, sink=node_a_id, edge=create_socket_connection(3))
+    )
+    topology.add_connection(
+        Connection(source=node_b_id, sink=node_a_id, edge=create_socket_connection(4))
+    )
+    topology.add_connection(
+        Connection(source=node_c_id, sink=node_b_id, edge=create_socket_connection(5))
+    )
+    topology.add_connection(
+        Connection(source=node_a_id, sink=node_c_id, edge=create_socket_connection(6))
+    )
+
+    model_card = ModelCard(
+        model_id=ModelId("test-model"),
+        n_layers=30,
+        storage_size=Memory.from_kb(300),  # 10KB per layer
+        hidden_size=1000,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+        backends=[Backend.MlxMetal],
+    )
+
+    cycles = topology.get_cycles()
+    selected_cycle = next(cycle for cycle in cycles if len(cycle) == 3)
+
+    # act
+    shard_assignments = get_shard_assignments(
+        model_card, selected_cycle, Sharding.Pipeline, node_memory, node_bandwidth
+    )
+
+    # assert
+    runner_id_a = shard_assignments.node_to_runner[node_a_id]
+    runner_id_b = shard_assignments.node_to_runner[node_b_id]
+    runner_id_c = shard_assignments.node_to_runner[node_c_id]
+
+    layers_a = (
+        shard_assignments.runner_to_shard[runner_id_a].end_layer
+        - shard_assignments.runner_to_shard[runner_id_a].start_layer
+    )
+    layers_b = (
+        shard_assignments.runner_to_shard[runner_id_b].end_layer
+        - shard_assignments.runner_to_shard[runner_id_b].start_layer
+    )
+    layers_c = (
+        shard_assignments.runner_to_shard[runner_id_c].end_layer
+        - shard_assignments.runner_to_shard[runner_id_c].start_layer
+    )
+
+    # Total layers preserved
+    assert layers_a + layers_b + layers_c == 30
+
+    # Bandwidth-proportional assignment with 400:200:100 GB/s (4:2:1 ratio):
+    # targets over all 30 layers are A=17.14, B=8.57, C=4.29, and layers go to
+    # the node furthest below its target until they run out: A=17, B=9, C=4.
+    # This distributes work across all nodes while favouring faster ones,
+    # minimising total pipeline time (dominated by the slowest stage).
+    assert layers_a == 17
+    assert layers_b == 9
+    assert layers_c == 4
+
+
+def test_get_shard_assignments_falls_back_without_bandwidth():
+    """Test that without bandwidth data, assignment falls back to RAM-proportional."""
+    # arrange
+    node_a_id = NodeId()
+    node_b_id = NodeId()
+
+    node_a_mem = create_node_memory(500 * 1024)  # 500KB
+    node_b_mem = create_node_memory(1000 * 1024)  # 1000KB
+
+    node_memory = {
+        node_a_id: node_a_mem,
+        node_b_id: node_b_mem,
+    }
+
+    topology = Topology()
+    topology.add_node(node_a_id)
+    topology.add_node(node_b_id)
+
+    topology.add_connection(
+        Connection(source=node_a_id, sink=node_b_id, edge=create_socket_connection(1))
+    )
+    topology.add_connection(
+        Connection(source=node_b_id, sink=node_a_id, edge=create_socket_connection(2))
+    )
+
+    model_card = ModelCard(
+        model_id=ModelId("test-model"),
+        n_layers=12,
+        storage_size=Memory.from_kb(100),
+        hidden_size=1000,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+        backends=[Backend.MlxMetal],
+    )
+
+    cycles = topology.get_cycles()
+    selected_cycle = next(cycle for cycle in cycles if len(cycle) == 2)
+
+    # act - no bandwidth data
+    shard_assignments = get_shard_assignments(
+        model_card, selected_cycle, Sharding.Pipeline, node_memory
+    )
+
+    # assert - RAM-proportional assignment (500KB:1000KB = 1:2 ratio)
+    runner_id_a = shard_assignments.node_to_runner[node_a_id]
+    runner_id_b = shard_assignments.node_to_runner[node_b_id]
+
+    layers_a = (
+        shard_assignments.runner_to_shard[runner_id_a].end_layer
+        - shard_assignments.runner_to_shard[runner_id_a].start_layer
+    )
+    layers_b = (
+        shard_assignments.runner_to_shard[runner_id_b].end_layer
+        - shard_assignments.runner_to_shard[runner_id_b].start_layer
+    )
+
+    assert layers_a + layers_b == 12
+    assert layers_a == 4
+    assert layers_b == 8
+
+
+def test_get_shard_assignments_bandwidth_aware_respects_ram_capacity():
+    """A fast node with little RAM must be capped and the excess redistributed."""
+    # arrange
+    node_a_id = NodeId()
+    node_b_id = NodeId()
+
+    # A is 4x faster but can only hold 3 of the 10 layers (100 bytes each)
+    node_a_mem = create_node_memory(300)
+    node_b_mem = create_node_memory(10_000)
+
+    node_memory = {
+        node_a_id: node_a_mem,
+        node_b_id: node_b_mem,
+    }
+
+    node_bandwidth = {
+        node_a_id: 400_000_000_000,
+        node_b_id: 100_000_000_000,
+    }
+
+    topology = Topology()
+    topology.add_node(node_a_id)
+    topology.add_node(node_b_id)
+
+    topology.add_connection(
+        Connection(source=node_a_id, sink=node_b_id, edge=create_socket_connection(1))
+    )
+    topology.add_connection(
+        Connection(source=node_b_id, sink=node_a_id, edge=create_socket_connection(2))
+    )
+
+    model_card = ModelCard(
+        model_id=ModelId("test-model"),
+        n_layers=10,
+        storage_size=Memory.from_bytes(1000),  # 100 bytes per layer
+        hidden_size=1000,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+        backends=[Backend.MlxMetal],
+    )
+
+    cycles = topology.get_cycles()
+    selected_cycle = next(cycle for cycle in cycles if len(cycle) == 2)
+
+    # act
+    shard_assignments = get_shard_assignments(
+        model_card, selected_cycle, Sharding.Pipeline, node_memory, node_bandwidth
+    )
+
+    # assert
+    runner_id_a = shard_assignments.node_to_runner[node_a_id]
+    runner_id_b = shard_assignments.node_to_runner[node_b_id]
+
+    layers_a = (
+        shard_assignments.runner_to_shard[runner_id_a].end_layer
+        - shard_assignments.runner_to_shard[runner_id_a].start_layer
+    )
+    layers_b = (
+        shard_assignments.runner_to_shard[runner_id_b].end_layer
+        - shard_assignments.runner_to_shard[runner_id_b].start_layer
+    )
+
+    # Bandwidth alone would give A 8 of 10 layers, but A's RAM fits only 3;
+    # the remainder must flow to B rather than exceeding A's capacity.
+    assert layers_a + layers_b == 10
+    assert layers_a == 3
+    assert layers_b == 7
+
+
+class TestAllocateLayersByBandwidth:
+    def test_proportional_to_bandwidth(self):
+        # 400:200:100 GB/s over 30 layers -> targets 17.14 / 8.57 / 4.29
+        assert allocate_layers_by_bandwidth(
+            30, [400.0, 200.0, 100.0], [30, 30, 30]
+        ) == [
+            17,
+            9,
+            4,
+        ]
+
+    def test_every_node_gets_at_least_one_layer(self):
+        # A node with no layers would still sit in the ring paying the hop cost.
+        result = allocate_layers_by_bandwidth(10, [1000.0, 1.0, 1.0], [10, 10, 10])
+        assert min(result) >= 1
+        assert sum(result) == 10
+
+    def test_fewer_remaining_layers_than_nodes(self):
+        # Regression: reserving one layer per node used to leave fewer layers than
+        # nodes for the proportional step, which raised ValueError.
+        assert (
+            sum(allocate_layers_by_bandwidth(4, [100.0, 100.0, 100.0], [4, 4, 4])) == 4
+        )
+
+    def test_spills_onto_slower_nodes_when_capacity_runs_out(self):
+        # Regression: redistributing a single layer across three equal-bandwidth
+        # nodes rounded every share to zero and looped forever.
+        result = allocate_layers_by_bandwidth(9, [2.0, 1.0, 1.0, 1.0], [2, 5, 5, 5])
+        assert result[0] == 2  # capped by capacity, not by bandwidth
+        assert sum(result) == 9
+
+    def test_capacity_is_never_exceeded(self):
+        result = allocate_layers_by_bandwidth(12, [800.0, 100.0, 100.0], [4, 6, 6])
+        assert result[0] <= 4
+        assert sum(result) == 12
+
+    def test_raises_when_cluster_cannot_hold_model(self):
+        with pytest.raises(ValueError, match="memory capacity"):
+            allocate_layers_by_bandwidth(30, [400.0, 200.0, 100.0], [3, 3, 3])
+
+    def test_fewer_layers_than_nodes_raises(self):
+        with pytest.raises(ValueError, match="at least 1 layer per node"):
+            allocate_layers_by_bandwidth(2, [1.0, 1.0, 1.0], [5, 5, 5])
+
+    def test_empty_node_list_raises(self):
+        with pytest.raises(ValueError, match="empty node list"):
+            allocate_layers_by_bandwidth(10, [], [])
+
+    def test_zero_total_bandwidth_raises(self):
+        with pytest.raises(ValueError, match="bandwidth is 0"):
+            allocate_layers_by_bandwidth(10, [0.0, 0.0], [10, 10])
 
 
 def _socket_edge(ip_address: str, latency_ms: float | None = None) -> SocketConnection:

--- a/src/exo/shared/apply.py
+++ b/src/exo/shared/apply.py
@@ -34,6 +34,7 @@ from exo.shared.types.events import (
 )
 from exo.shared.types.instance_link import InstanceLink, InstanceLinkId
 from exo.shared.types.profiling import (
+    NodeBandwidth,
     NodeIdentity,
     NodeNetworkInfo,
     NodeRdmaCtlStatus,
@@ -60,6 +61,7 @@ from exo.utils.info_gatherer.info_gatherer import (
     NodeBackends,
     NodeConfig,
     NodeDiskUsage,
+    NodeMemoryBandwidth,
     NodeNetworkInterfaces,
     RdmaCtlStatus,
     StaticNodeInformation,
@@ -320,6 +322,11 @@ def apply_node_timed_out(event: NodeTimedOut, state: State) -> State:
     node_rdma_ctl = {
         key: value for key, value in state.node_rdma_ctl.items() if key != event.node_id
     }
+    node_bandwidth = {
+        key: value
+        for key, value in state.node_bandwidth.items()
+        if key != event.node_id
+    }
     # Only recompute cycles if the leaving node had TB bridge enabled
     leaving_node_status = state.node_thunderbolt_bridge.get(event.node_id)
     leaving_node_had_tb_enabled = (
@@ -342,6 +349,7 @@ def apply_node_timed_out(event: NodeTimedOut, state: State) -> State:
             "node_thunderbolt": node_thunderbolt,
             "node_thunderbolt_bridge": node_thunderbolt_bridge,
             "node_rdma_ctl": node_rdma_ctl,
+            "node_bandwidth": node_bandwidth,
             "thunderbolt_bridge_cycles": thunderbolt_bridge_cycles,
         }
     )
@@ -465,6 +473,11 @@ def apply_node_gathered_info(event: NodeGatheredInfo, state: State) -> State:
             update["node_backends"] = {
                 **state.node_backends,
                 event.node_id: info.backends,
+            }
+        case NodeMemoryBandwidth():
+            update["node_bandwidth"] = {
+                **state.node_bandwidth,
+                event.node_id: NodeBandwidth(memory_bandwidth=info.memory_bandwidth),
             }
 
     return state.model_copy(update=update)

--- a/src/exo/shared/types/profiling.py
+++ b/src/exo/shared/types/profiling.py
@@ -109,3 +109,12 @@ class ThunderboltBridgeStatus(FrozenModel):
     enabled: bool
     exists: bool
     service_name: str | None = None
+
+
+class NodeBandwidth(FrozenModel):
+    """Memory bandwidth information for a node.
+
+    Only present in state for nodes whose bandwidth was successfully profiled.
+    """
+
+    memory_bandwidth: int

--- a/src/exo/shared/types/state.py
+++ b/src/exo/shared/types/state.py
@@ -13,6 +13,7 @@ from exo.shared.types.instance_link import InstanceLink, InstanceLinkId
 from exo.shared.types.profiling import (
     DiskUsage,
     MemoryUsage,
+    NodeBandwidth,
     NodeIdentity,
     NodeNetworkInfo,
     NodeRdmaCtlStatus,
@@ -61,6 +62,7 @@ class State(FrozenModel):
     node_thunderbolt_bridge: Mapping[NodeId, ThunderboltBridgeStatus] = {}
     node_rdma_ctl: Mapping[NodeId, NodeRdmaCtlStatus] = {}
     node_backends: Mapping[NodeId, list[Backend]] = {}
+    node_bandwidth: Mapping[NodeId, NodeBandwidth] = {}
 
     # Detected cycles where all nodes have Thunderbolt bridge enabled (>2 nodes)
     thunderbolt_bridge_cycles: Sequence[Sequence[NodeId]] = []

--- a/src/exo/shared/types/topology.py
+++ b/src/exo/shared/types/topology.py
@@ -24,6 +24,17 @@ class RDMAConnection(FrozenModel):
 
 class SocketConnection(FrozenModel):
     sink_multiaddr: Multiaddr
+    # Most recent reachability-probe round-trip time. Excluded from identity so
+    # jitter does not make otherwise-identical edges unequal.
+    latency_ms: float | None = None
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SocketConnection):
+            return NotImplemented
+        return (
+            self.sink_multiaddr.ip_address == other.sink_multiaddr.ip_address
+            and self.sink_multiaddr.port == other.sink_multiaddr.port
+        )
 
     def __hash__(self):
         return hash(self.sink_multiaddr.ip_address)

--- a/src/exo/utils/info_gatherer/info_gatherer.py
+++ b/src/exo/utils/info_gatherer/info_gatherer.py
@@ -38,6 +38,7 @@ from .system_info import (
     get_network_interfaces,
     get_os_build_version,
     get_os_version,
+    profile_memory_bandwidth,
 )
 
 IS_DARWIN = sys.platform == "darwin"
@@ -334,6 +335,38 @@ class NodeDiskUsage(TaggedModel):
         )
 
 
+class NodeMemoryBandwidth(TaggedModel):
+    """Memory bandwidth information gathered once at startup.
+
+    Bandwidth is sampled only once because:
+    - Apple Silicon has hardware-fixed bandwidth (not dynamic like CPU/GPU frequency)
+    - Profiling requires large GPU allocations (~4GB) which is risky during operation
+    - Unlike memory/disk usage, bandwidth doesn't change at runtime
+    """
+
+    memory_bandwidth: int
+
+    @classmethod
+    async def gather(cls) -> Self | None:
+        """Profile memory bandwidth with retries. Returns None if all attempts fail."""
+        for attempt in range(1, 6):
+            try:
+                bandwidth: int = await to_thread.run_sync(profile_memory_bandwidth)
+                logger.info("Memory bandwidth: {:.1f} GB/s", bandwidth / 1e9)
+                return cls(memory_bandwidth=bandwidth)
+            except Exception as e:
+                if attempt < 5:
+                    logger.warning(
+                        f"Memory bandwidth profiling attempt {attempt} failed: {e}"
+                    )
+                    await anyio.sleep(1)
+                else:
+                    logger.error(
+                        f"Memory bandwidth profiling failed after 5 attempts: {e}"
+                    )
+        return None
+
+
 async def _gather_iface_map() -> dict[str, str] | None:
     proc = await anyio.run_process(
         ["networksetup", "-listallhardwareports"], check=False
@@ -396,6 +429,7 @@ GatheredInfo = (
     | StaticNodeInformation
     | NodeDiskUsage
     | NodeBackends
+    | NodeMemoryBandwidth
 )
 
 
@@ -459,7 +493,17 @@ class InfoGatherer:
             if nc is not None:
                 await self.info_sender.send(nc)
 
+            # Gather memory bandwidth once at startup (macOS only), concurrently
+            # so its retries never delay the rest of the startup gathering
+            if IS_DARWIN:
+                tg.start_soon(self._gather_memory_bandwidth)
+
             await self.info_sender.send(await NodeBackends.gather())
+
+    async def _gather_memory_bandwidth(self):
+        bandwidth = await NodeMemoryBandwidth.gather()
+        if bandwidth is not None:
+            await self.info_sender.send(bandwidth)
 
     def shutdown(self):
         self._tg.cancel_tasks()

--- a/src/exo/utils/info_gatherer/net_profile.py
+++ b/src/exo/utils/info_gatherer/net_profile.py
@@ -1,3 +1,4 @@
+import time
 from collections import defaultdict
 from collections.abc import AsyncGenerator, Mapping
 
@@ -13,6 +14,26 @@ from exo.utils.channels import Sender, channel
 
 REACHABILITY_ATTEMPTS = 3
 
+# Thresholds below which a latency change is treated as measurement noise
+LATENCY_NOISE_FLOOR_MS = 2.0
+LATENCY_CHANGE_FACTOR = 2.0
+
+
+def latency_changed_materially(old_ms: float | None, new_ms: float) -> bool:
+    """Whether a new latency measurement differs enough to be worth republishing.
+
+    Requires both an absolute change above the noise floor and a factor-of-two
+    change, so probe jitter on fast links never churns the topology.
+    """
+    if old_ms is None:
+        return True
+    if abs(new_ms - old_ms) <= LATENCY_NOISE_FLOOR_MS:
+        return False
+    return (
+        new_ms < old_ms / LATENCY_CHANGE_FACTOR
+        or new_ms > old_ms * LATENCY_CHANGE_FACTOR
+    )
+
 
 async def check_reachability(
     target_ip: str,
@@ -20,8 +41,12 @@ async def check_reachability(
     out: dict[NodeId, set[str]],
     client: httpx.AsyncClient,
     api_port: int,
-) -> None:
-    """Check if a node is reachable at the given IP and verify its identity."""
+) -> float | None:
+    """Check if a node is reachable at the given IP and verify its identity.
+
+    Returns the round-trip time of the successful probe in milliseconds, or
+    None if the node was not reachable at this IP.
+    """
     if ":" in target_ip:
         # TODO: use real IpAddress types
         url = f"http://[{target_ip}]:{api_port}/node_id"
@@ -30,10 +55,13 @@ async def check_reachability(
 
     remote_node_id = None
     last_error = None
+    latency_ms = None
 
     for _ in range(REACHABILITY_ATTEMPTS):
         try:
+            probe_start = time.perf_counter()
             r = await client.get(url)
+            probe_elapsed_ms = (time.perf_counter() - probe_start) * 1000
             if r.status_code != 200:
                 await anyio.sleep(1)
                 continue
@@ -44,6 +72,7 @@ async def check_reachability(
                 continue
 
             remote_node_id = NodeId(body)
+            latency_ms = probe_elapsed_ms
             break
 
         # expected failure cases
@@ -64,7 +93,7 @@ async def check_reachability(
         )
 
     if remote_node_id is None:
-        return
+        return None
 
     if remote_node_id != expected_node_id:
         logger.debug(
@@ -72,11 +101,12 @@ async def check_reachability(
             f"ip={target_ip}, expected_node_id={expected_node_id}, "
             f"remote_node_id={remote_node_id}"
         )
-        return
+        return None
 
     if remote_node_id not in out:
         out[remote_node_id] = set()
     out[remote_node_id].add(target_ip)
+    return latency_ms
 
 
 async def check_reachable(
@@ -84,10 +114,10 @@ async def check_reachable(
     self_node_id: NodeId,
     node_network: Mapping[NodeId, NodeNetworkInfo],
     api_port: int,
-) -> AsyncGenerator[tuple[str, NodeId], None]:
-    """Yield (ip, node_id) pairs as reachability probes complete."""
+) -> AsyncGenerator[tuple[str, NodeId, float], None]:
+    """Yield (ip, node_id, latency_ms) tuples as reachability probes complete."""
 
-    send, recv = channel[tuple[str, NodeId]]()
+    send, recv = channel[tuple[str, NodeId, float]]()
 
     # these are intentionally httpx's defaults so we can tune them later
     timeout = httpx.Timeout(timeout=5.0)
@@ -101,13 +131,15 @@ async def check_reachable(
         target_ip: str,
         expected_node_id: NodeId,
         client: httpx.AsyncClient,
-        send: Sender[tuple[str, NodeId]],
+        send: Sender[tuple[str, NodeId, float]],
     ) -> None:
         async with send:
             out: defaultdict[NodeId, set[str]] = defaultdict(set)
-            await check_reachability(target_ip, expected_node_id, out, client, api_port)
-            if expected_node_id in out:
-                await send.send((target_ip, expected_node_id))
+            latency_ms = await check_reachability(
+                target_ip, expected_node_id, out, client, api_port
+            )
+            if expected_node_id in out and latency_ms is not None:
+                await send.send((target_ip, expected_node_id, latency_ms))
 
     async with (
         httpx.AsyncClient(timeout=timeout, limits=limits, verify=False) as client,

--- a/src/exo/utils/info_gatherer/system_info.py
+++ b/src/exo/utils/info_gatherer/system_info.py
@@ -1,6 +1,8 @@
+import math
 import platform
 import socket
 import sys
+import time
 from subprocess import CalledProcessError
 
 import psutil
@@ -148,3 +150,74 @@ async def get_model_and_chip() -> tuple[str, str]:
     chip = chip_line.split(": ")[1] if chip_line else "Unknown Chip"
 
     return (model, chip)
+
+
+def profile_memory_bandwidth() -> int:
+    """Profile device memory bandwidth using MLX GPU operations.
+
+    Uses a large array copy on the GPU to measure unified memory bandwidth.
+    Returns measured bandwidth in bytes/second.
+    Raises exception if MLX is unavailable or profiling fails.
+
+    Note: The benchmark needs two equal-sized buffers (source + destination), so
+    the working set is twice the buffer size. The buffer is sized to at most a
+    quarter of currently available memory so profiling never consumes more than
+    half of it, and is skipped entirely when memory is too scarce for a
+    meaningful measurement.
+
+    Design note: Bandwidth is profiled only once at startup. For Apple Silicon,
+    unified memory bandwidth is a hardware constant (architecture and clock frequency
+    dependent), making re-profiling unnecessary. This avoids the cost and risk of
+    repeated multi-GB allocations during operation.
+    """
+    import mlx.core as mx
+
+    if not mx.metal.is_available():
+        raise RuntimeError("Metal is not available")
+
+    # Prefer a 2GB buffer to saturate memory bandwidth, but never take more than
+    # a quarter of available memory (the copy needs 2x the buffer size).
+    max_size_bytes = 2 * 1024 * 1024 * 1024
+    min_size_bytes = 256 * 1024 * 1024
+    available_bytes = psutil.virtual_memory().available
+    size_bytes = min(max_size_bytes, available_bytes // 4)
+    if size_bytes < min_size_bytes:
+        raise RuntimeError(
+            f"Insufficient available memory ({available_bytes / 1e9:.1f} GB) "
+            "to profile memory bandwidth"
+        )
+    side = math.isqrt(size_bytes // 4)  # Square 2D array of float32
+    shape = (side, side)
+    actual_bytes = side * side * 4
+    bytes_transferred = actual_bytes * 2  # read + write
+
+    # Warm-up: run the full benchmark operation multiple times to stabilize GPU
+    for _ in range(3):
+        src = mx.random.uniform(shape=shape, dtype=mx.float32)
+        mx.eval(src)
+        dst = src + 0.0
+        mx.eval(dst)
+        mx.synchronize()
+        del src, dst
+
+    # Benchmark: measure time to copy array
+    best_bandwidth = 0.0
+    num_runs = 4
+
+    for _ in range(num_runs):
+        src = mx.random.uniform(shape=shape, dtype=mx.float32)
+        mx.eval(src)
+        mx.synchronize()
+
+        start = time.perf_counter()
+        dst = src + 0.0
+        mx.eval(dst)
+        mx.synchronize()
+        end = time.perf_counter()
+
+        bandwidth = bytes_transferred / (end - start)
+        best_bandwidth = max(best_bandwidth, bandwidth)
+
+        del src, dst
+
+    return int(best_bandwidth)

--- a/src/exo/utils/info_gatherer/tests/test_net_profile.py
+++ b/src/exo/utils/info_gatherer/tests/test_net_profile.py
@@ -1,0 +1,22 @@
+from exo.utils.info_gatherer.net_profile import latency_changed_materially
+
+
+def test_first_measurement_is_material():
+    assert latency_changed_materially(None, 0.5)
+
+
+def test_small_absolute_jitter_is_ignored():
+    # sub-noise-floor changes never republish, even when the factor is large
+    assert not latency_changed_materially(0.4, 1.9)
+    assert not latency_changed_materially(1.9, 0.4)
+
+
+def test_small_relative_change_is_ignored():
+    assert not latency_changed_materially(40.0, 55.0)
+    assert not latency_changed_materially(55.0, 40.0)
+
+
+def test_large_change_is_material():
+    # e.g. traffic silently rerouted from thunderbolt to a WAN path
+    assert latency_changed_materially(0.8, 45.0)
+    assert latency_changed_materially(45.0, 0.8)

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -55,7 +55,10 @@ from exo.shared.types.worker.instances import InstanceId
 from exo.shared.types.worker.runners import RunnerId
 from exo.utils.channels import Receiver, Sender, channel
 from exo.utils.info_gatherer.info_gatherer import GatheredInfo, InfoGatherer
-from exo.utils.info_gatherer.net_profile import check_reachable
+from exo.utils.info_gatherer.net_profile import (
+    check_reachable,
+    latency_changed_materially,
+)
 from exo.utils.keyed_backoff import KeyedBackoff
 from exo.utils.task_group import TaskGroup
 from exo.worker.plan import plan
@@ -388,11 +391,13 @@ class Worker:
 
     async def _poll_connection_updates(self):
         while True:
-            edges = set(
-                conn.edge for conn in self.state.topology.out_edges(self.node_id)
-            )
+            existing_edges: dict[SocketConnection, Connection] = {
+                conn.edge: conn
+                for conn in self.state.topology.out_edges(self.node_id)
+                if isinstance(conn.edge, SocketConnection)
+            }
             conns: defaultdict[NodeId, set[str]] = defaultdict(set)
-            async for ip, nid in check_reachable(
+            async for ip, nid, latency_ms in check_reachable(
                 self.state.topology,
                 self.node_id,
                 self.state.node_network,
@@ -407,9 +412,23 @@ class Worker:
                     if "." in ip
                     # nonsense multiaddr
                     else Multiaddr(address=f"/ip6/{ip}/tcp/{self.api_port}"),
+                    latency_ms=latency_ms,
                 )
-                if edge not in edges:
+                old_conn = existing_edges.get(edge)
+                if old_conn is None:
                     logger.debug(f"ping discovered {edge=}")
+                    await self.event_sender.send(
+                        TopologyEdgeCreated(
+                            conn=Connection(source=self.node_id, sink=nid, edge=edge)
+                        )
+                    )
+                elif isinstance(
+                    old_conn.edge, SocketConnection
+                ) and latency_changed_materially(old_conn.edge.latency_ms, latency_ms):
+                    logger.debug(
+                        f"latency changed {old_conn.edge.latency_ms}ms -> {latency_ms}ms for {edge=}"
+                    )
+                    await self.event_sender.send(TopologyEdgeDeleted(conn=old_conn))
                     await self.event_sender.send(
                         TopologyEdgeCreated(
                             conn=Connection(source=self.node_id, sink=nid, edge=edge)


### PR DESCRIPTION
## Problem

Pipeline placement currently chooses the smallest feasible cycle and divides layers by available RAM. That can put too much work on a low-bandwidth node, ignore a faster larger cycle, or select a ring ordering with slower links.

## Changes

- Profile live memory bandwidth on each node and carry it into placement.
- Allocate layers in proportion to bandwidth while treating available RAM as a hard capacity.
- Estimate each candidate's token time from its actual capacity-adjusted layer allocation and the measured RTT of each ring hop.
- Compare fully profiled cycles across device counts, with leaf status, download progress, and RAM used only as tie-breakers.
- Preserve the existing smallest-cycle and download-aware behavior until profiling has produced a complete candidate.
- Split placement filtering, selection, and instance construction into focused helpers.

This replaces #1088 and incorporates the review feedback there.

## Stack

Depends on #2254 for measured per-link latency. Until #2254 merges, GitHub will include its commits in this PR's diff because both head branches are in a fork. The diff will narrow to the placement changes automatically after #2254 lands.

## Tests

- Added end-to-end coverage for measured-latency selection, bandwidth taking priority over download progress, comparison across cycle sizes, and capacity-adjusted scoring.
- `uv run basedpyright`
- `uv run ruff check`
- `uv run ruff format --check` on changed Python files
- `uv run pytest --ignore=src/exo/download/tests --ignore=rust/exo_rs/tests/test_python.py` — 425 passed, 3 skipped, 190 deselected

`nix fmt` was unavailable locally because Nix is not installed.

Fixes #957
